### PR TITLE
feat: add 25 endpoints for devices, PIM, risk detections, admin units, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,16 +98,16 @@ node dist/index.js --preset identity
 node dist/index.js --preset security,audit,identity
 ```
 
-| Preset       | Description                                                    |
-| ------------ | -------------------------------------------------------------- |
-| `security`   | Security alerts, incidents, and attack simulations                          |
-| `audit`      | Directory audits, sign-ins, provisioning logs, deleted items                |
-| `health`     | Service health and Message Center                                           |
-| `reports`    | Usage reports (Teams, Email, SharePoint, OneDrive, Mailbox, M365 Apps)      |
-| `identity`   | Users, groups, roles, devices, PIM, conditional access, apps, domains       |
-| `compliance` | Licenses, Secure Score, Identity Protection, risk detections, policies      |
-| `response`   | Incident response write operations (disable, revoke, confirm, dismiss)      |
-| `all`        | All available tools                                                         |
+| Preset       | Description                                                            |
+| ------------ | ---------------------------------------------------------------------- |
+| `security`   | Security alerts, incidents, and attack simulations                     |
+| `audit`      | Directory audits, sign-ins, provisioning logs, deleted items           |
+| `health`     | Service health and Message Center                                      |
+| `reports`    | Usage reports (Teams, Email, SharePoint, OneDrive, Mailbox, M365 Apps) |
+| `identity`   | Users, groups, roles, devices, PIM, conditional access, apps, domains  |
+| `compliance` | Licenses, Secure Score, Identity Protection, risk detections, policies |
+| `response`   | Incident response write operations (disable, revoke, confirm, dismiss) |
+| `all`        | All available tools                                                    |
 
 ### Verify credentials
 
@@ -189,22 +189,22 @@ node dist/index.js --verify-login
 
 ### Directory roles & PIM (6)
 
-| Tool                           | Method |
-| ------------------------------ | ------ |
-| `list-directory-roles`         | GET    |
-| `list-role-members`            | GET    |
-| `list-role-assignments`        | GET    |
-| `list-role-definitions`        | GET    |
-| `list-pim-eligible-assignments`| GET    |
-| `list-pim-active-assignments`  | GET    |
+| Tool                            | Method |
+| ------------------------------- | ------ |
+| `list-directory-roles`          | GET    |
+| `list-role-members`             | GET    |
+| `list-role-assignments`         | GET    |
+| `list-role-definitions`         | GET    |
+| `list-pim-eligible-assignments` | GET    |
+| `list-pim-active-assignments`   | GET    |
 
 ### Administrative units (3)
 
-| Tool                                | Method |
-| ----------------------------------- | ------ |
-| `list-administrative-units`         | GET    |
-| `get-administrative-unit`           | GET    |
-| `list-administrative-unit-members`  | GET    |
+| Tool                               | Method |
+| ---------------------------------- | ------ |
+| `list-administrative-units`        | GET    |
+| `get-administrative-unit`          | GET    |
+| `list-administrative-unit-members` | GET    |
 
 ### Conditional access (3)
 
@@ -216,13 +216,13 @@ node dist/index.js --verify-login
 
 ### Applications & app roles (5)
 
-| Tool                            | Method |
-| ------------------------------- | ------ |
-| `list-applications`             | GET    |
-| `list-service-principals`       | GET    |
-| `list-oauth2-grants`            | GET    |
-| `list-user-app-role-assignments`| GET    |
-| `list-sp-app-role-assignments`  | GET    |
+| Tool                             | Method |
+| -------------------------------- | ------ |
+| `list-applications`              | GET    |
+| `list-service-principals`        | GET    |
+| `list-oauth2-grants`             | GET    |
+| `list-user-app-role-assignments` | GET    |
+| `list-sp-app-role-assignments`   | GET    |
 
 ### Organization (2)
 
@@ -261,28 +261,28 @@ node dist/index.js --verify-login
 
 ### Security & access policies (8)
 
-| Tool                              | Method |
-| --------------------------------- | ------ |
-| `get-auth-methods-policy`         | GET    |
-| `list-auth-method-configs`        | GET    |
-| `get-auth-method-config`          | GET    |
-| `get-security-defaults`           | GET    |
-| `get-admin-consent-policy`        | GET    |
-| `list-auth-strength-policies`     | GET    |
-| `get-cross-tenant-access-policy`  | GET    |
-| `list-cross-tenant-partners`      | GET    |
+| Tool                             | Method |
+| -------------------------------- | ------ |
+| `get-auth-methods-policy`        | GET    |
+| `list-auth-method-configs`       | GET    |
+| `get-auth-method-config`         | GET    |
+| `get-security-defaults`          | GET    |
+| `get-admin-consent-policy`       | GET    |
+| `list-auth-strength-policies`    | GET    |
+| `get-cross-tenant-access-policy` | GET    |
+| `list-cross-tenant-partners`     | GET    |
 
 ### Incident response (7) -- requires `--allow-writes`
 
-| Tool                             | Method | Risk     |
-| -------------------------------- | ------ | -------- |
-| `disable-user-account`           | PATCH  | critical |
-| `revoke-user-sessions`           | POST   | high     |
-| `add-security-alert-comment`     | POST   | low      |
-| `update-device`                  | PATCH  | high     |
-| `confirm-compromised-users`      | POST   | high     |
-| `dismiss-risky-users`            | POST   | medium   |
-| `delete-user-phone-auth-method`  | DELETE | high     |
+| Tool                            | Method | Risk     |
+| ------------------------------- | ------ | -------- |
+| `disable-user-account`          | PATCH  | critical |
+| `revoke-user-sessions`          | POST   | high     |
+| `add-security-alert-comment`    | POST   | low      |
+| `update-device`                 | PATCH  | high     |
+| `confirm-compromised-users`     | POST   | high     |
+| `dismiss-risky-users`           | POST   | medium   |
+| `delete-user-phone-auth-method` | DELETE | high     |
 
 ## Azure AD permissions
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 
 ## Features
 
-- **57 tools** covering security, audit, identity, compliance, reports, and incident response
+- **82 tools** covering security, audit, identity, compliance, reports, and incident response
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -100,14 +100,14 @@ node dist/index.js --preset security,audit,identity
 
 | Preset       | Description                                                    |
 | ------------ | -------------------------------------------------------------- |
-| `security`   | Security alerts and incidents                                  |
-| `audit`      | Directory audits, sign-ins, provisioning logs                  |
-| `health`     | Service health and Message Center                              |
-| `reports`    | Usage reports (Teams, Email, SharePoint, Active Users)         |
-| `identity`   | Users, groups, roles, conditional access, apps, domains        |
-| `compliance` | Licenses, Secure Score, Identity Protection, security policies |
-| `response`   | Incident response write operations                             |
-| `all`        | All available tools                                            |
+| `security`   | Security alerts, incidents, and attack simulations                          |
+| `audit`      | Directory audits, sign-ins, provisioning logs, deleted items                |
+| `health`     | Service health and Message Center                                           |
+| `reports`    | Usage reports (Teams, Email, SharePoint, OneDrive, Mailbox, M365 Apps)      |
+| `identity`   | Users, groups, roles, devices, PIM, conditional access, apps, domains       |
+| `compliance` | Licenses, Secure Score, Identity Protection, risk detections, policies      |
+| `response`   | Incident response write operations (disable, revoke, confirm, dismiss)      |
+| `all`        | All available tools                                                         |
 
 ### Verify credentials
 
@@ -115,9 +115,9 @@ node dist/index.js --preset security,audit,identity
 node dist/index.js --verify-login
 ```
 
