### PR TITLE
feat: add Entra ID endpoints, incident response writes, and HTTP transport

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:20-slim AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-slim
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package*.json ./
+RUN npm ci --omit=dev
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s CMD curl -f http://localhost:8080/health || exit 1
+CMD ["node", "dist/index.js", "--transport", "http", "--port", "8080"]

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,0 +1,116 @@
+// Azure Container Apps deployment for ms-365-admin-mcp-server
+// Skeleton template — fill in parameters and role assignments before deploying.
+
+@description('Azure region for all resources')
+param location string = resourceGroup().location
+
+@description('Container image to deploy')
+param containerImage string
+
+@description('Azure AD tenant ID for Graph API auth')
+@secure()
+param tenantId string
+
+@description('App registration client ID')
+@secure()
+param clientId string
+
+@description('App registration client secret')
+@secure()
+param clientSecret string
+
+// --- Log Analytics Workspace ---
+
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: 'law-mcp-admin'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+    retentionInDays: 30
+  }
+}
+
+// --- Application Insights ---
+
+resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: 'ai-mcp-admin'
+  location: location
+  kind: 'web'
+  properties: {
+    Application_Type: 'web'
+    WorkspaceResourceId: logAnalytics.id
+  }
+}
+
+// --- Container App Environment ---
+
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: 'cae-mcp-admin'
+  location: location
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalytics.properties.customerId
+        sharedKey: logAnalytics.listKeys().primarySharedKey
+      }
+    }
+  }
+}
+
+// --- Container App ---
+
+resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: 'ca-mcp-admin'
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    managedEnvironmentId: containerAppEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: 'http'
+      }
+      secrets: [
+        { name: 'client-id', value: clientId }
+        { name: 'client-secret', value: clientSecret }
+        { name: 'tenant-id', value: tenantId }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'mcp-admin'
+          image: containerImage
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+          env: [
+            { name: 'MS365_ADMIN_MCP_CLIENT_ID', secretRef: 'client-id' }
+            { name: 'MS365_ADMIN_MCP_CLIENT_SECRET', secretRef: 'client-secret' }
+            { name: 'MS365_ADMIN_MCP_TENANT_ID', secretRef: 'tenant-id' }
+            { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsights.properties.ConnectionString }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 3
+      }
+    }
+  }
+}
+
+// TODO: Add role assignments for the system-assigned managed identity
+// - Microsoft Graph API permissions cannot be assigned via Bicep directly
+// - Use a post-deployment script with az ad app permission grant
+// - Or use Azure CLI: az role assignment create --assignee <principalId> ...
+
+output containerAppUrl string = 'https://${containerApp.properties.configuration.ingress.fqdn}'
+output principalId string = containerApp.identity.principalId

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^3.8.0",
+        "@modelcontextprotocol/express": "^2.0.0-alpha.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^11.1.0",
         "dotenv": "^17.0.1",
+        "express": "^5.2.1",
         "js-yaml": "^4.1.0",
         "winston": "^3.17.0",
         "zod": "^3.24.2"
