### PR TITLE
feat: add 27 endpoints for Intune, Threat Intel, SharePoint, Teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 
 ## Features
 
-- **57 tools** covering security, audit, identity, compliance, reports, and incident response
+- **84 tools** covering security, audit, identity, compliance, Intune, threat intel, SharePoint, Teams, and incident response
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -98,16 +98,19 @@ node dist/index.js --preset identity
 node dist/index.js --preset security,audit,identity
 ```
 
-| Preset       | Description                                                    |
-| ------------ | -------------------------------------------------------------- |
-| `security`   | Security alerts and incidents                                  |
-| `audit`      | Directory audits, sign-ins, provisioning logs                  |
-| `health`     | Service health and Message Center                              |
-| `reports`    | Usage reports (Teams, Email, SharePoint, Active Users)         |
-| `identity`   | Users, groups, roles, conditional access, apps, domains        |
-| `compliance` | Licenses, Secure Score, Identity Protection, security policies |
-| `response`   | Incident response write operations                             |
-| `all`        | All available tools                                            |
+| Preset          | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| `security`      | Security alerts and incidents                                        |
+| `audit`         | Directory audits, sign-ins, provisioning logs                        |
+| `health`        | Service health and Message Center                                    |
+| `reports`       | Usage reports (Teams, Email, SharePoint, Active Users)               |
+| `identity`      | Users, groups, roles, conditional access, apps, domains              |
+| `compliance`    | Licenses, Secure Score, Identity Protection, security policies       |
+| `intune`        | Managed devices, compliance policies, configurations, detected apps  |
+| `threatintel`   | Threat intel articles, profiles, hosts, vulnerabilities, simulations |
+| `collaboration` | SharePoint, Teams, cross-tenant access, deleted items                |
+| `response`      | Incident response write operations                                   |
+| `all`           | All available tools                                                  |
 
 ### Verify credentials
 
@@ -115,7 +118,7 @@ node dist/index.js --preset security,audit,identity
 node dist/index.js --verify-login
 ```
 
-## Available tools (57)
+## Available tools (84)
 
 ### Security (6)
 
@@ -240,6 +243,48 @@ node dist/index.js --verify-login
 | `get-security-defaults`    | GET    |
 | `get-admin-consent-policy` | GET    |
 
+### Intune device management (8)
+
+| Tool                          | Method |
+| ----------------------------- | ------ |
+| `list-managed-devices`        | GET    |
+| `get-managed-device`          | GET    |
+| `get-managed-device-overview` | GET    |
+| `list-compliance-policies`    | GET    |
+| `get-compliance-policy`       | GET    |
+| `list-device-configurations`  | GET    |
+| `get-device-configuration`    | GET    |
+| `list-detected-apps`          | GET    |
+
+### Threat intelligence (10)
+
+| Tool                                | Method |
+| ----------------------------------- | ------ |
+| `list-threat-intel-articles`        | GET    |
+| `get-threat-intel-article`          | GET    |
+| `list-threat-intel-profiles`        | GET    |
+| `get-threat-intel-profile`          | GET    |
+| `list-threat-intel-hosts`           | GET    |
+| `get-threat-intel-host`             | GET    |
+| `list-threat-intel-vulnerabilities` | GET    |
+| `get-threat-intel-vulnerability`    | GET    |
+| `list-attack-simulations`           | GET    |
+| `get-attack-simulation`             | GET    |
+
+### SharePoint, Teams & collaboration (9)
+
+| Tool                         | Method |
+| ---------------------------- | ------ |
+| `list-sharepoint-sites`      | GET    |
+| `get-sharepoint-site`        | GET    |
+| `get-sharepoint-settings`    | GET    |
+| `list-teams`                 | GET    |
+| `get-team`                   | GET    |
+| `get-cross-tenant-policy`    | GET    |
+| `list-cross-tenant-partners` | GET    |
+| `list-deleted-users`         | GET    |
+| `list-deleted-groups`        | GET    |
+
 ### Incident response (4) -- requires `--allow-writes`
 
 | Tool                         | Method | Risk     |
