### PR TITLE
feat: add 5 new endpoint categories (306→369 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ node dist/index.js --preset security,audit,identity
 node dist/index.js --verify-login
 ```
 
-## Available tools (306)
+## Available tools (369)
 
 ### Security (8)
 
@@ -338,12 +338,15 @@ node dist/index.js --verify-login
 | `list-message-traces` | GET    |
 | `get-message-trace`   | GET    |
 
-### Exchange mailboxes (2)
+### Exchange mailboxes (5)
 
-| Tool                      | Method |
-| ------------------------- | ------ |
-| `list-exchange-mailboxes` | GET    |
-| `get-exchange-mailbox`    | GET    |
+| Tool                            | Method | Risk   |
+| ------------------------------- | ------ | ------ |
+| `list-exchange-mailboxes`       | GET    |        |
+| `get-exchange-mailbox`          | GET    |        |
+| `list-exchange-mailbox-folders` | GET    |        |
+| `get-exchange-mailbox-folder`   | GET    |        |
+| `export-exchange-mailbox-items` | POST   | medium |
 
 ### Threat intelligence - hosts (4)
 
@@ -527,11 +530,21 @@ node dist/index.js --verify-login
 | ----------------------- | ------ | ---- |
 | `list-ediscovery-cases` | GET    |      |
 
-### Teams call records (1)
+### Teams call records (11)
 
-| Tool                | Method | Risk |
-| ------------------- | ------ | ---- |
-| `list-call-records` | GET    |      |
+| Tool                            | Method |
+| ------------------------------- | ------ |
+| `list-call-records`             | GET    |
+| `get-call-record`               | GET    |
+| `list-call-record-sessions`     | GET    |
+| `get-call-record-session`       | GET    |
+| `list-call-session-segments`    | GET    |
+| `get-call-session-segment`      | GET    |
+| `list-call-record-participants` | GET    |
+| `get-call-record-participant`   | GET    |
+| `get-call-record-organizer`     | GET    |
+| `get-pstn-calls`                | GET    |
+| `get-direct-routing-calls`      | GET    |
 
 ### Cloud PC / Windows 365 (7)
 
@@ -556,18 +569,38 @@ node dist/index.js --verify-login
 | `list-print-operations`       | GET    |      |
 | `list-print-task-definitions` | GET    |      |
 
-### Information Protection (2)
+### Information Protection & Sensitivity Labels (7)
 
-| Tool                              | Method | Risk |
-| --------------------------------- | ------ | ---- |
-| `list-bitlocker-recovery-keys`    | GET    |      |
-| `list-threat-assessment-requests` | GET    |      |
+| Tool                              | Method |
+| --------------------------------- | ------ |
+| `list-bitlocker-recovery-keys`    | GET    |
+| `list-threat-assessment-requests` | GET    |
+| `list-sensitivity-labels`         | GET    |
+| `get-sensitivity-label`           | GET    |
+| `list-sensitivity-sublabels`      | GET    |
+| `get-sensitivity-label-rights`    | GET    |
+| `get-protection-scopes`           | GET    |
 
-### SharePoint admin (1)
+### SharePoint administration (16)
 
-| Tool                      | Method | Risk |
-| ------------------------- | ------ | ---- |
-| `get-sharepoint-settings` | GET    |      |
+| Tool                      | Method | Risk   |
+| ------------------------- | ------ | ------ |
+| `get-sharepoint-settings` | GET    |        |
+| `list-sharepoint-sites`   | GET    |        |
+| `get-sharepoint-site`     | GET    |        |
+| `update-sharepoint-site`  | PATCH  | medium |
+| `list-site-drives`        | GET    |        |
+| `get-site-default-drive`  | GET    |        |
+| `list-site-lists`         | GET    |        |
+| `get-site-list`           | GET    |        |
+| `list-site-list-items`    | GET    |        |
+| `list-site-list-columns`  | GET    |        |
+| `list-site-columns`       | GET    |        |
+| `list-site-content-types` | GET    |        |
+| `list-site-permissions`   | GET    |        |
+| `get-site-permission`     | GET    |        |
+| `get-site-analytics`      | GET    |        |
+| `list-site-subsites`      | GET    |        |
 
 ### Records Management (6)
 
@@ -579,6 +612,41 @@ node dist/index.js --verify-login
 | `list-file-plan-citations`   | GET    |      |
 | `list-file-plan-departments` | GET    |      |
 | `list-file-plan-references`  | GET    |      |
+
+### Teams administration (30)
+
+| Tool                             | Method | Risk     |
+| -------------------------------- | ------ | -------- |
+| `list-teams`                     | GET    |          |
+| `create-team`                    | POST   | medium   |
+| `get-team`                       | GET    |          |
+| `update-team`                    | PATCH  | medium   |
+| `delete-team`                    | DELETE | critical |
+| `list-team-admin-channels`       | GET    |          |
+| `create-team-admin-channel`      | POST   | low      |
+| `get-team-admin-channel`         | GET    |          |
+| `delete-team-admin-channel`      | DELETE | high     |
+| `list-team-admin-members`        | GET    |          |
+| `add-team-admin-members`         | POST   | medium   |
+| `remove-team-admin-members`      | POST   | medium   |
+| `get-team-admin-member`          | GET    |          |
+| `list-team-installed-apps`       | GET    |          |
+| `archive-team`                   | POST   | medium   |
+| `unarchive-team`                 | POST   | low      |
+| `clone-team`                     | POST   | medium   |
+| `list-team-operations`           | GET    |          |
+| `list-team-permission-grants`    | GET    |          |
+| `get-teams-app-settings`         | GET    |          |
+| `update-teams-app-settings`      | PATCH  | high     |
+| `list-deleted-teams`             | GET    |          |
+| `list-teams-catalog-apps`        | GET    |          |
+| `get-teams-catalog-app`          | GET    |          |
+| `list-teams-app-definitions`     | GET    |          |
+| `get-teams-admin-settings`       | GET    |          |
+| `list-teams-user-configurations` | GET    |          |
+| `get-teams-admin-policy`         | GET    |          |
+| `list-teams-policy-assignments`  | GET    |          |
+| `list-teams-phone-assignments`   | GET    |          |
 
 ### Intune reports (18) -- requires `--allow-writes` (POST endpoints)
 
@@ -751,13 +819,22 @@ node dist/index.js --verify-login
 AccessReview.Read.All
 AdministrativeUnit.Read.All
 Agreement.Read.All
+APIConnectors.Read.All
+AppCatalog.Read.All
 Application.Read.All
 AppRoleAssignment.Read.All
 AttackSimulation.Read.All
 AuditLog.Read.All
+BitlockerKey.Read.All
+CallRecords.Read.All
+Channel.ReadBasic.All
+CloudPC.Read.All
 ConsentRequest.Read.All
+CopilotSettings-Internal.ReadWrite.All
 CustomAuthenticationExtension.Read.All
+CustomSecAttributeDefinition.Read.All
 Device.Read.All
+DeviceLocalCredential.Read.All
 DeviceManagementApps.Read.All
 DeviceManagementConfiguration.Read.All
 DeviceManagementManagedDevices.Read.All
@@ -765,62 +842,71 @@ DeviceManagementRBAC.Read.All
 DeviceManagementServiceConfig.Read.All
 Directory.Read.All
 Domain.Read.All
+eDiscovery.Read.All
 EntitlementManagement.Read.All
 Exchange.ManageAsApp
 Group.Read.All
 GroupMember.Read.All
-APIConnectors.Read.All
 IdentityProvider.Read.All
 IdentityRiskEvent.Read.All
-IdentityUserFlow.Read.All
 IdentityRiskyServicePrincipal.Read.All
 IdentityRiskyUser.Read.All
+IdentityUserFlow.Read.All
+InformationProtectionPolicy.Read.All
 LifecycleWorkflows.Read.All
+MailboxSettings.Read
+OnPremDirectorySynchronization.Read.All
 Organization.Read.All
 Policy.Read.All
-MailboxSettings.Read
+Printer.Read.All
+PrintConnector.Read.All
+PrintJob.Read.All
 PrivilegedAccess.Read.AzureADGroup
+RecordsManagement.Read.All
 Reports.Read.All
 RoleAssignmentSchedule.Read.Directory
 RoleEligibilitySchedule.Read.Directory
 RoleManagement.Read.Directory
-BitlockerKey.Read.All
-CallRecords.Read.All
-CloudPC.Read.All
-CopilotSettings-Internal.ReadWrite.All
-CustomSecAttributeDefinition.Read.All
-DeviceLocalCredential.Read.All
-eDiscovery.Read.All
-OnPremDirectorySynchronization.Read.All
-Printer.Read.All
-PrintConnector.Read.All
-PrintJob.Read.All
-RecordsManagement.Read.All
 RoleManagementPolicy.Read.Directory
 SecurityAlert.Read.All
 SecurityEvents.Read.All
 SecurityIdentitiesHealth.Read.All
 SecurityIncident.Read.All
+ServiceHealth.Read.All
+ServiceMessage.Read.All
 SharePointTenantSettings.Read.All
+Sites.Read.All
+Sites.FullControl.All
 SubjectRightsRequest.Read.All
+Team.ReadBasic.All
+TeamMember.Read.All
+TeamsAppInstallation.ReadForTeam.All
+TeamworkAppSettings.Read.All
+TeamworkDevice.Read.All
 ThreatAssessment.Read.All
 ThreatHunting.Read.All
 ThreatIntelligence.Read.All
-ServiceHealth.Read.All
-ServiceMessage.Read.All
 User.Invite.All
 User.Read.All
 UserAuthenticationMethod.Read.All
 ```
 
-### Write (incident response + invitations)
+### Write (incident response, Teams admin, SharePoint, invitations)
 
 ```
+Channel.Create
+Channel.Delete.All
 Device.ReadWrite.All
+Group.ReadWrite.All
 IdentityRiskyServicePrincipal.ReadWrite.All
 IdentityRiskyUser.ReadWrite.All
 SecurityAlert.ReadWrite.All
 SecurityIncident.ReadWrite.All
+Sites.ReadWrite.All
+Team.Create
+Team.ReadWrite.All
+TeamMember.ReadWrite.All
+TeamworkAppSettings.ReadWrite.All
 User.ReadWrite.All
 UserAuthenticationMethod.ReadWrite.All
 ```

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2255,5 +2255,466 @@
     "toolName": "list-on-premises-sync",
     "appPermissions": ["OnPremDirectorySynchronization.Read.All"],
     "llmTip": "Lists on-premises directory synchronization (Entra Connect) configurations. Returns features enabled (passwordHashSync, passwordWriteback, seamlessSSO, cloudSync), configuration details, and sync status."
+  },
+
+  {
+    "pathPattern": "/teams",
+    "method": "get",
+    "toolName": "list-teams",
+    "appPermissions": ["Team.ReadBasic.All"],
+    "llmTip": "Lists all teams in the tenant. Use $filter=displayName eq 'name' to find specific teams. Use $select=id,displayName,description to limit fields. Returns id, displayName, description, visibility, isArchived."
+  },
+  {
+    "pathPattern": "/teams",
+    "method": "post",
+    "toolName": "create-team",
+    "appPermissions": ["Team.Create"],
+    "riskLevel": "medium",
+    "llmTip": "Creates a new team. Body requires template@odata.bind, displayName, description. Example: {\"template@odata.bind\":\"https://graph.microsoft.com/v1.0/teamsTemplates('standard')\",\"displayName\":\"My Team\",\"description\":\"desc\"}."
+  },
+  {
+    "pathPattern": "/teams/{team-id}",
+    "method": "get",
+    "toolName": "get-team",
+    "appPermissions": ["Team.ReadBasic.All"],
+    "llmTip": "Gets a specific team by ID. Returns displayName, description, visibility (public/private), isArchived, memberSettings, guestSettings, messagingSettings, funSettings, discoverySettings."
+  },
+  {
+    "pathPattern": "/teams/{team-id}",
+    "method": "patch",
+    "toolName": "update-team",
+    "appPermissions": ["Team.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates a team's settings. Body can include displayName, description, visibility, memberSettings, guestSettings, messagingSettings, funSettings."
+  },
+  {
+    "pathPattern": "/teams/{team-id}",
+    "method": "delete",
+    "toolName": "delete-team",
+    "appPermissions": ["Group.ReadWrite.All"],
+    "riskLevel": "critical",
+    "llmTip": "Deletes a team and its associated group. This is irreversible. The team and all its content (channels, messages, files) will be permanently deleted."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/channels",
+    "method": "get",
+    "toolName": "list-team-admin-channels",
+    "appPermissions": ["Channel.ReadBasic.All"],
+    "llmTip": "Lists channels in a team. Returns id, displayName, description, membershipType (standard/private/shared), createdDateTime, email, webUrl."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/channels",
+    "method": "post",
+    "toolName": "create-team-admin-channel",
+    "appPermissions": ["Channel.Create"],
+    "riskLevel": "low",
+    "llmTip": "Creates a new channel in a team. Body requires displayName. Optional: description, membershipType (standard/private/shared)."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/channels/{channel-id}",
+    "method": "get",
+    "toolName": "get-team-admin-channel",
+    "appPermissions": ["Channel.ReadBasic.All"],
+    "llmTip": "Gets a specific channel by ID. Returns displayName, description, membershipType, createdDateTime, email, webUrl, tenantId."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/channels/{channel-id}",
+    "method": "delete",
+    "toolName": "delete-team-admin-channel",
+    "appPermissions": ["Channel.Delete.All"],
+    "riskLevel": "high",
+    "llmTip": "Deletes a channel from a team. All messages and files in the channel will be deleted."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/members",
+    "method": "get",
+    "toolName": "list-team-admin-members",
+    "appPermissions": ["TeamMember.Read.All"],
+    "llmTip": "Lists members of a team. Returns each member's id, displayName, roles (owner/member/guest), userId, email."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/members/add",
+    "method": "post",
+    "toolName": "add-team-admin-members",
+    "appPermissions": ["TeamMember.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Adds members to a team in bulk. Body: {\"values\":[{\"@odata.type\":\"microsoft.graph.aadUserConversationMember\",\"roles\":[],\"user@odata.bind\":\"https://graph.microsoft.com/v1.0/users('userId')\"}]}."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/members/remove",
+    "method": "post",
+    "toolName": "remove-team-admin-members",
+    "appPermissions": ["TeamMember.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Removes members from a team in bulk. Body: {\"values\":[{\"id\":\"conversationMemberId\"}]}."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/members/{conversationMember-id}",
+    "method": "get",
+    "toolName": "get-team-admin-member",
+    "appPermissions": ["TeamMember.Read.All"],
+    "llmTip": "Gets a specific member of a team. Returns displayName, roles, userId, email, visibleHistoryStartDateTime."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/installedApps",
+    "method": "get",
+    "toolName": "list-team-installed-apps",
+    "appPermissions": ["TeamsAppInstallation.ReadForTeam.All"],
+    "llmTip": "Lists apps installed in a team. Use $expand=teamsAppDefinition to get app details. Returns teamsApp, teamsAppDefinition with displayName, version, description."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/archive",
+    "method": "post",
+    "toolName": "archive-team",
+    "appPermissions": ["Team.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Archives a team. Archived teams become read-only. Optional body: {\"shouldSetSpoSiteReadOnlyForMembers\": true} to also make the SharePoint site read-only."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/unarchive",
+    "method": "post",
+    "toolName": "unarchive-team",
+    "appPermissions": ["Team.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Unarchives a team, restoring it to active state and allowing users to send messages and edit the team again."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/clone",
+    "method": "post",
+    "toolName": "clone-team",
+    "appPermissions": ["Team.Create"],
+    "riskLevel": "medium",
+    "llmTip": "Clones a team. Body requires displayName, description, mailNickname, partsToClone (apps,tabs,settings,channels,members). classification and visibility are optional."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/operations",
+    "method": "get",
+    "toolName": "list-team-operations",
+    "appPermissions": ["Team.ReadBasic.All"],
+    "llmTip": "Lists async operations on a team (archive, clone, etc.). Returns operationType, status (notStarted/running/succeeded/failed), createdDateTime, lastActionDateTime, error."
+  },
+  {
+    "pathPattern": "/teams/{team-id}/permissionGrants",
+    "method": "get",
+    "toolName": "list-team-permission-grants",
+    "appPermissions": ["TeamsAppInstallation.ReadForTeam.All"],
+    "llmTip": "Lists resource-specific permission grants on a team. Shows which apps have been granted specific permissions (e.g., ChannelMessage.Read.Group)."
+  },
+  {
+    "pathPattern": "/teamwork/teamsAppSettings",
+    "method": "get",
+    "toolName": "get-teams-app-settings",
+    "appPermissions": ["TeamworkAppSettings.Read.All"],
+    "llmTip": "Gets tenant-wide Teams app settings. Returns allowUserRequestsForAppAccess (whether users can request admin approval for apps) and isUserPersonalScopeResourceSpecificConsentEnabled."
+  },
+  {
+    "pathPattern": "/teamwork/teamsAppSettings",
+    "method": "patch",
+    "toolName": "update-teams-app-settings",
+    "appPermissions": ["TeamworkAppSettings.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Updates tenant-wide Teams app settings. Body can include allowUserRequestsForAppAccess and isUserPersonalScopeResourceSpecificConsentEnabled."
+  },
+  {
+    "pathPattern": "/teamwork/deletedTeams",
+    "method": "get",
+    "toolName": "list-deleted-teams",
+    "appPermissions": ["Team.ReadBasic.All"],
+    "llmTip": "Lists recently deleted teams. Returns id and displayName. Deleted teams can be restored within 30 days."
+  },
+  {
+    "pathPattern": "/appCatalogs/teamsApps",
+    "method": "get",
+    "toolName": "list-teams-catalog-apps",
+    "appPermissions": ["AppCatalog.Read.All"],
+    "llmTip": "Lists apps in the Teams app catalog (tenant and store). Use $filter=distributionMethod eq 'organization' for tenant-only apps. Returns id, displayName, externalId, distributionMethod."
+  },
+  {
+    "pathPattern": "/appCatalogs/teamsApps/{teamsApp-id}",
+    "method": "get",
+    "toolName": "get-teams-catalog-app",
+    "appPermissions": ["AppCatalog.Read.All"],
+    "llmTip": "Gets a specific app from the Teams app catalog. Use $expand=appDefinitions to get version details."
+  },
+  {
+    "pathPattern": "/appCatalogs/teamsApps/{teamsApp-id}/appDefinitions",
+    "method": "get",
+    "toolName": "list-teams-app-definitions",
+    "appPermissions": ["AppCatalog.Read.All"],
+    "llmTip": "Lists all versions (definitions) of a Teams app. Each definition has displayName, description, version, publishingState, shortDescription, teamsAppId."
+  },
+  {
+    "pathPattern": "/admin/teams",
+    "method": "get",
+    "toolName": "get-teams-admin-settings",
+    "appPermissions": ["TeamworkDevice.Read.All"],
+    "llmTip": "Gets Teams admin settings for the tenant."
+  },
+  {
+    "pathPattern": "/admin/teams/userConfigurations",
+    "method": "get",
+    "toolName": "list-teams-user-configurations",
+    "appPermissions": ["TeamworkDevice.Read.All"],
+    "llmTip": "Lists Teams user configurations in the tenant."
+  },
+  {
+    "pathPattern": "/admin/teams/policy",
+    "method": "get",
+    "toolName": "get-teams-admin-policy",
+    "appPermissions": ["TeamworkDevice.Read.All"],
+    "llmTip": "Gets Teams admin policy settings."
+  },
+  {
+    "pathPattern": "/admin/teams/policy/userAssignments",
+    "method": "get",
+    "toolName": "list-teams-policy-assignments",
+    "appPermissions": ["TeamworkDevice.Read.All"],
+    "llmTip": "Lists Teams policy user assignments."
+  },
+  {
+    "pathPattern": "/admin/teams/telephoneNumberManagement/numberAssignments",
+    "method": "get",
+    "toolName": "list-teams-phone-assignments",
+    "appPermissions": ["TeamworkDevice.Read.All"],
+    "llmTip": "Lists telephone number assignments for Teams. Shows which phone numbers are assigned to which users or resources."
+  },
+
+  {
+    "pathPattern": "/sites",
+    "method": "get",
+    "toolName": "list-sharepoint-sites",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists or searches SharePoint sites. Use $search='keyword' to search by site name/URL. Use $filter to filter. Use $select=id,displayName,webUrl to limit fields. Returns id, displayName, webUrl, createdDateTime, lastModifiedDateTime."
+  },
+  {
+    "pathPattern": "/sites/{site-id}",
+    "method": "get",
+    "toolName": "get-sharepoint-site",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Gets a specific SharePoint site by ID. The site-id format is {hostname}:{server-relative-path} or a GUID. Returns displayName, webUrl, root, siteCollection, createdDateTime."
+  },
+  {
+    "pathPattern": "/sites/{site-id}",
+    "method": "patch",
+    "toolName": "update-sharepoint-site",
+    "appPermissions": ["Sites.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates a SharePoint site's properties. Body can include displayName and description."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/drives",
+    "method": "get",
+    "toolName": "list-site-drives",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists document libraries (drives) in a SharePoint site. Returns id, name, driveType, webUrl, quota, owner for each drive."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/drive",
+    "method": "get",
+    "toolName": "get-site-default-drive",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Gets the default document library (drive) for a SharePoint site. Returns id, name, driveType, webUrl, quota."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists",
+    "method": "get",
+    "toolName": "list-site-lists",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists SharePoint lists in a site. Returns id, displayName, list (template, contentTypesEnabled, hidden), createdDateTime, webUrl for each list."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}",
+    "method": "get",
+    "toolName": "get-site-list",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Gets a specific SharePoint list by ID. Returns displayName, list settings, columns, contentTypes, webUrl."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
+    "method": "get",
+    "toolName": "list-site-list-items",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists items in a SharePoint list. Use $expand=fields to get column values. Use $filter on fields/ColumnName for filtering."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}/columns",
+    "method": "get",
+    "toolName": "list-site-list-columns",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists column definitions for a SharePoint list. Returns each column's name, displayName, type (text, number, choice, etc.), description."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/columns",
+    "method": "get",
+    "toolName": "list-site-columns",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists site-level column definitions. Returns each column's name, displayName, type, description."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/contentTypes",
+    "method": "get",
+    "toolName": "list-site-content-types",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists content types defined in a SharePoint site. Returns id, name, description, group, isBuiltIn, parentId."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/permissions",
+    "method": "get",
+    "toolName": "list-site-permissions",
+    "appPermissions": ["Sites.FullControl.All"],
+    "llmTip": "Lists permissions granted on a SharePoint site. Returns each permission's id, roles, grantedToIdentities (application or user)."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
+    "method": "get",
+    "toolName": "get-site-permission",
+    "appPermissions": ["Sites.FullControl.All"],
+    "llmTip": "Gets a specific permission on a SharePoint site by ID. Returns id, roles, grantedToIdentities."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/analytics",
+    "method": "get",
+    "toolName": "get-site-analytics",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Gets analytics for a SharePoint site. Returns allTime and lastSevenDays access counts."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/sites",
+    "method": "get",
+    "toolName": "list-site-subsites",
+    "appPermissions": ["Sites.Read.All"],
+    "llmTip": "Lists subsites of a SharePoint site. Returns displayName, webUrl, createdDateTime for each subsite."
+  },
+
+  {
+    "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels",
+    "method": "get",
+    "toolName": "list-sensitivity-labels",
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "llmTip": "Lists sensitivity labels defined in the tenant. Returns id, name, description, tooltip, color, isActive, priority, parent. Labels are used for data classification and protection."
+  },
+  {
+    "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}",
+    "method": "get",
+    "toolName": "get-sensitivity-label",
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "llmTip": "Gets a specific sensitivity label by ID. Returns name, description, tooltip, color, isActive, priority, parent, contentFormats, autoLabeling settings."
+  },
+  {
+    "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}/sublabels",
+    "method": "get",
+    "toolName": "list-sensitivity-sublabels",
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "llmTip": "Lists sublabels under a parent sensitivity label. Returns id, name, description, tooltip, color, isActive, priority."
+  },
+  {
+    "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}/rights",
+    "method": "get",
+    "toolName": "get-sensitivity-label-rights",
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "llmTip": "Gets the rights associated with a sensitivity label, including encryption settings and usage rights."
+  },
+  {
+    "pathPattern": "/security/dataSecurityAndGovernance/protectionScopes",
+    "method": "get",
+    "toolName": "get-protection-scopes",
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "llmTip": "Gets the data security and governance protection scopes configured for the tenant."
+  },
+
+  {
+    "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/folders",
+    "method": "get",
+    "toolName": "list-exchange-mailbox-folders",
+    "appPermissions": ["Exchange.ManageAsApp"],
+    "llmTip": "Lists mailbox folders for an Exchange mailbox (admin). Returns id, displayName, totalItemCount, unreadItemCount, childFolderCount, parentFolderId."
+  },
+  {
+    "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/folders/{mailboxFolder-id}",
+    "method": "get",
+    "toolName": "get-exchange-mailbox-folder",
+    "appPermissions": ["Exchange.ManageAsApp"],
+    "llmTip": "Gets a specific mailbox folder by ID (admin). Returns displayName, totalItemCount, unreadItemCount, childFolderCount."
+  },
+  {
+    "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/exportItems",
+    "method": "post",
+    "toolName": "export-exchange-mailbox-items",
+    "appPermissions": ["Exchange.ManageAsApp"],
+    "riskLevel": "medium",
+    "llmTip": "Exports items from an Exchange mailbox. Body: {\"itemIds\":[\"itemId1\",\"itemId2\"]}. Returns exportedItems with data (base64)."
+  },
+
+  {
+    "pathPattern": "/communications/callRecords/{callRecord-id}",
+    "method": "get",
+    "toolName": "get-call-record",
+    "appPermissions": ["CallRecords.Read.All"],
+    "llmTip": "Gets a specific call record by ID. Returns type (groupCall/peerToPeer), modalities (audio/video/screenSharing), startDateTime, endDateTime, organizer, participants, version."
+  },
+  {
+    "pathPattern": "/communications/callRecords/{callRecord-id}/sessions",
+    "method": "get",
+    "toolName": "list-call-record-sessions",
+    "appPermissions": ["CallRecords.Read.All"],
+    "llmTip": "Lists sessions within a call record. Each session represents a participant's connection. Returns caller, callee, startDateTime, endDateTime, modalities, failureInfo."
+  },
+  {
+    "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}",
+    "method": "get",
+    "toolName": "get-call-record-session",
+    "appPermissions": ["CallRecords.Read.All"],
+    "llmTip": "Gets a specific session within a call record. Returns detailed caller/callee info, modalities, startDateTime, endDateTime, failureInfo, isTest."
+  },
+  {
+    "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}/segments",
+    "method": "get",
+    "toolName": "list-call-session-segments",
+    "appPermissions": ["CallRecords.Read.All"],
+    "llmTip": "Lists segments within a call session. Each segment has media streams with detailed quality metrics: jitter, packetLoss, roundTripTime, averageAudioDegradation, etc."
+  },
+  {
+    "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}/segments/{segment-id}",
+    "method": "get",
+    "toolName": "get-call-session-segment",
+    "appPermissions": ["CallRecords.Read.All"],
+    "llmTip": "Gets a specific segment of a call session. Returns detailed media stream quality metrics including jitter, packetLoss, roundTripTime for audio/video/screenSharing."
+  },
+  {
+    "pathPattern": "/communications/callRecords/{callRecord-id}/participants_v2",
+    "method": "get",
+    "toolName": "list-call-record-participants",
+    "appPermissions": ["CallRecords.Read.All"],
+    "llmTip": "Lists participants in a call record (v2 API). Returns each participant's identity (user, phone, application), and participant details."
+  },
+  {
+    "pathPattern": "/communications/callRecords/{callRecord-id}/participants_v2/{participant-id}",
+    "method": "get",
+    "toolName": "get-call-record-participant",
+    "appPermissions": ["CallRecords.Read.All"],
+    "llmTip": "Gets a specific participant in a call record (v2 API). Returns participant identity and details."
+  },
+  {
+    "pathPattern": "/communications/callRecords/{callRecord-id}/organizer_v2",
+    "method": "get",
+    "toolName": "get-call-record-organizer",
+    "appPermissions": ["CallRecords.Read.All"],
+    "llmTip": "Gets the organizer of a call record (v2 API). Returns the organizer's identity (user or application)."
+  },
+  {
+    "pathPattern": "/communications/callRecords/microsoft.graph.callRecords.getPstnCalls(fromDateTime={fromDateTime},toDateTime={toDateTime})",
+    "method": "get",
+    "toolName": "get-pstn-calls",
+    "appPermissions": ["CallRecords.Read.All"],
+    "skipEncoding": ["fromDateTime", "toDateTime"],
+    "llmTip": "Gets PSTN (Public Switched Telephone Network) call records for a date range. Parameters are ISO 8601 dates. Returns callId, userId, userPrincipalName, callerNumber, calleeNumber, duration, charge, callType, currency."
+  },
+  {
+    "pathPattern": "/communications/callRecords/microsoft.graph.callRecords.getDirectRoutingCalls(fromDateTime={fromDateTime},toDateTime={toDateTime})",
+    "method": "get",
+    "toolName": "get-direct-routing-calls",
+    "appPermissions": ["CallRecords.Read.All"],
+    "skipEncoding": ["fromDateTime", "toDateTime"],
+    "llmTip": "Gets Direct Routing call records for a date range. Parameters are ISO 8601 dates. Returns callId, correlationId, userId, callerNumber, calleeNumber, duration, startDateTime, failureDateTime, finalSipCode, mediaPathLocation."
   }
 ]

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -43,8 +43,8 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   },
   exchange: {
     name: 'exchange',
-    pattern: /message-trace|exchange-mailbox|mailbox-usage/i,
-    description: 'Exchange administration (message traces, mailboxes)',
+    pattern: /message-trace|exchange-mailbox|mailbox-usage|mailbox-folder|export-exchange/i,
+    description: 'Exchange administration (message traces, mailboxes, folders, export)',
   },
   intune: {
     name: 'intune',
@@ -80,8 +80,9 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   },
   callrecords: {
     name: 'callrecords',
-    pattern: /call-record/i,
-    description: 'Teams call records',
+    pattern: /call-record|call-session|pstn-call|direct-routing/i,
+    description:
+      'Teams call records (sessions, segments, participants, PSTN calls, Direct Routing)',
   },
   print: {
     name: 'print',
@@ -91,19 +92,30 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   },
   infoprotection: {
     name: 'infoprotection',
-    pattern: /bitlocker|threat-assessment|recovery-key/i,
-    description: 'Information Protection (BitLocker recovery keys, threat assessment requests)',
+    pattern:
+      /bitlocker|threat-assessment|recovery-key|sensitivity-label|sensitivity-sublabel|protection-scope/i,
+    description:
+      'Information Protection (BitLocker recovery keys, threat assessment requests, sensitivity labels)',
   },
   sharepointadmin: {
     name: 'sharepointadmin',
-    pattern: /sharepoint-setting/i,
-    description: 'SharePoint tenant administration settings',
+    pattern:
+      /sharepoint-setting|sharepoint-site|site-drive|site-list|site-column|site-content-type|site-permission|site-analytic|site-subsite/i,
+    description:
+      'SharePoint administration (tenant settings, sites, drives, lists, columns, content types, permissions, analytics)',
   },
   retention: {
     name: 'retention',
     pattern: /retention-label|file-plan/i,
     description:
       'Records Management (retention labels, file plan authorities, categories, citations, departments, references)',
+  },
+  teamsadmin: {
+    name: 'teamsadmin',
+    pattern:
+      /list-teams$|get-team$|create-team$|update-team$|delete-team$|team-admin|team-installed|archive-team|unarchive-team|clone-team|team-operation|team-permission|teams-app|teams-catalog|deleted-team|teams-user-config|teams-admin|teams-policy|teams-phone/i,
+    description:
+      'Teams administration (teams, channels, members, apps, archive/clone, policies, phone assignments)',
   },
   all: {
     name: 'all',


### PR DESCRIPTION
## Summary
- Add **63 new endpoints** across 5 categories, bringing total from 306 to 369 tools
- **Teams administration (30)**: teams CRUD, channels, members, apps, archive/clone, policies, phone number assignments, deleted teams, app catalog
- **SharePoint sites (15)**: site search/get/update, drives, lists, list items, columns, content types, permissions, analytics, subsites
- **Sensitivity labels (5)**: list/get labels, sublabels, rights, protection scopes (Purview Information Protection)
- **Exchange advanced (3)**: mailbox folders, folder details, mailbox item export
- **Call records detailed (10)**: sessions, segments, participants, organizer, PSTN calls, Direct Routing calls
- New `teamsadmin` preset category in tool-categories.ts
- Expanded patterns for `sharepointadmin`, `callrecords`, `exchange`, `infoprotection` presets
- Updated README with all new sections and permissions

## New permissions required
**Read-only**: `AppCatalog.Read.All`, `Channel.ReadBasic.All`, `InformationProtectionPolicy.Read.All`, `Sites.Read.All`, `Sites.FullControl.All`, `Team.ReadBasic.All`, `TeamMember.Read.All`, `TeamsAppInstallation.ReadForTeam.All`, `TeamworkAppSettings.Read.All`, `TeamworkDevice.Read.All`

**Write**: `Channel.Create`, `Channel.Delete.All`, `Group.ReadWrite.All`, `Sites.ReadWrite.All`, `Team.Create`, `Team.ReadWrite.All`, `TeamMember.ReadWrite.All`, `TeamworkAppSettings.ReadWrite.All`

## Test plan
- [x] `npm run generate` — OpenAPI client generation succeeds
- [x] `npm run build` — TypeScript compilation passes
- [x] `npm test` — 3/3 tests pass (including endpoint validation)
- [x] `npm run lint` — 0 errors (1 pre-existing warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)