-## Available tools (57)
+## Available tools (82)
 
-### Security (6)
+### Security (8)
 
 | Tool                       | Method | Risk   |
 | -------------------------- | ------ | ------ |
@@ -127,14 +127,18 @@ node dist/index.js --verify-login
 | `list-security-incidents`  | GET    |        |
 | `get-security-incident`    | GET    |        |
 | `update-security-incident` | PATCH  | medium |
+| `list-attack-simulations`  | GET    |        |
+| `get-attack-simulation`    | GET    |        |
 
-### Audit logs (3)
+### Audit logs & deleted items (5)
 
 | Tool                     | Method |
 | ------------------------ | ------ |
 | `list-directory-audits`  | GET    |
 | `list-sign-ins`          | GET    |
 | `list-provisioning-logs` | GET    |
+| `list-deleted-users`     | GET    |
+| `list-deleted-groups`    | GET    |
 
 ### Service health (3)
 
@@ -144,14 +148,18 @@ node dist/index.js --verify-login
 | `list-service-issues`   | GET    |
 | `list-service-messages` | GET    |
 
-### Usage reports (4)
+### Usage reports (8)
 
-| Tool                          | Method |
-| ----------------------------- | ------ |
-| `get-teams-activity-report`   | GET    |
-| `get-email-activity-report`   | GET    |
-| `get-active-users-report`     | GET    |
-| `get-sharepoint-usage-report` | GET    |
+| Tool                            | Method |
+| ------------------------------- | ------ |
+| `get-teams-activity-report`     | GET    |
+| `get-email-activity-report`     | GET    |
+| `get-active-users-report`       | GET    |
+| `get-sharepoint-usage-report`   | GET    |
+| `get-onedrive-usage-report`     | GET    |
+| `get-active-user-counts-report` | GET    |
+| `get-mailbox-usage-report`      | GET    |
+| `get-m365-apps-usage-report`    | GET    |
 
 ### Users (5)
 