@@ -255,7 +300,11 @@ node dist/index.js --verify-login
 
 ```
 Application.Read.All
+AttackSimulation.Read.All
 AuditLog.Read.All
+DeviceManagementApps.Read.All
+DeviceManagementConfiguration.Read.All
+DeviceManagementManagedDevices.Read.All
 Directory.Read.All
 Domain.Read.All
 Group.Read.All
@@ -271,6 +320,10 @@ SecurityEvents.Read.All
 SecurityIncident.Read.All
 ServiceHealth.Read.All
 ServiceMessage.Read.All
+SharePointTenantSettings.Read.All
+Sites.Read.All
+Team.ReadBasic.All
+ThreatIntelligence.Read.All
 User.Read.All
 UserAuthenticationMethod.Read.All
 ```

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -417,5 +417,197 @@
     "toolName": "get-admin-consent-policy",
     "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the admin consent request policy. Shows isEnabled, notifyReviewers, remindersEnabled, and reviewers list. Controls whether users can request admin consent for apps they want to use."
+  },
+
+  {
+    "pathPattern": "/deviceManagement/managedDevices",
+    "method": "get",
+    "toolName": "list-managed-devices",
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "llmTip": "Lists all Intune-managed devices. Use $filter=operatingSystem eq 'Windows' to filter by OS. Use $select=deviceName,operatingSystem,complianceState,lastSyncDateTime,userPrincipalName to get key fields. complianceState values: compliant, noncompliant, unknown."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}",
+    "method": "get",
+    "toolName": "get-managed-device",
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "llmTip": "Gets a specific Intune-managed device. Returns deviceName, operatingSystem, osVersion, complianceState, isEncrypted, managementAgent, enrolledDateTime, lastSyncDateTime, userPrincipalName."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDeviceOverview",
+    "method": "get",
+    "toolName": "get-managed-device-overview",
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "llmTip": "Gets a summary overview of all managed devices. Returns enrolledDeviceCount, mdmEnrolledCount, dualEnrolledDeviceCount, and device operating system summary."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCompliancePolicies",
+    "method": "get",
+    "toolName": "list-compliance-policies",
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "llmTip": "Lists all Intune device compliance policies. Each has displayName, description, lastModifiedDateTime, and platform-specific settings (password, encryption, OS version requirements)."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
+    "method": "get",
+    "toolName": "get-compliance-policy",
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "llmTip": "Gets a specific Intune compliance policy. Returns full policy details including platform-specific compliance settings."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceConfigurations",
+    "method": "get",
+    "toolName": "list-device-configurations",
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "llmTip": "Lists all Intune device configuration profiles. Each has displayName, description, lastModifiedDateTime, and @odata.type indicating the profile type (Wi-Fi, VPN, email, etc.)."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
+    "method": "get",
+    "toolName": "get-device-configuration",
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "llmTip": "Gets a specific Intune device configuration profile. Returns full configuration details."
+  },
+  {
+    "pathPattern": "/deviceManagement/detectedApps",
+    "method": "get",
+    "toolName": "list-detected-apps",
+    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "llmTip": "Lists applications detected on managed devices. Each has displayName, version, sizeInByte, deviceCount. Useful for software inventory and shadow IT detection."
+  },
+
+  {
+    "pathPattern": "/security/threatIntelligence/articles",
+    "method": "get",
+    "toolName": "list-threat-intel-articles",
+    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "llmTip": "Lists Microsoft Threat Intelligence articles. Each has title, body, createdDateTime, lastUpdatedDateTime, and indicators. Use to stay informed about current threat campaigns."
+  },
+  {
+    "pathPattern": "/security/threatIntelligence/articles/{article-id}",
+    "method": "get",
+    "toolName": "get-threat-intel-article",
+    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "llmTip": "Gets a specific threat intelligence article. Returns full content, indicators, and related articles."
+  },
+  {
+    "pathPattern": "/security/threatIntelligence/intelProfiles",
+    "method": "get",
+    "toolName": "list-threat-intel-profiles",
+    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "llmTip": "Lists threat actor intelligence profiles. Each has title, kind (actor, tool, vulnerability), tradecraft summary, and associated indicators."
+  },
+  {
+    "pathPattern": "/security/threatIntelligence/intelProfiles/{intelligenceProfile-id}",
+    "method": "get",
+    "toolName": "get-threat-intel-profile",
+    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "llmTip": "Gets a specific threat actor profile with full details including tradecraft, targets, and indicators."
+  },
+  {
+    "pathPattern": "/security/threatIntelligence/hosts",
+    "method": "get",
+    "toolName": "list-threat-intel-hosts",
+    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "llmTip": "Lists known threat intelligence hosts (IPs and hostnames). Use to look up reputation and history of suspicious hosts observed in your environment."
+  },
+  {
+    "pathPattern": "/security/threatIntelligence/hosts/{host-id}",
+    "method": "get",
+    "toolName": "get-threat-intel-host",
+    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "llmTip": "Gets details for a specific host. The host-id is the hostname or IP address. Returns firstSeenDateTime, lastSeenDateTime, reputation, and associated components."
+  },
+  {
+    "pathPattern": "/security/threatIntelligence/vulnerabilities",
+    "method": "get",
+    "toolName": "list-threat-intel-vulnerabilities",
+    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "llmTip": "Lists known vulnerabilities from Microsoft Threat Intelligence. Each has CVE ID, description, severity, exploits, and affected components."
+  },
+  {
+    "pathPattern": "/security/threatIntelligence/vulnerabilities/{vulnerability-id}",
+    "method": "get",
+    "toolName": "get-threat-intel-vulnerability",
+    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "llmTip": "Gets a specific vulnerability by CVE ID. Returns full details including CVSS score, exploits, remediation, and affected components."
+  },
+  {
+    "pathPattern": "/security/attackSimulation/simulations",
+    "method": "get",
+    "toolName": "list-attack-simulations",
+    "appPermissions": ["AttackSimulation.Read.All"],
+    "llmTip": "Lists attack simulation campaigns (phishing simulations). Each has displayName, status, launchDateTime, completionDateTime, and report with click rates and compromise rates."
+  },
+  {
+    "pathPattern": "/security/attackSimulation/simulations/{simulation-id}",
+    "method": "get",
+    "toolName": "get-attack-simulation",
+    "appPermissions": ["AttackSimulation.Read.All"],
+    "llmTip": "Gets details for a specific attack simulation campaign. Returns full report including user targeting, click rates, and training completion."
+  },
+
+  {
+    "pathPattern": "/sites",
+    "method": "get",
+    "toolName": "list-sharepoint-sites",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists SharePoint sites in the tenant. Use $select=displayName,webUrl,createdDateTime,lastModifiedDateTime to get key fields. Use $filter=isPersonalSite eq false to exclude OneDrive sites. Use $search to find sites by name."
+  },
+  {
+    "pathPattern": "/sites/{site-id}",
+    "method": "get",
+    "toolName": "get-sharepoint-site",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Gets a specific SharePoint site. Use root for the root site. Returns displayName, webUrl, description, createdDateTime. Use $expand=drives to list document libraries."
+  },
+  {
+    "pathPattern": "/admin/sharepoint/settings",
+    "method": "get",
+    "toolName": "get-sharepoint-settings",
+    "appPermissions": ["SharePointTenantSettings.Read.All"],
+    "llmTip": "Gets tenant-wide SharePoint admin settings. Returns sharingCapability, isResharingByExternalUsersEnabled, defaultSharingLinkType, isSiteCreationEnabled, and other governance settings. Critical for auditing external sharing configuration."
+  },
+  {
+    "pathPattern": "/teams",
+    "method": "get",
+    "toolName": "list-teams",
+    "appPermissions": ["Team.ReadBasic.All"],
+    "llmTip": "Lists all teams in the tenant. Use $select=displayName,description,createdDateTime,visibility to get key fields. visibility can be public or private."
+  },
+  {
+    "pathPattern": "/teams/{team-id}",
+    "method": "get",
+    "toolName": "get-team",
+    "appPermissions": ["Team.ReadBasic.All"],
+    "llmTip": "Gets a specific team. Returns displayName, description, visibility, memberSettings, messagingSettings, funSettings, guestSettings."
+  },
+  {
+    "pathPattern": "/policies/crossTenantAccessPolicy",
+    "method": "get",
+    "toolName": "get-cross-tenant-policy",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Gets the cross-tenant access policy. Shows default inbound/outbound settings for B2B collaboration and B2B direct connect. Critical for auditing external access configuration."
+  },
+  {
+    "pathPattern": "/policies/crossTenantAccessPolicy/partners",
+    "method": "get",
+    "toolName": "list-cross-tenant-partners",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Lists partner-specific cross-tenant access configurations. Each entry overrides the default policy for a specific external tenant. Shows tenantId, inboundTrust, b2bCollaborationInbound/Outbound settings."
+  },
+  {
+    "pathPattern": "/directory/deletedItems/graph.user",
+    "method": "get",
+    "toolName": "list-deleted-users",
+    "appPermissions": ["User.Read.All"],
+    "llmTip": "Lists recently deleted users (soft-deleted, recoverable within 30 days). Returns the same user properties as active users. Useful for auditing account deletions and recovery."
+  },
+  {
+    "pathPattern": "/directory/deletedItems/graph.group",
+    "method": "get",
+    "toolName": "list-deleted-groups",
+    "appPermissions": ["Group.Read.All"],
+    "llmTip": "Lists recently deleted groups (soft-deleted, recoverable within 30 days). Only Microsoft 365 groups can be restored. Security groups are permanently deleted."
   }
 ]

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -37,6 +37,22 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
       /secure-score|subscribed-sku|license|risky-user|risky-service|security-defaults|auth-method-config|admin-consent/i,
     description: 'Compliance, licenses, Secure Score, Identity Protection, and security policies',
   },
