### PR TITLE
security: fix risk level and least-privilege permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,7 @@ node dist/index.js --verify-login
 | `add-security-alert-comment`    | POST   | low      |
 | `update-device`                 | PATCH  | high     |
 | `confirm-compromised-users`     | POST   | high     |
-| `dismiss-risky-users`           | POST   | medium   |
+| `dismiss-risky-users`           | POST   | high     |
 | `delete-user-phone-auth-method` | DELETE | high     |
 
 ### eDiscovery (1)
@@ -585,7 +585,7 @@ AccessReview.Read.All
 AdministrativeUnit.Read.All
 Agreement.Read.All
 Application.Read.All
-AppRoleAssignment.ReadWrite.All
+AppRoleAssignment.Read.All
 AttackSimulation.Read.All
 AuditLog.Read.All
 ConsentRequest.Read.All

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -527,7 +527,7 @@
     "pathPattern": "/users/{user-id}/appRoleAssignments",
     "method": "get",
     "toolName": "list-user-app-role-assignments",
-    "appPermissions": ["AppRoleAssignment.ReadWrite.All"],
+    "appPermissions": ["AppRoleAssignment.Read.All"],
     "llmTip": "Lists app role assignments for a user. Shows which enterprise apps the user has been granted access to and with which roles. Each entry has appRoleId, resourceDisplayName, and principalDisplayName."
   },
   {
@@ -551,7 +551,7 @@
     "method": "post",
     "toolName": "dismiss-risky-users",
     "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
-    "riskLevel": "medium",
+    "riskLevel": "high",
     "llmTip": "Dismisses risk for one or more users. Body: {\"userIds\": [\"user-id-1\", \"user-id-2\"]}. Sets riskState to dismissed. Use after investigating a risk detection and determining it is a false positive or has been remediated."
   },
   {


### PR DESCRIPTION
## Summary
- Revue de securite des 199 endpoints restaures
- 2 corrections trouvees

## Corrections

| Issue | Description |
|-------|-------------|
| **Risk level** | `dismiss-risky-users` eleve de `medium` a `high` — supprimer les flags de risque peut masquer une compromission active |
| **Least privilege** | `list-user-app-role-assignments` corrige de `AppRoleAssignment.ReadWrite.All` a `AppRoleAssignment.Read.All` — un GET n'a pas besoin de write |

## Audit complet (aucun autre probleme)
- 199 endpoints, 10 write, tous avec riskLevel
- Pas de toolNames dupliques
- Tous les endpoints ont des appPermissions
- Pas de GET avec contentType
- Pas d'endpoints de telechargement non securises
- Tous les endpoints ont un llmTip
- Les 8 endpoints skipEncoding sont proteges par la validation SEC-A (PR #20)

## Test plan
- [ ] `npm run verify` passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)