@@ -163,6 +171,13 @@ node dist/index.js --verify-login
 | `list-user-auth-methods` | GET    |
 | `list-user-devices`      | GET    |
 
+### Devices (2)
+
+| Tool           | Method |
+| -------------- | ------ |
+| `list-devices` | GET    |
+| `get-device`   | GET    |
+
 ### Groups (4)
 
 | Tool                 | Method |
@@ -172,14 +187,24 @@ node dist/index.js --verify-login
 | `list-group-members` | GET    |
 | `list-group-owners`  | GET    |
 
-### Directory roles & PIM (4)
+### Directory roles & PIM (6)
 
-| Tool                    | Method |
-| ----------------------- | ------ |
-| `list-directory-roles`  | GET    |
-| `list-role-members`     | GET    |
-| `list-role-assignments` | GET    |
-| `list-role-definitions` | GET    |
+| Tool                           | Method |
+| ------------------------------ | ------ |
+| `list-directory-roles`         | GET    |
+| `list-role-members`            | GET    |
+| `list-role-assignments`        | GET    |
+| `list-role-definitions`        | GET    |
+| `list-pim-eligible-assignments`| GET    |
+| `list-pim-active-assignments`  | GET    |
+
+### Administrative units (3)
+
+| Tool                                | Method |
+| ----------------------------------- | ------ |
+| `list-administrative-units`         | GET    |
+| `get-administrative-unit`           | GET    |
+| `list-administrative-unit-members`  | GET    |
 
 ### Conditional access (3)
 
@@ -189,13 +214,15 @@ node dist/index.js --verify-login
 | `get-conditional-access-policy`    | GET    |
 | `list-named-locations`             | GET    |
 
-### Applications (3)
+### Applications & app roles (5)
 
-| Tool                      | Method |
-| ------------------------- | ------ |
-| `list-applications`       | GET    |
-| `list-service-principals` | GET    |
-| `list-oauth2-grants`      | GET    |
+| Tool                            | Method |
+| ------------------------------- | ------ |
+| `list-applications`             | GET    |
+| `list-service-principals`       | GET    |
+| `list-oauth2-grants`            | GET    |
+| `list-user-app-role-assignments`| GET    |
+| `list-sp-app-role-assignments`  | GET    |
 
 ### Organization (2)
 
@@ -220,7 +247,7 @@ node dist/index.js --verify-login
 | `list-secure-score-controls` | GET    |
 | `get-secure-score-control`   | GET    |
 
-### Identity Protection (5)
+### Identity Protection & risk detections (7)
 
 | Tool                            | Method |
 | ------------------------------- | ------ |
@@ -229,42 +256,57 @@ node dist/index.js --verify-login
 | `list-risky-user-history`       | GET    |
 | `list-risky-service-principals` | GET    |
 | `get-risky-service-principal`   | GET    |
+| `list-risk-detections`          | GET    |
+| `get-risk-detection`            | GET    |
 
-### Security policies (5)
+### Security & access policies (8)
 