+  intune: {
+    name: 'intune',
+    pattern: /managed-device|compliance-polic|device-configuration|detected-app/i,
+    description: 'Intune device management (managed devices, compliance, configurations, apps)',
+  },
+  threatintel: {
+    name: 'threatintel',
+    pattern: /threat-intel|attack-simulation/i,
+    description:
+      'Threat intelligence (articles, profiles, hosts, vulnerabilities, attack simulations)',
+  },
+  collaboration: {
+    name: 'collaboration',
+    pattern: /sharepoint|team(?!s-activity)|cross-tenant|deleted-user|deleted-group/i,
+    description: 'SharePoint, Teams, cross-tenant access, and deleted items',
+  },
   response: {
     name: 'response',
     pattern:


### PR DESCRIPTION
## Summary

- **Chantier 7 — Intune** (8 endpoints): `list-managed-devices`, `get-managed-device`, `get-managed-device-overview`, `list-compliance-policies`, `get-compliance-policy`, `list-device-configurations`, `get-device-configuration`, `list-detected-apps`
- **Chantier 8 — Threat Intelligence** (10 endpoints): `list/get-threat-intel-articles`, `list/get-threat-intel-profiles`, `list/get-threat-intel-hosts`, `list/get-threat-intel-vulnerabilities`, `list/get-attack-simulations`
- **Chantier 9 — Collaboration & Admin** (9 endpoints): `list/get-sharepoint-sites`, `get-sharepoint-settings`, `list/get-teams`, `get-cross-tenant-policy`, `list-cross-tenant-partners`, `list-deleted-users`, `list-deleted-groups`
- 3 new presets: `intune`, `threatintel`, `collaboration`
- **Total tools: 57 → 84**

## New permissions required

| Permission | Endpoints |
|------------|-----------|
| `DeviceManagementManagedDevices.Read.All` | Managed devices (3) |
| `DeviceManagementConfiguration.Read.All` | Compliance policies, device configs (4) |
| `DeviceManagementApps.Read.All` | Detected apps (1) |
| `ThreatIntelligence.Read.All` | Threat intel articles, profiles, hosts, vulns (8) |
| `AttackSimulation.Read.All` | Attack simulations (2) |
| `Sites.Read.All` | SharePoint sites (2) |
| `SharePointTenantSettings.Read.All` | SharePoint settings (1) |
| `Team.ReadBasic.All` | Teams (2) |
| `Policy.Read.All` | Cross-tenant (2, already granted) |
| `User.Read.All` | Deleted users (1, already granted) |
| `Group.Read.All` | Deleted groups (1, already granted) |

## Test plan

- [x] `npm run verify` passes (3/3 tests)
- [ ] Manual test with `npm run inspector`
- [ ] Verify new presets: `--preset intune`, `--preset threatintel`, `--preset collaboration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)