@@ -21,6 +23,7 @@
         "ms-365-admin-mcp-server": "dist/index.js"
       },
       "devDependencies": {
+        "@types/express": "^5.0.6",
         "@types/node": "^22.15.15",
         "@typescript-eslint/eslint-plugin": "^8.38.0",
         "@typescript-eslint/parser": "^8.38.0",
@@ -1230,6 +1233,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@modelcontextprotocol/express": {
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/express/-/express-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-TlTUFnpUCH3dqegSnAZpCe+pn4fM43tow0KLRa3QTTWaC/jctsl51QQykqXHse5UhBpqGw+QF1rLfWOwEI9PPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/server": "^2.0.0-alpha.2",
+        "express": "^5.2.1"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -1268,6 +1284,37 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server": {
+      "version": "2.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-alpha.2.tgz",
+      "integrity": "sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "zod": "^4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1641,6 +1688,17 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1650,6 +1708,16 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1663,6 +1731,38 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1681,6 +1781,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/triple-beam": {

--- a/package.json
+++ b/package.json
@@ -32,9 +32,11 @@
   "license": "MIT",
   "dependencies": {
     "@azure/msal-node": "^3.8.0",
+    "@modelcontextprotocol/express": "^2.0.0-alpha.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "^11.1.0",
     "dotenv": "^17.0.1",
+    "express": "^5.2.1",
     "js-yaml": "^4.1.0",
     "winston": "^3.17.0",
     "zod": "^3.24.2"
@@ -44,6 +46,7 @@
     "@azure/keyvault-secrets": "^4.9.0"
   },
   "devDependencies": {
+    "@types/express": "^5.0.6",
     "@types/node": "^22.15.15",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,8 @@ program
   .version(version)
   .option('-v', 'Enable verbose logging')
   .option('--verify-login', 'Verify login by testing client credentials against Graph API')
-  .option('--read-only', 'Start server in read-only mode, disabling write operations')
+  .option('--read-only', 'Start server in read-only mode, disabling write operations (default)')
+  .option('--allow-writes', 'Enable write operations (server is read-only by default)')
   .option(
     '--enabled-tools <pattern>',
     'Filter tools using regex pattern (e.g., "security|audit" to enable only security and audit tools)'
@@ -29,18 +30,28 @@ program
   .option('--list-presets', 'List all available presets and exit')
   .option('--list-permissions', 'List all required Graph API application permissions and exit')
   .option('--list-tools', 'List all available tools and exit')
-  .option('--cloud <type>', 'Microsoft cloud environment: global (default) or china (21Vianet)');
+  .option('--cloud <type>', 'Microsoft cloud environment: global (default) or china (21Vianet)')
+  .option('--transport <type>', 'Transport mode: stdio (default) or http', 'stdio')
+  .option('--port <number>', 'HTTP server port (only with --transport http)', '8080')
+  .option(
+    '--allowed-clients <ids>',
+    'Comma-separated Entra app IDs allowed to connect (HTTP mode)'
+  );
 
 export interface CommandOptions {
   v?: boolean;
   verifyLogin?: boolean;
   readOnly?: boolean;
+  allowWrites?: boolean;
   enabledTools?: string;
   preset?: string;
   listPresets?: boolean;
   listPermissions?: boolean;
   listTools?: boolean;
   cloud?: string;
+  transport?: string;
+  port?: string;
+  allowedClients?: string;
   [key: string]: unknown;
 }
 
@@ -64,7 +75,12 @@ export function parseArgs(): CommandOptions {
     }
   }
 
-  if (process.env.READ_ONLY === 'true' || process.env.READ_ONLY === '1') {
+  // Default to read-only. Only --allow-writes (or READ_ONLY=false) enables mutations.
+  if (options.allowWrites) {
+    options.readOnly = false;
+  } else if (process.env.READ_ONLY === 'false' || process.env.READ_ONLY === '0') {
+    options.readOnly = false;
+  } else {
     options.readOnly = true;
   }
 

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -18,6 +18,7 @@
     "method": "patch",
     "toolName": "update-security-alert",
     "appPermissions": ["SecurityAlert.ReadWrite.All"],
+    "riskLevel": "medium",
     "llmTip": "Updates a security alert. Body can include: status ('new', 'inProgress', 'resolved'), assignedTo (email), classification ('truePositive', 'falsePositive', 'informationalExpectedActivity'), determination, comment."
   },
   {
@@ -39,6 +40,7 @@
     "method": "patch",
     "toolName": "update-security-incident",
     "appPermissions": ["SecurityIncident.ReadWrite.All"],
+    "riskLevel": "medium",
     "llmTip": "Updates a security incident. Body can include: status ('active', 'resolved', 'redirected'), assignedTo (email), classification ('truePositive', 'falsePositive', 'informationalExpectedActivity'), determination, customTags."
   },
   {
@@ -114,5 +116,191 @@
     "appPermissions": ["Reports.Read.All"],
     "skipEncoding": ["period"],
     "llmTip": "Gets SharePoint site usage details. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with per-site details: siteUrl, ownerDisplayName, storageUsedInBytes, fileCount, activeFileCount, pageViewCount, lastActivityDate."
+  },
+
+  {
+    "pathPattern": "/users",
+    "method": "get",
+    "toolName": "list-users",
+    "appPermissions": ["User.Read.All"],
+    "llmTip": "Lists all users in the tenant. Use $filter=accountEnabled eq true/false to find enabled/disabled accounts. Use $select=displayName,userPrincipalName,accountEnabled,signInActivity,createdDateTime to get key fields. Use $filter=signInActivity/lastSignInDateTime le 2024-01-01T00:00:00Z to find inactive users. Use $top to paginate, follow @odata.nextLink for more. Max $top=999 for users."
+  },
+  {
+    "pathPattern": "/users/{user-id}",
+    "method": "get",
+    "toolName": "get-user",
+    "appPermissions": ["User.Read.All"],
+    "llmTip": "Gets a single user by ID or userPrincipalName. Use $select=displayName,userPrincipalName,accountEnabled,signInActivity,assignedLicenses,memberOf to get detailed info. signInActivity requires AuditLog.Read.All in addition to User.Read.All."
+  },
+  {
+    "pathPattern": "/users/{user-id}/memberOf",
+    "method": "get",
+    "toolName": "list-user-memberships",
+    "appPermissions": ["Directory.Read.All"],
+    "llmTip": "Lists all groups and directory roles a user is a member of. Returns directoryRole and group objects. Use $select=displayName,id to reduce payload. Useful for auditing a user's access."
+  },
+  {
+    "pathPattern": "/users/{user-id}/authentication/methods",
+    "method": "get",
+    "toolName": "list-user-auth-methods",
+    "appPermissions": ["UserAuthenticationMethod.Read.All"],
+    "llmTip": "Lists authentication methods registered for a user (phone, email, FIDO2, Microsoft Authenticator, etc.). Useful for MFA coverage audits. Each method has @odata.type to identify the method kind."
+  },
+  {
+    "pathPattern": "/users/{user-id}/registeredDevices",
+    "method": "get",
+    "toolName": "list-user-devices",
+    "appPermissions": ["Directory.Read.All"],
+    "llmTip": "Lists devices registered to a user. Returns device objects with displayName, operatingSystem, operatingSystemVersion, isCompliant, isManaged, approximateLastSignInDateTime."
+  },
+
+  {
+    "pathPattern": "/groups",
+    "method": "get",
+    "toolName": "list-groups",
+    "appPermissions": ["Group.Read.All"],
+    "llmTip": "Lists all groups. Use $filter=groupTypes/any(c:c eq 'Unified') for Microsoft 365 groups. Use $filter=securityEnabled eq true for security groups. Use $filter=onPremisesSyncEnabled eq true for hybrid-synced groups. Use $select=displayName,mail,groupTypes,securityEnabled,membershipRule to get key fields."
+  },
+  {
+    "pathPattern": "/groups/{group-id}",
+    "method": "get",
+    "toolName": "get-group",
+    "appPermissions": ["Group.Read.All"],
+    "llmTip": "Gets a single group by ID. Use $select=displayName,description,groupTypes,securityEnabled,membershipRule,membershipRuleProcessingState for policy details."
+  },
+  {
+    "pathPattern": "/groups/{group-id}/members",
+    "method": "get",
+    "toolName": "list-group-members",
+    "appPermissions": ["GroupMember.Read.All"],
+    "llmTip": "Lists members of a group. Returns user and servicePrincipal objects. Use $select=displayName,userPrincipalName,id. Use $top to paginate. For large groups, use $count=true with ConsistencyLevel=eventual header."
+  },
+  {
+    "pathPattern": "/groups/{group-id}/owners",
+    "method": "get",
+    "toolName": "list-group-owners",
+    "appPermissions": ["GroupMember.Read.All"],
+    "llmTip": "Lists owners of a group. Useful for auditing ownerless groups. Returns user objects."
+  },
+
+  {
+    "pathPattern": "/directoryRoles",
+    "method": "get",
+    "toolName": "list-directory-roles",
+    "appPermissions": ["RoleManagement.Read.Directory"],
+    "llmTip": "Lists activated directory roles in the tenant. Only roles that have been activated (have at least one member) appear here. Use $expand=members to see who holds each role. Key roles to audit: Global Administrator, Privileged Role Administrator, Security Administrator."
+  },
+  {
+    "pathPattern": "/directoryRoles/{directoryRole-id}/members",
+    "method": "get",
+    "toolName": "list-role-members",
+    "appPermissions": ["RoleManagement.Read.Directory"],
+    "llmTip": "Lists members of a specific directory role. Use this to audit who has Global Admin, Exchange Admin, etc. Returns user and servicePrincipal objects."
+  },
+  {
+    "pathPattern": "/roleManagement/directory/roleAssignments",
+    "method": "get",
+    "toolName": "list-role-assignments",
+    "appPermissions": ["RoleManagement.Read.Directory"],
+    "llmTip": "Lists all role assignments in the directory. Use $filter=principalId eq '{user-id}' to find all roles for a specific user. Use $expand=principal to get user details. Includes both permanent and PIM-eligible assignments."
+  },
+  {
+    "pathPattern": "/roleManagement/directory/roleDefinitions",
+    "method": "get",
+    "toolName": "list-role-definitions",
+    "appPermissions": ["RoleManagement.Read.Directory"],
+    "llmTip": "Lists all role definitions (built-in and custom). Each has displayName, description, isBuiltIn, rolePermissions. Useful for understanding what each role can do."
+  },
+
+  {
+    "pathPattern": "/identity/conditionalAccess/policies",
+    "method": "get",
+    "toolName": "list-conditional-access-policies",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Lists all Conditional Access policies. Each policy has displayName, state (enabled/disabled/enabledForReportingButNotEnforced), conditions (users, applications, locations, platforms, signInRiskLevels), and grantControls (MFA, compliant device, etc.). Use this to audit MFA enforcement and access controls."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
+    "method": "get",
+    "toolName": "get-conditional-access-policy",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Gets a single Conditional Access policy by ID. Returns full policy details including conditions, grantControls, and sessionControls."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/namedLocations",
+    "method": "get",
+    "toolName": "list-named-locations",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Lists named locations used in Conditional Access policies. Shows trusted IP ranges and country-based locations. Useful for auditing geographic access controls."
+  },
+
+  {
+    "pathPattern": "/applications",
+    "method": "get",
+    "toolName": "list-applications",
+    "appPermissions": ["Application.Read.All"],
+    "llmTip": "Lists all app registrations in the tenant. Use $select=displayName,appId,signInAudience,requiredResourceAccess,passwordCredentials,keyCredentials to audit app permissions and credentials. Use $filter=passwordCredentials/any(p:p/endDateTime le 2024-06-01T00:00:00Z) to find apps with expiring secrets (beta)."
+  },
+  {
+    "pathPattern": "/servicePrincipals",
+    "method": "get",
+    "toolName": "list-service-principals",
+    "appPermissions": ["Application.Read.All"],
+    "llmTip": "Lists all service principals (enterprise apps). Use $filter=appOwnerOrganizationId ne '{tenant-id}' to find third-party apps. Use $select=displayName,appId,appOwnerOrganizationId,servicePrincipalType,accountEnabled to audit external access."
+  },
+  {
+    "pathPattern": "/oauth2PermissionGrants",
+    "method": "get",
+    "toolName": "list-oauth2-grants",
+    "appPermissions": ["Directory.Read.All"],
+    "llmTip": "Lists all delegated permission grants (OAuth2 consent). Shows which apps have been granted what permissions by whom (admin consent vs user consent). Use $filter=consentType eq 'AllPrincipals' to find admin-consented grants. Critical for auditing overpermissioned apps."
+  },
+
+  {
+    "pathPattern": "/organization",
+    "method": "get",
+    "toolName": "get-organization",
+    "appPermissions": ["Organization.Read.All"],
+    "llmTip": "Gets tenant organization info. Returns displayName, verifiedDomains, securityComplianceNotificationPhones, technicalNotificationMails, tenantType. Useful for basic tenant identity verification."
+  },
+  {
+    "pathPattern": "/domains",
+    "method": "get",
+    "toolName": "list-domains",
+    "appPermissions": ["Domain.Read.All"],
+    "llmTip": "Lists all domains registered in the tenant. Shows isVerified, isDefault, authenticationType (Managed vs Federated). Useful for auditing federated domains and finding unverified domains."
+  },
+
+  {
+    "pathPattern": "/users/{user-id}",
+    "method": "patch",
+    "toolName": "disable-user-account",
+    "appPermissions": ["User.ReadWrite.All"],
+    "riskLevel": "critical",
+    "llmTip": "Disables a user account by setting accountEnabled to false. Body MUST be: {\"accountEnabled\": false}. This blocks all sign-ins immediately. Use for compromised accounts. CRITICAL: verify the user-id carefully — disabling the wrong account locks out a legitimate user. To re-enable, send {\"accountEnabled\": true}."
+  },
+  {
+    "pathPattern": "/users/{user-id}/revokeSignInSessions",
+    "method": "post",
+    "toolName": "revoke-user-sessions",
+    "appPermissions": ["User.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Revokes all refresh tokens and session cookies for a user, forcing re-authentication everywhere. No request body needed. Use after password reset or account compromise. Effect is not instant — cached tokens may remain valid for up to 1 hour. Combine with disable-user-account for immediate containment."
+  },
+  {
+    "pathPattern": "/security/alerts_v2/{alert-id}/comments",
+    "method": "post",
+    "toolName": "add-security-alert-comment",
+    "appPermissions": ["SecurityAlert.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Adds a comment to a security alert for tracking investigation progress. Body: {\"comment\": \"your comment text\"}. Use to document triage decisions and findings."
+  },
+  {
+    "pathPattern": "/devices/{device-id}",
+    "method": "patch",
+    "toolName": "update-device",
+    "appPermissions": ["Device.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Updates device properties. Use {\"accountEnabled\": false} to disable a device in Entra ID. This prevents the device from authenticating. Useful for lost/stolen devices or compromised endpoints."
   }
 ]

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -16,6 +16,7 @@ interface EndpointConfig {
   toolName: string;
   appPermissions?: string[];
   llmTip?: string;
+  riskLevel?: 'low' | 'medium' | 'high' | 'critical';
   skipEncoding?: string[];
   contentType?: string;
   acceptType?: string;
@@ -281,6 +282,15 @@ export function registerGraphTools(
       tool.description || `Execute ${tool.method.toUpperCase()} request to ${tool.path}`;
     if (endpointConfig?.llmTip) {
       toolDescription += `\n\nTIP: ${endpointConfig.llmTip}`;
+    }
+    if (endpointConfig?.riskLevel) {
+      toolDescription += `\n\nRISK LEVEL: ${endpointConfig.riskLevel.toUpperCase()}. ${
+        endpointConfig.riskLevel === 'critical'
+          ? 'This action is irreversible or has major security impact. Always confirm with the operator before executing.'
+          : endpointConfig.riskLevel === 'high'
+            ? 'This action has significant impact. Verify the target carefully before executing.'
+            : ''
+      }`;
     }
 
     try {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -1,0 +1,62 @@
+import express from 'express';
+import type { Request, Response, NextFunction } from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import logger from './logger.js';
+import { validateEntraToken, type TokenValidatorOptions } from './token-validator.js';
+
+export interface HttpServerOptions {
+  port: number;
+  server: McpServer;
+  tokenValidatorOptions?: TokenValidatorOptions;
+}
+
+export async function startHttpServer(options: HttpServerOptions): Promise<void> {
+  const app = express();
+  app.use(express.json());
+
+  app.get('/health', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', transport: 'http', timestamp: new Date().toISOString() });
+  });
+
+  if (options.tokenValidatorOptions) {
+    const validatorOptions = options.tokenValidatorOptions;
+    app.use('/mcp', async (req: Request, res: Response, next: NextFunction) => {
+      const authHeader = req.headers.authorization;
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        res.status(401).json({ error: 'Missing or invalid Authorization header' });
+        return;
+      }
+      const token = authHeader.slice(7);
+      const valid = await validateEntraToken(token, validatorOptions);
+      if (!valid) {
+        res.status(403).json({ error: 'Token validation failed' });
+        return;
+      }
+      next();
+    });
+  }
+
+  // Stateless MCP endpoint — each request gets its own transport
+  app.post('/mcp', async (req: Request, res: Response) => {
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await options.server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  });
+
+  app.delete('/mcp', async (req: Request, res: Response) => {
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await options.server.connect(transport);
+    await transport.handleRequest(req, res);
+  });
+
+  app.get('/mcp', async (req: Request, res: Response) => {
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    await options.server.connect(transport);
+    await transport.handleRequest(req, res);
+  });
+
+  app.listen(options.port, () => {
+    logger.info(`HTTP MCP server listening on port ${options.port}`);
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -53,9 +53,29 @@ class AdminGraphServer {
       logger.info('Server running in READ-ONLY mode.');
     }
 
-    const transport = new StdioServerTransport();
-    await this.server!.connect(transport);
-    logger.info('Server connected to stdio transport');
+    if (this.options.transport === 'http') {
+      const { startHttpServer } = await import('./http-server.js');
+      const port = parseInt(this.options.port || '8080', 10);
+
+      let tokenValidatorOptions;
+      if (this.options.allowedClients && this.secrets) {
+        tokenValidatorOptions = {
+          tenantId: this.secrets.tenantId,
+          allowedClientIds: this.options.allowedClients.split(',').map((id: string) => id.trim()),
+        };
+      }
+
+      await startHttpServer({
+        port,
+        server: this.server!,
+        tokenValidatorOptions,
+      });
+      logger.info(`Server connected to HTTP transport on port ${port}`);
+    } else {
+      const transport = new StdioServerTransport();
+      await this.server!.connect(transport);
+      logger.info('Server connected to stdio transport');
+    }
   }
 }
 

--- a/src/token-validator.ts
+++ b/src/token-validator.ts
@@ -1,0 +1,53 @@
+import logger from './logger.js';
+
+export interface TokenValidatorOptions {
+  tenantId: string;
+  allowedClientIds: string[];
+}
+
+interface JwtPayload {
+  iss?: string;
+  aud?: string;
+  exp?: number;
+  appid?: string;
+  azp?: string;
+}
+
+function decodeJwtPayload(token: string): JwtPayload {
+  const parts = token.split('.');
+  if (parts.length !== 3) {
+    throw new Error('Invalid JWT format');
+  }
+  const payload = Buffer.from(parts[1], 'base64url').toString('utf8');
+  return JSON.parse(payload) as JwtPayload;
+}
+
+export async function validateEntraToken(
+  token: string,
+  options: TokenValidatorOptions
+): Promise<boolean> {
+  try {
+    const payload = decodeJwtPayload(token);
+
+    if (!payload.iss || !payload.iss.includes(options.tenantId)) {
+      logger.warn(`Token issuer mismatch: ${payload.iss}`);
+      return false;
+    }
+
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) {
+      logger.warn('Token expired');
+      return false;
+    }
+
+    const clientId = payload.appid || payload.azp;
+    if (!clientId || !options.allowedClientIds.includes(clientId)) {
+      logger.warn(`Token client ID not allowed: ${clientId}`);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    logger.error(`Token validation failed: ${(error as Error).message}`);
+    return false;
+  }
+}

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -25,6 +25,18 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
     pattern: /report|activity|usage/i,
     description: 'Usage reports (Teams, Email, Active Users, SharePoint)',
   },
+  identity: {
+    name: 'identity',
+    pattern:
+      /user|group|role|conditional|directory|domain|auth-method|credential|application|service-principal|oauth2|organization|named-location/i,
+    description: 'Identity and access management (Entra ID users, groups, roles, policies)',
+  },
+  response: {
+    name: 'response',
+    pattern:
+      /disable-user|revoke|block|reset|isolate|update-security|delete-user-auth|update-device|update-user-auth/i,
+    description: 'Incident response operations (disable user, revoke sessions, update alerts)',
+  },
   all: {
     name: 'all',
     pattern: /.*/,


### PR DESCRIPTION
## Summary

- **Chantier 1 — Entra ID endpoints**: Add 22 read-only identity endpoints (users, groups, directory roles, conditional access policies, applications, service principals, oauth2 grants, domains, organization) and an `identity` preset in tool-categories
- **Chantier 2 — Incident Response writes**: Add 4 write endpoints (`disable-user-account`, `revoke-user-sessions`, `add-security-alert-comment`, `update-device`) with `riskLevel` classification (low/medium/high/critical) injected into tool descriptions. Default to read-only mode with new `--allow-writes` flag. Add `response` preset
- **Chantier 3 — HTTP transport**: Add Express-based StreamableHTTP server (`/mcp` + `/health`), Entra ID bearer token validation, `--transport`/`--port`/`--allowed-clients` CLI options, multi-stage Dockerfile, and Azure Container Apps Bicep skeleton

## Notable decisions

- `delete-user-auth-method` and `update-user-auth-requirements` excluded — paths not available in Microsoft Graph OpenAPI v1.0 spec
- Path parameters corrected to match OpenAPI spec (`{directoryRole-id}`, `{conditionalAccessPolicy-id}` instead of simplified names)
- HTTP transport uses stateless mode (`sessionIdGenerator: undefined`) for container scalability

## Test plan

- [x] `npm run verify` passes (generate + lint + format + build + 3/3 tests)
- [ ] Manual test with `npm run inspector` for new Entra ID tools
- [ ] Manual test of HTTP transport with `--transport http --port 8080`
- [ ] Validate `--allow-writes` flag correctly gates write endpoints
- [ ] Docker build and health check verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)