### PR TITLE
security: exhaustive security review and fixes

### DIFF
--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -8,7 +8,6 @@ interface GraphRequestOptions {
   method?: string;
   body?: string;
   rawResponse?: boolean;
-  includeHeaders?: boolean;
   excludeResponse?: boolean;
 }
 
@@ -39,7 +38,7 @@ class GraphClient {
       const result = await this.makeRequest(endpoint, options);
       return this.formatResponse(result, options.rawResponse, options.excludeResponse);
     } catch (error) {
-      logger.error(`Error in Graph API request: ${error}`);
+      logger.error(`Error in Graph API request: ${(error as Error).message}`);
       return {
         content: [{ type: 'text', text: JSON.stringify({ error: (error as Error).message }) }],
         isError: true,
@@ -68,9 +67,21 @@ class GraphClient {
 
     if (!response.ok) {
       const errorText = await response.text();
-      throw new Error(
-        `Microsoft Graph API error: ${response.status} ${response.statusText} - ${errorText}`
-      );
+      // SEC-B: Log full error for debugging but return sanitized message to client
+      logger.error(`Graph API error ${response.status} on ${url.split('?')[0]}: ${errorText}`);
+      let clientMessage = `Microsoft Graph API error: ${response.status} ${response.statusText}`;
+      try {
+        const parsed = JSON.parse(errorText) as { error?: { message?: string; code?: string } };
+        if (parsed.error?.code) {
+          clientMessage += ` (${parsed.error.code})`;
+        }
+        if (parsed.error?.message) {
+          clientMessage += ` - ${parsed.error.message}`;
+        }
+      } catch {
+        // Non-JSON error body — don't leak raw text
+      }
+      throw new Error(clientMessage);
     }
 
     const text = await response.text();

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -75,7 +75,7 @@ async function executeGraphTool(
     let body: unknown = null;
 
     for (const [paramName, paramValue] of Object.entries(params)) {
-      if (['includeHeaders', 'excludeResponse'].includes(paramName)) {
+      if (paramName === 'excludeResponse') {
         continue;
       }
 
@@ -106,9 +106,19 @@ async function executeGraphTool(
         switch (paramDef.type) {
           case 'Path': {
             const shouldSkipEncoding = config?.skipEncoding?.includes(paramName) ?? false;
-            const encodedValue = shouldSkipEncoding
-              ? (paramValue as string)
-              : encodeURIComponent(paramValue as string).replace(/%3D/g, '=');
+            let encodedValue: string;
+            if (shouldSkipEncoding) {
+              // SEC-A: Validate skip-encoded params to prevent path traversal
+              const raw = paramValue as string;
+              if (/[\/\\?#&]|\.\./.test(raw)) {
+                throw new Error(
+                  `Invalid value for path parameter '${paramName}': contains disallowed characters`
+                );
+              }
+              encodedValue = raw;
+            } else {
+              encodedValue = encodeURIComponent(paramValue as string).replace(/%3D/g, '=');
+            }
 
             path = path
               .replace(`{${paramName}}`, encodedValue)
@@ -177,7 +187,6 @@ async function executeGraphTool(
       method: tool.method.toUpperCase(),
       headers,
       rawResponse: !!config?.acceptType || !!config?.returnDownloadUrl,
-      includeHeaders: !!params.includeHeaders,
       excludeResponse: !!params.excludeResponse,
     };
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -110,7 +110,7 @@ async function executeGraphTool(
             if (shouldSkipEncoding) {
               // SEC-A: Validate skip-encoded params to prevent path traversal
               const raw = paramValue as string;
-              if (/[\/\\?#&]|\.\./.test(raw)) {
+              if (/[/\\?#&]|\.\./.test(raw)) {
                 throw new Error(
                   `Invalid value for path parameter '${paramName}': contains disallowed characters`
                 );

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -68,6 +68,8 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   // SEC-12: Wrap handlers in try-catch
   async function handleMcpRequest(req: Request, res: Response): Promise<void> {
     try {
+      // SEC-E: Stateless — each request creates a fresh transport. Session affinity is
+      // handled by the Entra token validation (tenant + allowed-clients).
       const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
       await options.server.connect(transport);
       await transport.handleRequest(req, res, req.body);

--- a/src/server.ts
+++ b/src/server.ts
@@ -70,6 +70,7 @@ class AdminGraphServer {
       const tokenValidatorOptions = {
         tenantId: this.secrets!.tenantId,
         allowedClientIds: this.options.allowedClients.split(',').map((id: string) => id.trim()),
+        expectedAudience: `api://${this.secrets!.clientId}`,
       };
 
       await startHttpServer({


### PR DESCRIPTION
## Summary
- Revue exhaustive de securite du codebase complet (14 points audites)
- Correction de 5 vulnerabilites identifiees

## Corrections

| ID | Severite | Description |
|----|----------|-------------|
| SEC-F | MEDIUM | Ajout de la validation `audience` sur les tokens HTTP — empêche la reutilisation de tokens emis pour d'autres apps du meme tenant |
| SEC-A | LOW | Validation des parametres path avec `skipEncoding` contre l'injection de chemin (`/`, `\`, `..`, `?`, `#`, `&`) |
| SEC-B | MEDIUM | Sanitisation des erreurs Graph API — log complet cote serveur, seul le code d'erreur + message Graph retourne au client MCP |
| SEC-C | LOW | Log de `error.message` au lieu de l'objet error complet pour eviter les fuites de stack traces |
| SEC-D | LOW | Suppression du code mort `includeHeaders` qui exposait un parametre inutile aux LLMs |

## Points audites (aucun probleme)
- Gestion des secrets (env vars + Key Vault)
- Read-only par defaut
- Rate limiting HTTP (100 req/min)
- Security headers (CSP, X-Frame-Options, etc.)
- Body size limit (100kb)
- Bind localhost par defaut
- Protection ReDoS (regex < 500 chars)
- Classification de risque sur tous les endpoints write
- .gitignore couvre .env et tokens
- Permissions log directory (0o700)
- Encodage des path params

## Test plan
- [ ] `npm run build` passe
- [ ] `npm test` passe (3 tests)
- [ ] `npm run format:check` passe
- [ ] Verifier que les endpoints avec `skipEncoding` rejettent les valeurs malicieuses
- [ ] Verifier que les erreurs Graph API ne leakent plus le body brut

🤖 Generated with [Claude Code](https://claude.com/claude-code)