-| Tool                       | Method |
-| -------------------------- | ------ |
-| `get-auth-methods-policy`  | GET    |
-| `list-auth-method-configs` | GET    |
-| `get-auth-method-config`   | GET    |
-| `get-security-defaults`    | GET    |
-| `get-admin-consent-policy` | GET    |
+| Tool                              | Method |
+| --------------------------------- | ------ |
+| `get-auth-methods-policy`         | GET    |
+| `list-auth-method-configs`        | GET    |
+| `get-auth-method-config`          | GET    |
+| `get-security-defaults`           | GET    |
+| `get-admin-consent-policy`        | GET    |
+| `list-auth-strength-policies`     | GET    |
+| `get-cross-tenant-access-policy`  | GET    |
+| `list-cross-tenant-partners`      | GET    |
 
-### Incident response (4) -- requires `--allow-writes`
+### Incident response (7) -- requires `--allow-writes`
 
-| Tool                         | Method | Risk     |
-| ---------------------------- | ------ | -------- |
-| `disable-user-account`       | PATCH  | critical |
-| `revoke-user-sessions`       | POST   | high     |
-| `add-security-alert-comment` | POST   | low      |
-| `update-device`              | PATCH  | high     |
+| Tool                             | Method | Risk     |
+| -------------------------------- | ------ | -------- |
+| `disable-user-account`           | PATCH  | critical |
+| `revoke-user-sessions`           | POST   | high     |
+| `add-security-alert-comment`     | POST   | low      |
+| `update-device`                  | PATCH  | high     |
+| `confirm-compromised-users`      | POST   | high     |
+| `dismiss-risky-users`            | POST   | medium   |
+| `delete-user-phone-auth-method`  | DELETE | high     |
 
 ## Azure AD permissions
 
 ### Read-only (default)
 
 ```
+AdministrativeUnit.Read.All
 Application.Read.All
+AppRoleAssignment.ReadWrite.All
+AttackSimulation.Read.All
 AuditLog.Read.All
+Device.Read.All
 Directory.Read.All
 Domain.Read.All
 Group.Read.All
 GroupMember.Read.All
+IdentityRiskEvent.Read.All
 IdentityRiskyServicePrincipal.Read.All
 IdentityRiskyUser.Read.All
 Organization.Read.All
 Policy.Read.All
 Reports.Read.All
+RoleAssignmentSchedule.Read.Directory
+RoleEligibilitySchedule.Read.Directory
 RoleManagement.Read.Directory
 SecurityAlert.Read.All
 SecurityEvents.Read.All
@@ -279,9 +321,11 @@ UserAuthenticationMethod.Read.All
 
 ```
 Device.ReadWrite.All
+IdentityRiskyUser.ReadWrite.All
 SecurityAlert.ReadWrite.All
 SecurityIncident.ReadWrite.All
 User.ReadWrite.All
+UserAuthenticationMethod.ReadWrite.All
 ```
 
 ## Remote HTTP deployment

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -417,5 +417,197 @@
     "toolName": "get-admin-consent-policy",
     "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the admin consent request policy. Shows isEnabled, notifyReviewers, remindersEnabled, and reviewers list. Controls whether users can request admin consent for apps they want to use."
+  },
+
+  {
+    "pathPattern": "/devices",
+    "method": "get",
+    "toolName": "list-devices",
+    "appPermissions": ["Device.Read.All"],
+    "llmTip": "Lists all devices registered in the tenant. Use $filter=isCompliant eq false to find non-compliant devices. Use $filter=isManaged eq true for Intune-managed devices. Use $filter=operatingSystem eq 'Windows' to filter by OS. Use $select=displayName,operatingSystem,operatingSystemVersion,isCompliant,isManaged,accountEnabled,approximateLastSignInDateTime. Use $filter=approximateLastSignInDateTime le 2024-01-01T00:00:00Z to find stale devices."
+  },
+  {
+    "pathPattern": "/devices/{device-id}",
+    "method": "get",
+    "toolName": "get-device",
+    "appPermissions": ["Device.Read.All"],
+    "llmTip": "Gets a specific device by ID. Returns displayName, operatingSystem, operatingSystemVersion, isCompliant, isManaged, accountEnabled, trustType, approximateLastSignInDateTime, and deviceId."
+  },
+
+  {
+    "pathPattern": "/identityProtection/riskDetections",
+    "method": "get",
+    "toolName": "list-risk-detections",
+    "appPermissions": ["IdentityRiskEvent.Read.All"],
+    "llmTip": "Lists individual risk detections from Identity Protection. Use $filter=riskLevel eq 'high' to find high-risk events. Use $filter=detectedDateTime ge 2024-01-01T00:00:00Z to filter by date. Each detection has riskEventType (e.g. anonymizedIPAddress, leakedCredentials, malwareInfectedIPAddress), riskLevel, riskState, userPrincipalName, ipAddress, location, and activityType (signin, user)."
+  },
+  {
+    "pathPattern": "/identityProtection/riskDetections/{riskDetection-id}",
+    "method": "get",
+    "toolName": "get-risk-detection",
+    "appPermissions": ["IdentityRiskEvent.Read.All"],
+    "llmTip": "Gets a specific risk detection by ID. Returns full details including riskEventType, riskLevel, detectionTimingType (realtime, offline), source, ipAddress, location, userPrincipalName, and additionalInfo."
+  },
+
+  {
+    "pathPattern": "/directory/deletedItems/graph.user",
+    "method": "get",
+    "toolName": "list-deleted-users",
+    "appPermissions": ["User.Read.All"],
+    "llmTip": "Lists recently deleted users (recoverable within 30 days). Use $select=displayName,userPrincipalName,deletedDateTime to see when each user was deleted. Useful for auditing account deletions and potential recovery."
+  },
+  {
+    "pathPattern": "/directory/deletedItems/graph.group",
+    "method": "get",
+    "toolName": "list-deleted-groups",
+    "appPermissions": ["Group.Read.All"],
+    "llmTip": "Lists recently deleted groups (recoverable within 30 days). Only Microsoft 365 groups (unified groups) are soft-deleted and recoverable. Use $select=displayName,deletedDateTime,groupTypes."
+  },
+
+  {
+    "pathPattern": "/directory/administrativeUnits",
+    "method": "get",
+    "toolName": "list-administrative-units",
+    "appPermissions": ["AdministrativeUnit.Read.All"],
+    "llmTip": "Lists all administrative units in the tenant. Administrative units scope admin roles to a subset of users/groups/devices. Use $select=displayName,description,membershipType,membershipRule. membershipType can be 'Assigned' or 'Dynamic'."
+  },
+  {
+    "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}",
+    "method": "get",
+    "toolName": "get-administrative-unit",
+    "appPermissions": ["AdministrativeUnit.Read.All"],
+    "llmTip": "Gets a specific administrative unit by ID. Returns displayName, description, membershipType, membershipRule, and visibility."
+  },
+  {
+    "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}/members",
+    "method": "get",
+    "toolName": "list-administrative-unit-members",
+    "appPermissions": ["AdministrativeUnit.Read.All"],
+    "llmTip": "Lists members (users, groups, devices) of an administrative unit. Returns directory objects. Use $select=displayName,userPrincipalName for users."
+  },
+
+  {
+    "pathPattern": "/policies/authenticationStrengthPolicies",
+    "method": "get",
+    "toolName": "list-auth-strength-policies",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Lists authentication strength policies. These define which MFA method combinations are acceptable (e.g. phishing-resistant MFA, passwordless). Built-in policies include 'MFA', 'Passwordless MFA', and 'Phishing-resistant MFA'. Custom policies can restrict to specific methods. Used by Conditional Access grant controls."
+  },
+  {
+    "pathPattern": "/policies/crossTenantAccessPolicy",
+    "method": "get",
+    "toolName": "get-cross-tenant-access-policy",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Gets the cross-tenant access policy. Controls B2B collaboration and B2B direct connect defaults. Returns allowedCloudEndpoints and default inbound/outbound settings for users, applications, and organizations."
+  },
+  {
+    "pathPattern": "/policies/crossTenantAccessPolicy/partners",
+    "method": "get",
+    "toolName": "list-cross-tenant-partners",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Lists partner-specific cross-tenant access configurations. Each entry has tenantId and overrides for inbound/outbound B2B collaboration and direct connect settings. Useful for auditing which external organizations have special access."
+  },
+
+  {
+    "pathPattern": "/roleManagement/directory/roleEligibilityScheduleInstances",
+    "method": "get",
+    "toolName": "list-pim-eligible-assignments",
+    "appPermissions": ["RoleEligibilitySchedule.Read.Directory"],
+    "llmTip": "Lists PIM (Privileged Identity Management) eligible role assignments. These are just-in-time assignments that users must activate. Use $filter=principalId eq '{user-id}' to find eligible roles for a specific user. Use $expand=roleDefinition to get role names. Compare with list-role-assignments to distinguish permanent vs eligible assignments."
+  },
+  {
+    "pathPattern": "/roleManagement/directory/roleAssignmentScheduleInstances",
+    "method": "get",
+    "toolName": "list-pim-active-assignments",
+    "appPermissions": ["RoleAssignmentSchedule.Read.Directory"],
+    "llmTip": "Lists PIM active role assignment schedule instances, including time-bound and activated assignments. Use $filter=principalId eq '{user-id}' to find active assignments for a user. Shows assignmentType (Assigned or Activated), startDateTime, endDateTime. Useful for auditing who currently has active privileged roles."
+  },
+
+  {
+    "pathPattern": "/users/{user-id}/appRoleAssignments",
+    "method": "get",
+    "toolName": "list-user-app-role-assignments",
+    "appPermissions": ["AppRoleAssignment.ReadWrite.All"],
+    "llmTip": "Lists app role assignments for a user. Shows which enterprise apps the user has been granted access to and with which roles. Each entry has appRoleId, resourceDisplayName, and principalDisplayName."
+  },
+  {
+    "pathPattern": "/servicePrincipals/{servicePrincipal-id}/appRoleAssignedTo",
+    "method": "get",
+    "toolName": "list-sp-app-role-assignments",
+    "appPermissions": ["Application.Read.All"],
+    "llmTip": "Lists all users and groups assigned app roles on a service principal. Use to audit who has access to a specific enterprise application. Each entry has principalDisplayName, principalType, appRoleId."
+  },
+
+  {
+    "pathPattern": "/identityProtection/riskyUsers/confirmCompromised",
+    "method": "post",
+    "toolName": "confirm-compromised-users",
+    "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Confirms one or more users as compromised. Body: {\"userIds\": [\"user-id-1\", \"user-id-2\"]}. This sets riskState to confirmedCompromised and riskLevel to high, which triggers any Conditional Access policies targeting risky users. Use after confirming a breach."
+  },
+  {
+    "pathPattern": "/identityProtection/riskyUsers/dismiss",
+    "method": "post",
+    "toolName": "dismiss-risky-users",
+    "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Dismisses risk for one or more users. Body: {\"userIds\": [\"user-id-1\", \"user-id-2\"]}. Sets riskState to dismissed. Use after investigating a risk detection and determining it is a false positive or has been remediated."
+  },
+  {
+    "pathPattern": "/users/{user-id}/authentication/phoneMethods/{phoneAuthenticationMethod-id}",
+    "method": "delete",
+    "toolName": "delete-user-phone-auth-method",
+    "appPermissions": ["UserAuthenticationMethod.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Deletes a phone authentication method for a user. Use list-user-auth-methods first to get the phoneAuthenticationMethod ID. Useful for removing a compromised phone number during incident response. Cannot delete if it is the user's only MFA method and MFA is required."
+  },
+
+  {
+    "pathPattern": "/reports/getOneDriveUsageAccountDetail(period='{period}')",
+    "method": "get",
+    "toolName": "get-onedrive-usage-report",
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
+    "llmTip": "Gets OneDrive usage details per account. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with ownerDisplayName, ownerPrincipalName, siteUrl, storageUsedInBytes, fileCount, activeFileCount, lastActivityDate."
+  },
+  {
+    "pathPattern": "/reports/getOffice365ActiveUserCounts(period='{period}')",
+    "method": "get",
+    "toolName": "get-active-user-counts-report",
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
+    "llmTip": "Gets daily active user counts across Microsoft 365 services. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with daily counts per service: office365, exchange, oneDrive, sharePoint, skypeForBusiness, yammer, teams."
+  },
+  {
+    "pathPattern": "/reports/getMailboxUsageDetail(period='{period}')",
+    "method": "get",
+    "toolName": "get-mailbox-usage-report",
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
+    "llmTip": "Gets mailbox usage details per user. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with userPrincipalName, displayName, storageUsedInBytes, issueWarningQuotaInBytes, prohibitSendQuotaInBytes, itemCount, lastActivityDate."
+  },
+  {
+    "pathPattern": "/reports/getM365AppUserDetail(period='{period}')",
+    "method": "get",
+    "toolName": "get-m365-apps-usage-report",
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
+    "llmTip": "Gets Microsoft 365 Apps usage details per user. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data showing which apps each user used (Outlook, Word, Excel, PowerPoint, OneNote, Teams) and on which platforms (Windows, Mac, Web, Mobile)."
+  },
+
+  {
+    "pathPattern": "/security/attackSimulation/simulations",
+    "method": "get",
+    "toolName": "list-attack-simulations",
+    "appPermissions": ["AttackSimulation.Read.All"],
+    "llmTip": "Lists attack simulation campaigns (phishing simulations). Each simulation has displayName, status, attackType (social, credential harvest, etc.), launchDateTime, completionDateTime, report with overview (resolvedTargetsCount, compromisedRate). Useful for tracking security awareness training effectiveness."
+  },
+  {
+    "pathPattern": "/security/attackSimulation/simulations/{simulation-id}",
+    "method": "get",
+    "toolName": "get-attack-simulation",
+    "appPermissions": ["AttackSimulation.Read.All"],
+    "llmTip": "Gets a specific attack simulation by ID. Returns full details including report with simulationEventsContent (users who clicked, reported, etc.) and trainingsContent."
   }
 ]

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -7,13 +7,13 @@ export interface ToolCategory {
 export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   security: {
     name: 'security',
-    pattern: /security|alert|incident/i,
-    description: 'Security alerts and incidents (Microsoft 365 Defender)',
+    pattern: /security|alert|incident|attack-simulation/i,
+    description: 'Security alerts, incidents, and attack simulations (Microsoft 365 Defender)',
   },
   audit: {
     name: 'audit',
-    pattern: /audit|sign-in|provisioning|directory/i,
-    description: 'Audit logs (directory audits, sign-ins, provisioning)',
+    pattern: /audit|sign-in|provisioning|directory|deleted-user|deleted-group/i,
+    description: 'Audit logs, deleted items (directory audits, sign-ins, provisioning)',
   },
   health: {
     name: 'health',
@@ -23,25 +23,25 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   reports: {
     name: 'reports',
     pattern: /report|activity|usage/i,
-    description: 'Usage reports (Teams, Email, Active Users, SharePoint)',
+    description: 'Usage reports (Teams, Email, Active Users, SharePoint, OneDrive, Mailbox, M365 Apps)',
   },
   identity: {
     name: 'identity',
     pattern:
-      /user|group|role|conditional|directory|domain|auth-method|credential|application|service-principal|oauth2|organization|named-location/i,
-    description: 'Identity and access management (Entra ID users, groups, roles, policies)',
+      /user|group|role|conditional|directory|domain|auth-method|credential|application|service-principal|oauth2|organization|named-location|device|administrative-unit|cross-tenant|pim|app-role/i,
+    description: 'Identity and access management (Entra ID users, groups, roles, devices, PIM, policies)',
   },
   compliance: {
     name: 'compliance',
     pattern:
-      /secure-score|subscribed-sku|license|risky-user|risky-service|security-defaults|auth-method-config|admin-consent/i,
-    description: 'Compliance, licenses, Secure Score, Identity Protection, and security policies',
+      /secure-score|subscribed-sku|license|risky-user|risky-service|risk-detection|security-defaults|auth-method-config|auth-strength|admin-consent/i,
+    description: 'Compliance, licenses, Secure Score, Identity Protection, risk detections, and security policies',
   },
   response: {
     name: 'response',
     pattern:
-      /disable-user|revoke|block|reset|isolate|update-security|delete-user-auth|update-device|update-user-auth/i,
-    description: 'Incident response operations (disable user, revoke sessions, update alerts)',
+      /disable-user|revoke|block|reset|isolate|update-security|delete-user-auth|delete-user-phone|update-device|update-user-auth|confirm-compromised|dismiss-risky/i,
+    description: 'Incident response operations (disable user, revoke sessions, confirm compromised, dismiss risk, update alerts)',
   },
   all: {
     name: 'all',

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -23,25 +23,29 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   reports: {
     name: 'reports',
     pattern: /report|activity|usage/i,
-    description: 'Usage reports (Teams, Email, Active Users, SharePoint, OneDrive, Mailbox, M365 Apps)',
+    description:
+      'Usage reports (Teams, Email, Active Users, SharePoint, OneDrive, Mailbox, M365 Apps)',
   },
   identity: {
     name: 'identity',
     pattern:
       /user|group|role|conditional|directory|domain|auth-method|credential|application|service-principal|oauth2|organization|named-location|device|administrative-unit|cross-tenant|pim|app-role/i,
-    description: 'Identity and access management (Entra ID users, groups, roles, devices, PIM, policies)',
+    description:
+      'Identity and access management (Entra ID users, groups, roles, devices, PIM, policies)',
   },
   compliance: {
     name: 'compliance',
     pattern:
       /secure-score|subscribed-sku|license|risky-user|risky-service|risk-detection|security-defaults|auth-method-config|auth-strength|admin-consent/i,
-    description: 'Compliance, licenses, Secure Score, Identity Protection, risk detections, and security policies',
+    description:
+      'Compliance, licenses, Secure Score, Identity Protection, risk detections, and security policies',
   },
   response: {
     name: 'response',
     pattern:
       /disable-user|revoke|block|reset|isolate|update-security|delete-user-auth|delete-user-phone|update-device|update-user-auth|confirm-compromised|dismiss-risky/i,
-    description: 'Incident response operations (disable user, revoke sessions, confirm compromised, dismiss risk, update alerts)',
+    description:
+      'Incident response operations (disable user, revoke sessions, confirm compromised, dismiss risk, update alerts)',
   },
   all: {
     name: 'all',


### PR DESCRIPTION
## Summary

- **25 new Graph API endpoints** bringing the total from 57 to **82 tools**
- Updated tool categories/presets to match new endpoints
- Updated README with new tool tables and permissions

## New endpoints by category

| Category | Tools | Count |
|---|---|---|
| Devices (tenant-wide) | `list-devices`, `get-device` | 2 |
| Risk detections | `list-risk-detections`, `get-risk-detection` | 2 |
| Deleted items | `list-deleted-users`, `list-deleted-groups` | 2 |
| Administrative units | `list-administrative-units`, `get-administrative-unit`, `list-administrative-unit-members` | 3 |
| Auth strength & cross-tenant | `list-auth-strength-policies`, `get-cross-tenant-access-policy`, `list-cross-tenant-partners` | 3 |
| PIM (Privileged Identity Mgmt) | `list-pim-eligible-assignments`, `list-pim-active-assignments` | 2 |
| App role assignments | `list-user-app-role-assignments`, `list-sp-app-role-assignments` | 2 |
| Usage reports | `get-onedrive-usage-report`, `get-active-user-counts-report`, `get-mailbox-usage-report`, `get-m365-apps-usage-report` | 4 |
| Attack simulations | `list-attack-simulations`, `get-attack-simulation` | 2 |
| Incident response (write) | `confirm-compromised-users`, `dismiss-risky-users`, `delete-user-phone-auth-method` | 3 |

## New permissions required

**Read:** `AdministrativeUnit.Read.All`, `AppRoleAssignment.ReadWrite.All`, `AttackSimulation.Read.All`, `Device.Read.All`, `IdentityRiskEvent.Read.All`, `RoleAssignmentSchedule.Read.Directory`, `RoleEligibilitySchedule.Read.Directory`

**Write:** `IdentityRiskyUser.ReadWrite.All`, `UserAuthenticationMethod.ReadWrite.All`

## Test plan

- [x] `npm run generate` succeeds
- [x] `npm run build` succeeds
- [x] `npm test` — all 3 tests pass (endpoint validation)
- [x] `npm run lint` — no new warnings
- [ ] Manual test with Graph API credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)