### PR TITLE
feat: add admin write operations (369→444 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,18 +176,18 @@ node dist/index.js --verify-login
 
 ### Users (10)
 
-| Tool                       | Method | Risk     |
-| -------------------------- | ------ | -------- |
-| `list-users`               | GET    |          |
-| `get-user`                 | GET    |          |
-| `list-user-memberships`    | GET    |          |
-| `list-user-auth-methods`   | GET    |          |
-| `list-user-devices`        | GET    |          |
-| `create-user`              | POST   | high     |
-| `update-user`              | PATCH  | medium   |
-| `delete-user`              | DELETE | critical |
-| `assign-user-license`      | POST   | medium   |
-| `reprocess-user-license`   | POST   | low      |
+| Tool                     | Method | Risk     |
+| ------------------------ | ------ | -------- |
+| `list-users`             | GET    |          |
+| `get-user`               | GET    |          |
+| `list-user-memberships`  | GET    |          |
+| `list-user-auth-methods` | GET    |          |
+| `list-user-devices`      | GET    |          |
+| `create-user`            | POST   | high     |
+| `update-user`            | PATCH  | medium   |
+| `delete-user`            | DELETE | critical |
+| `assign-user-license`    | POST   | medium   |
+| `reprocess-user-license` | POST   | low      |
 
 ### Devices (2)
 
@@ -312,21 +312,21 @@ node dist/index.js --verify-login
 
 ### Security & access policies (13)
 
-| Tool                             | Method | Risk   |
-| -------------------------------- | ------ | ------ |
-| `get-auth-methods-policy`        | GET    |        |
-| `list-auth-method-configs`       | GET    |        |
-| `get-auth-method-config`         | GET    |        |
-| `get-security-defaults`          | GET    |        |
-| `get-admin-consent-policy`       | GET    |        |
-| `list-auth-strength-policies`    | GET    |        |
-| `get-auth-strength-policy`       | GET    |        |
-| `create-auth-strength-policy`    | POST   | high   |
-| `update-auth-strength-policy`    | PATCH  | high   |
-| `delete-auth-strength-policy`    | DELETE | high   |
-| `get-cross-tenant-access-policy` | GET    |        |
-| `list-cross-tenant-partners`     | GET    |        |
-| `change-user-password`           | POST   | high   |
+| Tool                             | Method | Risk |
+| -------------------------------- | ------ | ---- |
+| `get-auth-methods-policy`        | GET    |      |
+| `list-auth-method-configs`       | GET    |      |
+| `get-auth-method-config`         | GET    |      |
+| `get-security-defaults`          | GET    |      |
+| `get-admin-consent-policy`       | GET    |      |
+| `list-auth-strength-policies`    | GET    |      |
+| `get-auth-strength-policy`       | GET    |      |
+| `create-auth-strength-policy`    | POST   | high |
+| `update-auth-strength-policy`    | PATCH  | high |
+| `delete-auth-strength-policy`    | DELETE | high |
+| `get-cross-tenant-access-policy` | GET    |      |
+| `list-cross-tenant-partners`     | GET    |      |
+| `change-user-password`           | POST   | high |
 
 ### Guest user invitations (2)
 
@@ -444,18 +444,18 @@ node dist/index.js --verify-login
 
 ### Enrollment & Autopilot (10)
 
-| Tool                               | Method | Risk   |
-| ---------------------------------- | ------ | ------ |
-| `list-enrollment-configurations`   | GET    |        |
-| `get-enrollment-configuration`     | GET    |        |
-| `list-autopilot-devices`           | GET    |        |
-| `get-autopilot-device`             | GET    |        |
-| `create-enrollment-configuration`  | POST   | medium |
-| `update-enrollment-configuration`  | PATCH  | medium |
-| `delete-enrollment-configuration`  | DELETE | high   |
-| `update-autopilot-device`          | PATCH  | medium |
-| `delete-autopilot-device`          | DELETE | high   |
-| `import-autopilot-device`          | POST   | medium |
+| Tool                              | Method | Risk   |
+| --------------------------------- | ------ | ------ |
+| `list-enrollment-configurations`  | GET    |        |
+| `get-enrollment-configuration`    | GET    |        |
+| `list-autopilot-devices`          | GET    |        |
+| `get-autopilot-device`            | GET    |        |
+| `create-enrollment-configuration` | POST   | medium |
+| `update-enrollment-configuration` | PATCH  | medium |
+| `delete-enrollment-configuration` | DELETE | high   |
+| `update-autopilot-device`         | PATCH  | medium |
+| `delete-autopilot-device`         | DELETE | high   |
+| `import-autopilot-device`         | POST   | medium |
 
 ### Detected apps (3)
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ node dist/index.js --preset security,audit,identity
 node dist/index.js --verify-login
 ```
 
-## Available tools (369)
+## Available tools (410)
 
 ### Security (8)
 
@@ -338,15 +338,17 @@ node dist/index.js --verify-login
 | `list-message-traces` | GET    |
 | `get-message-trace`   | GET    |
 
-### Exchange mailboxes (5)
+### Exchange mailboxes (7)
 
-| Tool                            | Method | Risk   |
-| ------------------------------- | ------ | ------ |
-| `list-exchange-mailboxes`       | GET    |        |
-| `get-exchange-mailbox`          | GET    |        |
-| `list-exchange-mailbox-folders` | GET    |        |
-| `get-exchange-mailbox-folder`   | GET    |        |
-| `export-exchange-mailbox-items` | POST   | medium |
+| Tool                            | Method | Risk     |
+| ------------------------------- | ------ | -------- |
+| `list-exchange-mailboxes`       | GET    |          |
+| `get-exchange-mailbox`          | GET    |          |
+| `list-exchange-mailbox-folders` | GET    |          |
+| `get-exchange-mailbox-folder`   | GET    |          |
+| `export-exchange-mailbox-items` | POST   | medium   |
+| `update-exchange-mailbox`       | PATCH  | medium   |
+| `delete-exchange-mailbox`       | DELETE | critical |
 
 ### Threat intelligence - hosts (4)
 
@@ -524,6 +526,51 @@ node dist/index.js --verify-login
 | `confirm-safe-users`                     | POST   | high     |
 | `run-hunting-query`                      | POST   | low      |
 
+### Intune device remote actions (16) -- requires `--allow-writes`
+
+| Tool                            | Method | Risk     |
+| ------------------------------- | ------ | -------- |
+| `wipe-managed-device`           | POST   | critical |
+| `retire-managed-device`         | POST   | high     |
+| `sync-managed-device`           | POST   | low      |
+| `reboot-managed-device`         | POST   | high     |
+| `remote-lock-device`            | POST   | medium   |
+| `reset-device-passcode`         | POST   | high     |
+| `shutdown-managed-device`       | POST   | high     |
+| `disable-lost-mode`             | POST   | low      |
+| `locate-managed-device`         | POST   | low      |
+| `bypass-activation-lock`        | POST   | high     |
+| `trigger-defender-scan`         | POST   | low      |
+| `update-defender-signatures`    | POST   | low      |
+| `clean-windows-device`          | POST   | critical |
+| `logout-shared-apple-user`      | POST   | medium   |
+| `delete-shared-apple-user`      | POST   | high     |
+| `update-windows-device-account` | POST   | medium   |
+
+### Conditional Access CRUD (8) -- requires `--allow-writes`
+
+| Tool                                | Method | Risk     |
+| ----------------------------------- | ------ | -------- |
+| `list-conditional-access-templates` | GET    |          |
+| `get-conditional-access-policy`     | GET    |          |
+| `create-conditional-access-policy`  | POST   | high     |
+| `update-conditional-access-policy`  | PATCH  | high     |
+| `delete-conditional-access-policy`  | DELETE | critical |
+| `create-named-location`             | POST   | medium   |
+| `update-named-location`             | PATCH  | medium   |
+| `delete-named-location`             | DELETE | high     |
+
+### Intune policies CRUD (6) -- requires `--allow-writes`
+
+| Tool                          | Method | Risk   |
+| ----------------------------- | ------ | ------ |
+| `create-compliance-policy`    | POST   | medium |
+| `update-compliance-policy`    | PATCH  | medium |
+| `delete-compliance-policy`    | DELETE | high   |
+| `create-device-configuration` | POST   | medium |
+| `update-device-configuration` | PATCH  | medium |
+| `delete-device-configuration` | DELETE | high   |
+
 ### eDiscovery (1)
 
 | Tool                    | Method | Risk |
@@ -581,7 +628,7 @@ node dist/index.js --verify-login
 | `get-sensitivity-label-rights`    | GET    |
 | `get-protection-scopes`           | GET    |
 
-### SharePoint administration (16)
+### SharePoint administration (25)
 
 | Tool                      | Method | Risk   |
 | ------------------------- | ------ | ------ |
@@ -593,12 +640,21 @@ node dist/index.js --verify-login
 | `get-site-default-drive`  | GET    |        |
 | `list-site-lists`         | GET    |        |
 | `get-site-list`           | GET    |        |
+| `create-site-list`        | POST   | low    |
+| `update-site-list`        | PATCH  | low    |
+| `delete-site-list`        | DELETE | high   |
 | `list-site-list-items`    | GET    |        |
+| `create-site-list-item`   | POST   | low    |
+| `update-site-list-item`   | PATCH  | low    |
+| `delete-site-list-item`   | DELETE | medium |
 | `list-site-list-columns`  | GET    |        |
 | `list-site-columns`       | GET    |        |
 | `list-site-content-types` | GET    |        |
 | `list-site-permissions`   | GET    |        |
 | `get-site-permission`     | GET    |        |
+| `create-site-permission`  | POST   | medium |
+| `update-site-permission`  | PATCH  | medium |
+| `delete-site-permission`  | DELETE | high   |
 | `get-site-analytics`      | GET    |        |
 | `list-site-subsites`      | GET    |        |
 
@@ -891,15 +947,18 @@ User.Read.All
 UserAuthenticationMethod.Read.All
 ```
 
-### Write (incident response, Teams admin, SharePoint, invitations)
+### Write (incident response, device actions, CA policies, Teams, SharePoint)
 
 ```
 Channel.Create
 Channel.Delete.All
 Device.ReadWrite.All
+DeviceManagementConfiguration.ReadWrite.All
+DeviceManagementManagedDevices.PrivilegedOperations.All
 Group.ReadWrite.All
 IdentityRiskyServicePrincipal.ReadWrite.All
 IdentityRiskyUser.ReadWrite.All
+Policy.ReadWrite.ConditionalAccess
 SecurityAlert.ReadWrite.All
 SecurityIncident.ReadWrite.All
 Sites.ReadWrite.All

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 
 ## Features
 
-- **306 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
+- **447 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -125,9 +125,9 @@ node dist/index.js --preset security,audit,identity
 node dist/index.js --verify-login
 ```
 
-## Available tools (410)
+## Available tools (447)
 
-### Security (8)
+### Security (11)
 
 | Tool                       | Method | Risk   |
 | -------------------------- | ------ | ------ |
@@ -139,6 +139,9 @@ node dist/index.js --verify-login
 | `update-security-incident` | PATCH  | medium |
 | `list-attack-simulations`  | GET    |        |
 | `get-attack-simulation`    | GET    |        |
+| `create-attack-simulation` | POST   | high   |
+| `update-attack-simulation` | PATCH  | medium |
+| `delete-attack-simulation` | DELETE | medium |
 
 ### Audit logs & deleted items (5)
 
@@ -171,15 +174,20 @@ node dist/index.js --verify-login
 | `get-mailbox-usage-report`      | GET    |
 | `get-m365-apps-usage-report`    | GET    |
 
-### Users (5)
+### Users (10)
 
-| Tool                     | Method |
-| ------------------------ | ------ |
-| `list-users`             | GET    |
-| `get-user`               | GET    |
-| `list-user-memberships`  | GET    |
-| `list-user-auth-methods` | GET    |
-| `list-user-devices`      | GET    |
+| Tool                       | Method | Risk     |
+| -------------------------- | ------ | -------- |
+| `list-users`               | GET    |          |
+| `get-user`                 | GET    |          |
+| `list-user-memberships`    | GET    |          |
+| `list-user-auth-methods`   | GET    |          |
+| `list-user-devices`        | GET    |          |
+| `create-user`              | POST   | high     |
+| `update-user`              | PATCH  | medium   |
+| `delete-user`              | DELETE | critical |
+| `assign-user-license`      | POST   | medium   |
+| `reprocess-user-license`   | POST   | low      |
 
 ### Devices (2)
 
@@ -188,33 +196,42 @@ node dist/index.js --verify-login
 | `list-devices` | GET    |
 | `get-device`   | GET    |
 
-### Groups (4)
+### Groups (8)
 
-| Tool                 | Method |
-| -------------------- | ------ |
-| `list-groups`        | GET    |
-| `get-group`          | GET    |
-| `list-group-members` | GET    |
-| `list-group-owners`  | GET    |
+| Tool                 | Method | Risk     |
+| -------------------- | ------ | -------- |
+| `list-groups`        | GET    |          |
+| `get-group`          | GET    |          |
+| `list-group-members` | GET    |          |
+| `list-group-owners`  | GET    |          |
+| `create-group`       | POST   | medium   |
+| `update-group`       | PATCH  | medium   |
+| `delete-group`       | DELETE | critical |
+| `add-group-member`   | POST   | medium   |
 
-### Directory roles & PIM (6)
+### Directory roles & PIM (7)
 
-| Tool                            | Method |
-| ------------------------------- | ------ |
-| `list-directory-roles`          | GET    |
-| `list-role-members`             | GET    |
-| `list-role-assignments`         | GET    |
-| `list-role-definitions`         | GET    |
-| `list-pim-eligible-assignments` | GET    |
-| `list-pim-active-assignments`   | GET    |
+| Tool                            | Method | Risk     |
+| ------------------------------- | ------ | -------- |
+| `list-directory-roles`          | GET    |          |
+| `list-role-members`             | GET    |          |
+| `list-role-assignments`         | GET    |          |
+| `list-role-definitions`         | GET    |          |
+| `list-pim-eligible-assignments` | GET    |          |
+| `list-pim-active-assignments`   | GET    |          |
+| `add-directory-role-member`     | POST   | critical |
 
-### Administrative units (3)
+### Administrative units (7)
 
-| Tool                               | Method |
-| ---------------------------------- | ------ |
-| `list-administrative-units`        | GET    |
-| `get-administrative-unit`          | GET    |
-| `list-administrative-unit-members` | GET    |
+| Tool                               | Method | Risk   |
+| ---------------------------------- | ------ | ------ |
+| `list-administrative-units`        | GET    |        |
+| `get-administrative-unit`          | GET    |        |
+| `list-administrative-unit-members` | GET    |        |
+| `create-administrative-unit`       | POST   | medium |
+| `update-administrative-unit`       | PATCH  | medium |
+| `delete-administrative-unit`       | DELETE | high   |
+| `add-administrative-unit-member`   | POST   | medium |
 
 ### Conditional access (3)
 
@@ -224,15 +241,18 @@ node dist/index.js --verify-login
 | `get-conditional-access-policy`    | GET    |
 | `list-named-locations`             | GET    |
 
-### Applications & app roles (5)
+### Applications & app roles (8)
 
-| Tool                             | Method |
-| -------------------------------- | ------ |
-| `list-applications`              | GET    |
-| `list-service-principals`        | GET    |
-| `list-oauth2-grants`             | GET    |
-| `list-user-app-role-assignments` | GET    |
-| `list-sp-app-role-assignments`   | GET    |
+| Tool                             | Method | Risk     |
+| -------------------------------- | ------ | -------- |
+| `list-applications`              | GET    |          |
+| `list-service-principals`        | GET    |          |
+| `list-oauth2-grants`             | GET    |          |
+| `list-user-app-role-assignments` | GET    |          |
+| `list-sp-app-role-assignments`   | GET    |          |
+| `update-application`             | PATCH  | high     |
+| `delete-application`             | DELETE | critical |
+| `update-service-principal`       | PATCH  | high     |
 
 ### App credentials & owners (7)
 
@@ -253,12 +273,14 @@ node dist/index.js --verify-login
 | `list-app-management-policies` | GET    |
 | `get-app-management-policy`    | GET    |
 
-### Organization (2)
+### Organization & domains (4)
 
-| Tool               | Method |
-| ------------------ | ------ |
-| `get-organization` | GET    |
-| `list-domains`     | GET    |
+| Tool               | Method | Risk   |
+| ------------------ | ------ | ------ |
+| `get-organization` | GET    |        |
+| `list-domains`     | GET    |        |
+| `create-domain`    | POST   | high   |
+| `verify-domain`    | POST   | medium |
 
 ### Licenses (2)
 
@@ -288,18 +310,23 @@ node dist/index.js --verify-login
 | `list-risk-detections`          | GET    |
 | `get-risk-detection`            | GET    |
 
-### Security & access policies (8)
+### Security & access policies (13)
 
-| Tool                             | Method |
-| -------------------------------- | ------ |
-| `get-auth-methods-policy`        | GET    |
-| `list-auth-method-configs`       | GET    |
-| `get-auth-method-config`         | GET    |
-| `get-security-defaults`          | GET    |
-| `get-admin-consent-policy`       | GET    |
-| `list-auth-strength-policies`    | GET    |
-| `get-cross-tenant-access-policy` | GET    |
-| `list-cross-tenant-partners`     | GET    |
+| Tool                             | Method | Risk   |
+| -------------------------------- | ------ | ------ |
+| `get-auth-methods-policy`        | GET    |        |
+| `list-auth-method-configs`       | GET    |        |
+| `get-auth-method-config`         | GET    |        |
+| `get-security-defaults`          | GET    |        |
+| `get-admin-consent-policy`       | GET    |        |
+| `list-auth-strength-policies`    | GET    |        |
+| `get-auth-strength-policy`       | GET    |        |
+| `create-auth-strength-policy`    | POST   | high   |
+| `update-auth-strength-policy`    | PATCH  | high   |
+| `delete-auth-strength-policy`    | DELETE | high   |
+| `get-cross-tenant-access-policy` | GET    |        |
+| `list-cross-tenant-partners`     | GET    |        |
+| `change-user-password`           | POST   | high   |
 
 ### Guest user invitations (2)
 
@@ -386,15 +413,16 @@ node dist/index.js --verify-login
 | `list-threat-intel-host-components` | GET    |
 | `list-threat-intel-ssl-certs`       | GET    |
 
-### Managed devices (5)
+### Managed devices (6)
 
-| Tool                               | Method |
-| ---------------------------------- | ------ |
-| `list-managed-devices`             | GET    |
-| `get-managed-device`               | GET    |
-| `list-device-compliance-states`    | GET    |
-| `list-device-configuration-states` | GET    |
-| `get-managed-device-overview`      | GET    |
+| Tool                               | Method | Risk     |
+| ---------------------------------- | ------ | -------- |
+| `list-managed-devices`             | GET    |          |
+| `get-managed-device`               | GET    |          |
+| `list-device-compliance-states`    | GET    |          |
+| `list-device-configuration-states` | GET    |          |
+| `get-managed-device-overview`      | GET    |          |
+| `delete-managed-device`            | DELETE | critical |
 
 ### Compliance policies (5)
 
@@ -414,14 +442,20 @@ node dist/index.js --verify-login
 | `get-device-configuration`                 | GET    |
 | `get-device-configuration-status-overview` | GET    |
 
-### Enrollment & Autopilot (4)
+### Enrollment & Autopilot (10)
 
-| Tool                             | Method |
-| -------------------------------- | ------ |
-| `list-enrollment-configurations` | GET    |
-| `get-enrollment-configuration`   | GET    |
-| `list-autopilot-devices`         | GET    |
-| `get-autopilot-device`           | GET    |
+| Tool                               | Method | Risk   |
+| ---------------------------------- | ------ | ------ |
+| `list-enrollment-configurations`   | GET    |        |
+| `get-enrollment-configuration`     | GET    |        |
+| `list-autopilot-devices`           | GET    |        |
+| `get-autopilot-device`             | GET    |        |
+| `create-enrollment-configuration`  | POST   | medium |
+| `update-enrollment-configuration`  | PATCH  | medium |
+| `delete-enrollment-configuration`  | DELETE | high   |
+| `update-autopilot-device`          | PATCH  | medium |
+| `delete-autopilot-device`          | DELETE | high   |
+| `import-autopilot-device`          | POST   | medium |
 
 ### Detected apps (3)
 
@@ -593,17 +627,20 @@ node dist/index.js --verify-login
 | `get-pstn-calls`                | GET    |
 | `get-direct-routing-calls`      | GET    |
 
-### Cloud PC / Windows 365 (7)
+### Cloud PC / Windows 365 (10)
 
-| Tool                                    | Method | Risk |
-| --------------------------------------- | ------ | ---- |
-| `list-cloud-pcs`                        | GET    |      |
-| `list-cloud-pc-provisioning-policies`   | GET    |      |
-| `list-cloud-pc-device-images`           | GET    |      |
-| `list-cloud-pc-gallery-images`          | GET    |      |
-| `list-cloud-pc-on-premises-connections` | GET    |      |
-| `list-cloud-pc-user-settings`           | GET    |      |
-| `list-cloud-pc-audit-events`            | GET    |      |
+| Tool                                    | Method | Risk   |
+| --------------------------------------- | ------ | ------ |
+| `list-cloud-pcs`                        | GET    |        |
+| `list-cloud-pc-provisioning-policies`   | GET    |        |
+| `list-cloud-pc-device-images`           | GET    |        |
+| `list-cloud-pc-gallery-images`          | GET    |        |
+| `list-cloud-pc-on-premises-connections` | GET    |        |
+| `list-cloud-pc-user-settings`           | GET    |        |
+| `list-cloud-pc-audit-events`            | GET    |        |
+| `create-cloud-pc-provisioning-policy`   | POST   | medium |
+| `update-cloud-pc-provisioning-policy`   | PATCH  | medium |
+| `delete-cloud-pc-provisioning-policy`   | DELETE | high   |
 
 ### Universal Print (6)
 
@@ -947,18 +984,29 @@ User.Read.All
 UserAuthenticationMethod.Read.All
 ```
 
-### Write (incident response, device actions, CA policies, Teams, SharePoint)
+### Write (incident response, device actions, CA policies, Teams, SharePoint, identity management)
 
 ```
+AdministrativeUnit.ReadWrite.All
+Application.ReadWrite.All
+AttackSimulation.ReadWrite.All
 Channel.Create
 Channel.Delete.All
+CloudPC.ReadWrite.All
 Device.ReadWrite.All
 DeviceManagementConfiguration.ReadWrite.All
 DeviceManagementManagedDevices.PrivilegedOperations.All
+DeviceManagementManagedDevices.ReadWrite.All
+DeviceManagementServiceConfig.ReadWrite.All
+Directory.AccessAsUser.All
+Domain.ReadWrite.All
 Group.ReadWrite.All
+GroupMember.ReadWrite.All
 IdentityRiskyServicePrincipal.ReadWrite.All
 IdentityRiskyUser.ReadWrite.All
+Policy.ReadWrite.AuthenticationMethod
 Policy.ReadWrite.ConditionalAccess
+RoleManagement.ReadWrite.Directory
 SecurityAlert.ReadWrite.All
 SecurityIncident.ReadWrite.All
 Sites.ReadWrite.All

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -3,21 +3,27 @@
     "pathPattern": "/security/alerts_v2",
     "method": "get",
     "toolName": "list-security-alerts",
-    "appPermissions": ["SecurityAlert.Read.All"],
+    "appPermissions": [
+      "SecurityAlert.Read.All"
+    ],
     "llmTip": "Lists security alerts from Microsoft 365 Defender. Use $filter=status eq 'new' or status eq 'inProgress' to filter by status. Use $filter=severity eq 'high' to filter by severity (informational, low, medium, high). Use $orderby=createdDateTime desc to sort by newest. Use $top to limit results. Each alert has title, description, severity, status, category, serviceSource, detectionSource, and evidence."
   },
   {
     "pathPattern": "/security/alerts_v2/{alert-id}",
     "method": "get",
     "toolName": "get-security-alert",
-    "appPermissions": ["SecurityAlert.Read.All"],
+    "appPermissions": [
+      "SecurityAlert.Read.All"
+    ],
     "llmTip": "Gets a specific security alert by ID. Returns full alert details including title, description, severity, status, category, serviceSource, evidence, mitreTechniques, actorDisplayName, and recommendedActions."
   },
   {
     "pathPattern": "/security/alerts_v2/{alert-id}",
     "method": "patch",
     "toolName": "update-security-alert",
-    "appPermissions": ["SecurityAlert.ReadWrite.All"],
+    "appPermissions": [
+      "SecurityAlert.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates a security alert. Body can include: status ('new', 'inProgress', 'resolved'), assignedTo (email), classification ('truePositive', 'falsePositive', 'informationalExpectedActivity'), determination, comment."
   },
@@ -25,21 +31,27 @@
     "pathPattern": "/security/incidents",
     "method": "get",
     "toolName": "list-security-incidents",
-    "appPermissions": ["SecurityIncident.Read.All"],
+    "appPermissions": [
+      "SecurityIncident.Read.All"
+    ],
     "llmTip": "Lists security incidents from Microsoft 365 Defender. An incident correlates multiple alerts from the same attack. Use $filter=status eq 'active' to filter active incidents. Use $filter=severity eq 'high' to filter by severity. Use $orderby=createdDateTime desc. Each incident has displayName, severity, status, assignedTo, classification, and linked alerts."
   },
   {
     "pathPattern": "/security/incidents/{incident-id}",
     "method": "get",
     "toolName": "get-security-incident",
-    "appPermissions": ["SecurityIncident.Read.All"],
+    "appPermissions": [
+      "SecurityIncident.Read.All"
+    ],
     "llmTip": "Gets a specific security incident by ID. Returns full details including displayName, severity, status, assignedTo, classification, determination, description, and linked alerts."
   },
   {
     "pathPattern": "/security/incidents/{incident-id}",
     "method": "patch",
     "toolName": "update-security-incident",
-    "appPermissions": ["SecurityIncident.ReadWrite.All"],
+    "appPermissions": [
+      "SecurityIncident.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates a security incident. Body can include: status ('active', 'resolved', 'redirected'), assignedTo (email), classification ('truePositive', 'falsePositive', 'informationalExpectedActivity'), determination, customTags."
   },
@@ -47,251 +59,320 @@
     "pathPattern": "/auditLogs/directoryAudits",
     "method": "get",
     "toolName": "list-directory-audits",
-    "appPermissions": ["AuditLog.Read.All"],
+    "appPermissions": [
+      "AuditLog.Read.All"
+    ],
     "llmTip": "Lists Azure AD directory audit logs. Use $filter=activityDateTime ge 2024-01-01T00:00:00Z to filter by date. Use $filter=category eq 'UserManagement' to filter by category. Use $filter=activityDisplayName eq 'Add user' to find specific activities. Each entry has activityDisplayName, category, result, initiatedBy, targetResources, and activityDateTime."
   },
   {
     "pathPattern": "/auditLogs/signIns",
     "method": "get",
     "toolName": "list-sign-ins",
-    "appPermissions": ["AuditLog.Read.All"],
+    "appPermissions": [
+      "AuditLog.Read.All"
+    ],
     "llmTip": "Lists Azure AD sign-in logs. Use $filter=createdDateTime ge 2024-01-01T00:00:00Z to filter by date. Use $filter=userPrincipalName eq 'user@domain.com' to filter by user. Use $filter=status/errorCode ne 0 to find failed sign-ins. Each entry has userDisplayName, userPrincipalName, appDisplayName, ipAddress, location, status, conditionalAccessStatus, and riskState."
   },
   {
     "pathPattern": "/auditLogs/provisioning",
     "method": "get",
     "toolName": "list-provisioning-logs",
-    "appPermissions": ["AuditLog.Read.All"],
+    "appPermissions": [
+      "AuditLog.Read.All"
+    ],
     "llmTip": "Lists provisioning logs for Azure AD and third-party integrations. Use $filter=statusInfo/status eq 'failure' to find failed provisioning events. Use $filter=provisioningAction eq 'create' to filter by action type (create, update, delete, disable). Each entry has sourceSystem, targetSystem, provisioningAction, initiatedBy, sourceIdentity, targetIdentity, and statusInfo."
   },
   {
     "pathPattern": "/admin/serviceAnnouncement/healthOverviews",
     "method": "get",
     "toolName": "list-service-health",
-    "appPermissions": ["ServiceHealth.Read.All"],
+    "appPermissions": [
+      "ServiceHealth.Read.All"
+    ],
     "llmTip": "Lists health status for all Microsoft 365 services. Each entry has service name (Exchange Online, Microsoft Teams, etc.) and status (serviceDegradation, serviceOperational, etc.). Use $select=service,status to get a quick overview."
   },
   {
     "pathPattern": "/admin/serviceAnnouncement/issues",
     "method": "get",
     "toolName": "list-service-issues",
-    "appPermissions": ["ServiceHealth.Read.All"],
+    "appPermissions": [
+      "ServiceHealth.Read.All"
+    ],
     "llmTip": "Lists active and recent service health issues. Use $filter=isResolved eq false to see only active issues. Each issue has title, service, status (investigating, serviceRestored, etc.), classification (advisory, incident), startDateTime, and posts with updates."
   },
   {
     "pathPattern": "/admin/serviceAnnouncement/messages",
     "method": "get",
     "toolName": "list-service-messages",
-    "appPermissions": ["ServiceMessage.Read.All"],
+    "appPermissions": [
+      "ServiceMessage.Read.All"
+    ],
     "llmTip": "Lists Message Center posts about planned changes, new features, and actions required. Use $filter=services/any(s:s eq 'Exchange Online') to filter by service. Use $filter=category eq 'planForChange' to filter by category (planForChange, stayInformed, preventOrFixIssue). Each message has title, body, services, tags, startDateTime, endDateTime, and actionRequiredByDateTime."
   },
   {
     "pathPattern": "/reports/getTeamsUserActivityCounts(period='{period}')",
     "method": "get",
     "toolName": "get-teams-activity-report",
-    "appPermissions": ["Reports.Read.All"],
-    "skipEncoding": ["period"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
+    "skipEncoding": [
+      "period"
+    ],
     "llmTip": "Gets Teams user activity counts for the specified period. The period parameter must be one of: D7, D30, D90, D180 (last 7/30/90/180 days). Returns CSV data with daily counts of teamChatMessages, privateChatMessages, calls, and meetings."
   },
   {
     "pathPattern": "/reports/getEmailActivityCounts(period='{period}')",
     "method": "get",
     "toolName": "get-email-activity-report",
-    "appPermissions": ["Reports.Read.All"],
-    "skipEncoding": ["period"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
+    "skipEncoding": [
+      "period"
+    ],
     "llmTip": "Gets email activity counts for the specified period. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with daily counts of send, receive, and read email activities."
   },
   {
     "pathPattern": "/reports/getOffice365ActiveUserDetail(period='{period}')",
     "method": "get",
     "toolName": "get-active-users-report",
-    "appPermissions": ["Reports.Read.All"],
-    "skipEncoding": ["period"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
+    "skipEncoding": [
+      "period"
+    ],
     "llmTip": "Gets details about active Microsoft 365 users. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with per-user details: displayName, isDeleted, lastActivityDate, and product-specific activity dates (Exchange, OneDrive, SharePoint, Teams, etc.)."
   },
   {
     "pathPattern": "/reports/getSharePointSiteUsageDetail(period='{period}')",
     "method": "get",
     "toolName": "get-sharepoint-usage-report",
-    "appPermissions": ["Reports.Read.All"],
-    "skipEncoding": ["period"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
+    "skipEncoding": [
+      "period"
+    ],
     "llmTip": "Gets SharePoint site usage details. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with per-site details: siteUrl, ownerDisplayName, storageUsedInBytes, fileCount, activeFileCount, pageViewCount, lastActivityDate."
   },
-
   {
     "pathPattern": "/users",
     "method": "get",
     "toolName": "list-users",
-    "appPermissions": ["User.Read.All"],
+    "appPermissions": [
+      "User.Read.All"
+    ],
     "llmTip": "Lists all users in the tenant. Use $filter=accountEnabled eq true/false to find enabled/disabled accounts. Use $select=displayName,userPrincipalName,accountEnabled,signInActivity,createdDateTime to get key fields. Use $filter=signInActivity/lastSignInDateTime le 2024-01-01T00:00:00Z to find inactive users. Use $top to paginate, follow @odata.nextLink for more. Max $top=999 for users."
   },
   {
     "pathPattern": "/users/{user-id}",
     "method": "get",
     "toolName": "get-user",
-    "appPermissions": ["User.Read.All"],
+    "appPermissions": [
+      "User.Read.All"
+    ],
     "llmTip": "Gets a single user by ID or userPrincipalName. Use $select=displayName,userPrincipalName,accountEnabled,signInActivity,assignedLicenses,memberOf to get detailed info. signInActivity requires AuditLog.Read.All in addition to User.Read.All."
   },
   {
     "pathPattern": "/users/{user-id}/memberOf",
     "method": "get",
     "toolName": "list-user-memberships",
-    "appPermissions": ["Directory.Read.All"],
+    "appPermissions": [
+      "Directory.Read.All"
+    ],
     "llmTip": "Lists all groups and directory roles a user is a member of. Returns directoryRole and group objects. Use $select=displayName,id to reduce payload. Useful for auditing a user's access."
   },
   {
     "pathPattern": "/users/{user-id}/authentication/methods",
     "method": "get",
     "toolName": "list-user-auth-methods",
-    "appPermissions": ["UserAuthenticationMethod.Read.All"],
+    "appPermissions": [
+      "UserAuthenticationMethod.Read.All"
+    ],
     "llmTip": "Lists authentication methods registered for a user (phone, email, FIDO2, Microsoft Authenticator, etc.). Useful for MFA coverage audits. Each method has @odata.type to identify the method kind."
   },
   {
     "pathPattern": "/users/{user-id}/registeredDevices",
     "method": "get",
     "toolName": "list-user-devices",
-    "appPermissions": ["Directory.Read.All"],
+    "appPermissions": [
+      "Directory.Read.All"
+    ],
     "llmTip": "Lists devices registered to a user. Returns device objects with displayName, operatingSystem, operatingSystemVersion, isCompliant, isManaged, approximateLastSignInDateTime."
   },
-
   {
     "pathPattern": "/groups",
     "method": "get",
     "toolName": "list-groups",
-    "appPermissions": ["Group.Read.All"],
+    "appPermissions": [
+      "Group.Read.All"
+    ],
     "llmTip": "Lists all groups. Use $filter=groupTypes/any(c:c eq 'Unified') for Microsoft 365 groups. Use $filter=securityEnabled eq true for security groups. Use $filter=onPremisesSyncEnabled eq true for hybrid-synced groups. Use $select=displayName,mail,groupTypes,securityEnabled,membershipRule to get key fields."
   },
   {
     "pathPattern": "/groups/{group-id}",
     "method": "get",
     "toolName": "get-group",
-    "appPermissions": ["Group.Read.All"],
+    "appPermissions": [
+      "Group.Read.All"
+    ],
     "llmTip": "Gets a single group by ID. Use $select=displayName,description,groupTypes,securityEnabled,membershipRule,membershipRuleProcessingState for policy details."
   },
   {
     "pathPattern": "/groups/{group-id}/members",
     "method": "get",
     "toolName": "list-group-members",
-    "appPermissions": ["GroupMember.Read.All"],
+    "appPermissions": [
+      "GroupMember.Read.All"
+    ],
     "llmTip": "Lists members of a group. Returns user and servicePrincipal objects. Use $select=displayName,userPrincipalName,id. Use $top to paginate. For large groups, use $count=true with ConsistencyLevel=eventual header."
   },
   {
     "pathPattern": "/groups/{group-id}/owners",
     "method": "get",
     "toolName": "list-group-owners",
-    "appPermissions": ["GroupMember.Read.All"],
+    "appPermissions": [
+      "GroupMember.Read.All"
+    ],
     "llmTip": "Lists owners of a group. Useful for auditing ownerless groups. Returns user objects."
   },
-
   {
     "pathPattern": "/directoryRoles",
     "method": "get",
     "toolName": "list-directory-roles",
-    "appPermissions": ["RoleManagement.Read.Directory"],
+    "appPermissions": [
+      "RoleManagement.Read.Directory"
+    ],
     "llmTip": "Lists activated directory roles in the tenant. Only roles that have been activated (have at least one member) appear here. Use $expand=members to see who holds each role. Key roles to audit: Global Administrator, Privileged Role Administrator, Security Administrator."
   },
   {
     "pathPattern": "/directoryRoles/{directoryRole-id}/members",
     "method": "get",
     "toolName": "list-role-members",
-    "appPermissions": ["RoleManagement.Read.Directory"],
+    "appPermissions": [
+      "RoleManagement.Read.Directory"
+    ],
     "llmTip": "Lists members of a specific directory role. Use this to audit who has Global Admin, Exchange Admin, etc. Returns user and servicePrincipal objects."
   },
   {
     "pathPattern": "/roleManagement/directory/roleAssignments",
     "method": "get",
     "toolName": "list-role-assignments",
-    "appPermissions": ["RoleManagement.Read.Directory"],
+    "appPermissions": [
+      "RoleManagement.Read.Directory"
+    ],
     "llmTip": "Lists all role assignments in the directory. Use $filter=principalId eq '{user-id}' to find all roles for a specific user. Use $expand=principal to get user details. Includes both permanent and PIM-eligible assignments."
   },
   {
     "pathPattern": "/roleManagement/directory/roleDefinitions",
     "method": "get",
     "toolName": "list-role-definitions",
-    "appPermissions": ["RoleManagement.Read.Directory"],
+    "appPermissions": [
+      "RoleManagement.Read.Directory"
+    ],
     "llmTip": "Lists all role definitions (built-in and custom). Each has displayName, description, isBuiltIn, rolePermissions. Useful for understanding what each role can do."
   },
-
   {
     "pathPattern": "/identity/conditionalAccess/policies",
     "method": "get",
     "toolName": "list-conditional-access-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists all Conditional Access policies. Each policy has displayName, state (enabled/disabled/enabledForReportingButNotEnforced), conditions (users, applications, locations, platforms, signInRiskLevels), and grantControls (MFA, compliant device, etc.). Use this to audit MFA enforcement and access controls."
   },
   {
     "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
     "method": "get",
     "toolName": "get-conditional-access-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets a single Conditional Access policy by ID. Returns full policy details including conditions, grantControls, and sessionControls."
   },
   {
     "pathPattern": "/identity/conditionalAccess/namedLocations",
     "method": "get",
     "toolName": "list-named-locations",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists named locations used in Conditional Access policies. Shows trusted IP ranges and country-based locations. Useful for auditing geographic access controls."
   },
-
   {
     "pathPattern": "/applications",
     "method": "get",
     "toolName": "list-applications",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Lists all app registrations in the tenant. Use $select=displayName,appId,signInAudience,requiredResourceAccess,passwordCredentials,keyCredentials to audit app permissions and credentials. Use $filter=passwordCredentials/any(p:p/endDateTime le 2024-06-01T00:00:00Z) to find apps with expiring secrets (beta)."
   },
   {
     "pathPattern": "/servicePrincipals",
     "method": "get",
     "toolName": "list-service-principals",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Lists all service principals (enterprise apps). Use $filter=appOwnerOrganizationId ne '{tenant-id}' to find third-party apps. Use $select=displayName,appId,appOwnerOrganizationId,servicePrincipalType,accountEnabled to audit external access."
   },
   {
     "pathPattern": "/oauth2PermissionGrants",
     "method": "get",
     "toolName": "list-oauth2-grants",
-    "appPermissions": ["Directory.Read.All"],
+    "appPermissions": [
+      "Directory.Read.All"
+    ],
     "llmTip": "Lists all delegated permission grants (OAuth2 consent). Shows which apps have been granted what permissions by whom (admin consent vs user consent). Use $filter=consentType eq 'AllPrincipals' to find admin-consented grants. Critical for auditing overpermissioned apps."
   },
-
   {
     "pathPattern": "/organization",
     "method": "get",
     "toolName": "get-organization",
-    "appPermissions": ["Organization.Read.All"],
+    "appPermissions": [
+      "Organization.Read.All"
+    ],
     "llmTip": "Gets tenant organization info. Returns displayName, verifiedDomains, securityComplianceNotificationPhones, technicalNotificationMails, tenantType. Useful for basic tenant identity verification."
   },
   {
     "pathPattern": "/domains",
     "method": "get",
     "toolName": "list-domains",
-    "appPermissions": ["Domain.Read.All"],
+    "appPermissions": [
+      "Domain.Read.All"
+    ],
     "llmTip": "Lists all domains registered in the tenant. Shows isVerified, isDefault, authenticationType (Managed vs Federated). Useful for auditing federated domains and finding unverified domains."
   },
-
   {
     "pathPattern": "/users/{user-id}",
     "method": "patch",
     "toolName": "disable-user-account",
-    "appPermissions": ["User.ReadWrite.All"],
+    "appPermissions": [
+      "User.ReadWrite.All"
+    ],
     "riskLevel": "critical",
-    "llmTip": "Disables a user account by setting accountEnabled to false. Body MUST be: {\"accountEnabled\": false}. This blocks all sign-ins immediately. Use for compromised accounts. CRITICAL: verify the user-id carefully — disabling the wrong account locks out a legitimate user. To re-enable, send {\"accountEnabled\": true}."
+    "llmTip": "Disables a user account by setting accountEnabled to false. Body MUST be: {\"accountEnabled\": false}. This blocks all sign-ins immediately. Use for compromised accounts. CRITICAL: verify the user-id carefully \u2014 disabling the wrong account locks out a legitimate user. To re-enable, send {\"accountEnabled\": true}."
   },
   {
     "pathPattern": "/users/{user-id}/revokeSignInSessions",
     "method": "post",
     "toolName": "revoke-user-sessions",
-    "appPermissions": ["User.ReadWrite.All"],
+    "appPermissions": [
+      "User.ReadWrite.All"
+    ],
     "riskLevel": "high",
-    "llmTip": "Revokes all refresh tokens and session cookies for a user, forcing re-authentication everywhere. No request body needed. Use after password reset or account compromise. Effect is not instant — cached tokens may remain valid for up to 1 hour. Combine with disable-user-account for immediate containment."
+    "llmTip": "Revokes all refresh tokens and session cookies for a user, forcing re-authentication everywhere. No request body needed. Use after password reset or account compromise. Effect is not instant \u2014 cached tokens may remain valid for up to 1 hour. Combine with disable-user-account for immediate containment."
   },
   {
     "pathPattern": "/security/alerts_v2/{alert-id}/comments",
     "method": "post",
     "toolName": "add-security-alert-comment",
-    "appPermissions": ["SecurityAlert.ReadWrite.All"],
+    "appPermissions": [
+      "SecurityAlert.ReadWrite.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Adds a comment to a security alert for tracking investigation progress. Body: {\"comment\": \"your comment text\"}. Use to document triage decisions and findings."
   },
@@ -299,250 +380,307 @@
     "pathPattern": "/devices/{device-id}",
     "method": "patch",
     "toolName": "update-device",
-    "appPermissions": ["Device.ReadWrite.All"],
+    "appPermissions": [
+      "Device.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Updates device properties. Use {\"accountEnabled\": false} to disable a device in Entra ID. This prevents the device from authenticating. Useful for lost/stolen devices or compromised endpoints."
   },
-
   {
     "pathPattern": "/subscribedSkus",
     "method": "get",
     "toolName": "list-subscribed-skus",
-    "appPermissions": ["Organization.Read.All"],
+    "appPermissions": [
+      "Organization.Read.All"
+    ],
     "llmTip": "Lists all commercial subscriptions (licenses) in the tenant. Each SKU has skuPartNumber (e.g. ENTERPRISEPACK for E3), prepaidUnits, consumedUnits. Use to audit license allocation and find unused licenses."
   },
   {
     "pathPattern": "/subscribedSkus/{subscribedSku-id}",
     "method": "get",
     "toolName": "get-subscribed-sku",
-    "appPermissions": ["Organization.Read.All"],
+    "appPermissions": [
+      "Organization.Read.All"
+    ],
     "llmTip": "Gets details for a specific license SKU by ID. Returns prepaidUnits (enabled, suspended, warning), consumedUnits, and servicePlans with their provisioning status."
   },
   {
     "pathPattern": "/security/secureScores",
     "method": "get",
     "toolName": "list-secure-scores",
-    "appPermissions": ["SecurityEvents.Read.All"],
+    "appPermissions": [
+      "SecurityEvents.Read.All"
+    ],
     "llmTip": "Lists Secure Score snapshots over time. Each entry has currentScore, maxScore, and controlScores array. Use $top=1&$orderby=createdDateTime desc to get the latest score. Useful for tracking security posture improvement."
   },
   {
     "pathPattern": "/security/secureScores/{secureScore-id}",
     "method": "get",
     "toolName": "get-secure-score",
-    "appPermissions": ["SecurityEvents.Read.All"],
+    "appPermissions": [
+      "SecurityEvents.Read.All"
+    ],
     "llmTip": "Gets a specific Secure Score snapshot. Returns currentScore, maxScore, averageComparativeScores (comparison with similar tenants), and controlScores with detailed per-control scoring."
   },
   {
     "pathPattern": "/security/secureScoreControlProfiles",
     "method": "get",
     "toolName": "list-secure-score-controls",
-    "appPermissions": ["SecurityEvents.Read.All"],
+    "appPermissions": [
+      "SecurityEvents.Read.All"
+    ],
     "llmTip": "Lists all Secure Score control profiles. Each has title, maxScore, implementationStatus, and actionUrl. Useful to prioritize security improvements."
   },
   {
     "pathPattern": "/security/secureScoreControlProfiles/{secureScoreControlProfile-id}",
     "method": "get",
     "toolName": "get-secure-score-control",
-    "appPermissions": ["SecurityEvents.Read.All"],
+    "appPermissions": [
+      "SecurityEvents.Read.All"
+    ],
     "llmTip": "Gets a specific Secure Score control profile. Returns remediation impact, implementation cost, threats addressed, and compliance information."
   },
-
   {
     "pathPattern": "/identityProtection/riskyUsers",
     "method": "get",
     "toolName": "list-risky-users",
-    "appPermissions": ["IdentityRiskyUser.Read.All"],
+    "appPermissions": [
+      "IdentityRiskyUser.Read.All"
+    ],
     "llmTip": "Lists users flagged as risky by Identity Protection. Use $filter=riskLevel eq 'high' to find high-risk users. Each entry has riskLevel (low, medium, high), riskState (atRisk, confirmedCompromised, remediated, dismissed), riskDetail, and riskLastUpdatedDateTime."
   },
   {
     "pathPattern": "/identityProtection/riskyUsers/{riskyUser-id}",
     "method": "get",
     "toolName": "get-risky-user",
-    "appPermissions": ["IdentityRiskyUser.Read.All"],
+    "appPermissions": [
+      "IdentityRiskyUser.Read.All"
+    ],
     "llmTip": "Gets details for a specific risky user. Returns full risk information including riskLevel, riskState, riskDetail, and history."
   },
   {
     "pathPattern": "/identityProtection/riskyUsers/{riskyUser-id}/history",
     "method": "get",
     "toolName": "list-risky-user-history",
-    "appPermissions": ["IdentityRiskyUser.Read.All"],
+    "appPermissions": [
+      "IdentityRiskyUser.Read.All"
+    ],
     "llmTip": "Lists the risk history for a specific user. Shows how risk level changed over time and what triggered each risk event."
   },
   {
     "pathPattern": "/identityProtection/riskyServicePrincipals",
     "method": "get",
     "toolName": "list-risky-service-principals",
-    "appPermissions": ["IdentityRiskyServicePrincipal.Read.All"],
+    "appPermissions": [
+      "IdentityRiskyServicePrincipal.Read.All"
+    ],
     "llmTip": "Lists service principals flagged as risky. Useful for detecting compromised applications and service accounts."
   },
   {
     "pathPattern": "/identityProtection/riskyServicePrincipals/{riskyServicePrincipal-id}",
     "method": "get",
     "toolName": "get-risky-service-principal",
-    "appPermissions": ["IdentityRiskyServicePrincipal.Read.All"],
+    "appPermissions": [
+      "IdentityRiskyServicePrincipal.Read.All"
+    ],
     "llmTip": "Gets details for a specific risky service principal. Returns riskLevel, riskState, and riskDetail."
   },
-
   {
     "pathPattern": "/policies/authenticationMethodsPolicy",
     "method": "get",
     "toolName": "get-auth-methods-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the tenant authentication methods policy. Shows which authentication methods are enabled (FIDO2, Microsoft Authenticator, SMS, etc.) and their configuration. Critical for auditing MFA enforcement."
   },
   {
     "pathPattern": "/policies/authenticationMethodsPolicy/authenticationMethodConfigurations",
     "method": "get",
     "toolName": "list-auth-method-configs",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists all authentication method configurations. Each has id (method type), state (enabled/disabled), and method-specific settings. Useful to verify FIDO2, Authenticator, and passwordless policies."
   },
   {
     "pathPattern": "/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/{authenticationMethodConfiguration-id}",
     "method": "get",
     "toolName": "get-auth-method-config",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets a specific authentication method configuration. IDs include: microsoftAuthenticator, fido2, email, sms, temporaryAccessPass, x509Certificate, etc."
   },
   {
     "pathPattern": "/policies/identitySecurityDefaultsEnforcementPolicy",
     "method": "get",
     "toolName": "get-security-defaults",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the security defaults policy. Returns isEnabled (true/false). Security defaults enforce MFA for all users, block legacy auth, and require MFA for admin roles. Should be disabled only if Conditional Access is used instead."
   },
   {
     "pathPattern": "/policies/adminConsentRequestPolicy",
     "method": "get",
     "toolName": "get-admin-consent-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the admin consent request policy. Shows isEnabled, notifyReviewers, remindersEnabled, and reviewers list. Controls whether users can request admin consent for apps they want to use."
   },
-
   {
     "pathPattern": "/devices",
     "method": "get",
     "toolName": "list-devices",
-    "appPermissions": ["Device.Read.All"],
+    "appPermissions": [
+      "Device.Read.All"
+    ],
     "llmTip": "Lists all devices registered in the tenant. Use $filter=isCompliant eq false to find non-compliant devices. Use $filter=isManaged eq true for Intune-managed devices. Use $filter=operatingSystem eq 'Windows' to filter by OS. Use $select=displayName,operatingSystem,operatingSystemVersion,isCompliant,isManaged,accountEnabled,approximateLastSignInDateTime. Use $filter=approximateLastSignInDateTime le 2024-01-01T00:00:00Z to find stale devices."
   },
   {
     "pathPattern": "/devices/{device-id}",
     "method": "get",
     "toolName": "get-device",
-    "appPermissions": ["Device.Read.All"],
+    "appPermissions": [
+      "Device.Read.All"
+    ],
     "llmTip": "Gets a specific device by ID. Returns displayName, operatingSystem, operatingSystemVersion, isCompliant, isManaged, accountEnabled, trustType, approximateLastSignInDateTime, and deviceId."
   },
-
   {
     "pathPattern": "/identityProtection/riskDetections",
     "method": "get",
     "toolName": "list-risk-detections",
-    "appPermissions": ["IdentityRiskEvent.Read.All"],
+    "appPermissions": [
+      "IdentityRiskEvent.Read.All"
+    ],
     "llmTip": "Lists individual risk detections from Identity Protection. Use $filter=riskLevel eq 'high' to find high-risk events. Use $filter=detectedDateTime ge 2024-01-01T00:00:00Z to filter by date. Each detection has riskEventType (e.g. anonymizedIPAddress, leakedCredentials, malwareInfectedIPAddress), riskLevel, riskState, userPrincipalName, ipAddress, location, and activityType (signin, user)."
   },
   {
     "pathPattern": "/identityProtection/riskDetections/{riskDetection-id}",
     "method": "get",
     "toolName": "get-risk-detection",
-    "appPermissions": ["IdentityRiskEvent.Read.All"],
+    "appPermissions": [
+      "IdentityRiskEvent.Read.All"
+    ],
     "llmTip": "Gets a specific risk detection by ID. Returns full details including riskEventType, riskLevel, detectionTimingType (realtime, offline), source, ipAddress, location, userPrincipalName, and additionalInfo."
   },
-
   {
     "pathPattern": "/directory/deletedItems/graph.user",
     "method": "get",
     "toolName": "list-deleted-users",
-    "appPermissions": ["User.Read.All"],
+    "appPermissions": [
+      "User.Read.All"
+    ],
     "llmTip": "Lists recently deleted users (recoverable within 30 days). Use $select=displayName,userPrincipalName,deletedDateTime to see when each user was deleted. Useful for auditing account deletions and potential recovery."
   },
   {
     "pathPattern": "/directory/deletedItems/graph.group",
     "method": "get",
     "toolName": "list-deleted-groups",
-    "appPermissions": ["Group.Read.All"],
+    "appPermissions": [
+      "Group.Read.All"
+    ],
     "llmTip": "Lists recently deleted groups (recoverable within 30 days). Only Microsoft 365 groups (unified groups) are soft-deleted and recoverable. Use $select=displayName,deletedDateTime,groupTypes."
   },
-
   {
     "pathPattern": "/directory/administrativeUnits",
     "method": "get",
     "toolName": "list-administrative-units",
-    "appPermissions": ["AdministrativeUnit.Read.All"],
+    "appPermissions": [
+      "AdministrativeUnit.Read.All"
+    ],
     "llmTip": "Lists all administrative units in the tenant. Administrative units scope admin roles to a subset of users/groups/devices. Use $select=displayName,description,membershipType,membershipRule. membershipType can be 'Assigned' or 'Dynamic'."
   },
   {
     "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}",
     "method": "get",
     "toolName": "get-administrative-unit",
-    "appPermissions": ["AdministrativeUnit.Read.All"],
+    "appPermissions": [
+      "AdministrativeUnit.Read.All"
+    ],
     "llmTip": "Gets a specific administrative unit by ID. Returns displayName, description, membershipType, membershipRule, and visibility."
   },
   {
     "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}/members",
     "method": "get",
     "toolName": "list-administrative-unit-members",
-    "appPermissions": ["AdministrativeUnit.Read.All"],
+    "appPermissions": [
+      "AdministrativeUnit.Read.All"
+    ],
     "llmTip": "Lists members (users, groups, devices) of an administrative unit. Returns directory objects. Use $select=displayName,userPrincipalName for users."
   },
-
   {
     "pathPattern": "/policies/authenticationStrengthPolicies",
     "method": "get",
     "toolName": "list-auth-strength-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists authentication strength policies. These define which MFA method combinations are acceptable (e.g. phishing-resistant MFA, passwordless). Built-in policies include 'MFA', 'Passwordless MFA', and 'Phishing-resistant MFA'. Custom policies can restrict to specific methods. Used by Conditional Access grant controls."
   },
   {
     "pathPattern": "/policies/crossTenantAccessPolicy",
     "method": "get",
     "toolName": "get-cross-tenant-access-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the cross-tenant access policy. Controls B2B collaboration and B2B direct connect defaults. Returns allowedCloudEndpoints and default inbound/outbound settings for users, applications, and organizations."
   },
   {
     "pathPattern": "/policies/crossTenantAccessPolicy/partners",
     "method": "get",
     "toolName": "list-cross-tenant-partners",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists partner-specific cross-tenant access configurations. Each entry has tenantId and overrides for inbound/outbound B2B collaboration and direct connect settings. Useful for auditing which external organizations have special access."
   },
-
   {
     "pathPattern": "/roleManagement/directory/roleEligibilityScheduleInstances",
     "method": "get",
     "toolName": "list-pim-eligible-assignments",
-    "appPermissions": ["RoleEligibilitySchedule.Read.Directory"],
+    "appPermissions": [
+      "RoleEligibilitySchedule.Read.Directory"
+    ],
     "llmTip": "Lists PIM (Privileged Identity Management) eligible role assignments. These are just-in-time assignments that users must activate. Use $filter=principalId eq '{user-id}' to find eligible roles for a specific user. Use $expand=roleDefinition to get role names. Compare with list-role-assignments to distinguish permanent vs eligible assignments."
   },
   {
     "pathPattern": "/roleManagement/directory/roleAssignmentScheduleInstances",
     "method": "get",
     "toolName": "list-pim-active-assignments",
-    "appPermissions": ["RoleAssignmentSchedule.Read.Directory"],
+    "appPermissions": [
+      "RoleAssignmentSchedule.Read.Directory"
+    ],
     "llmTip": "Lists PIM active role assignment schedule instances, including time-bound and activated assignments. Use $filter=principalId eq '{user-id}' to find active assignments for a user. Shows assignmentType (Assigned or Activated), startDateTime, endDateTime. Useful for auditing who currently has active privileged roles."
   },
-
   {
     "pathPattern": "/users/{user-id}/appRoleAssignments",
     "method": "get",
     "toolName": "list-user-app-role-assignments",
-    "appPermissions": ["AppRoleAssignment.Read.All"],
+    "appPermissions": [
+      "AppRoleAssignment.Read.All"
+    ],
     "llmTip": "Lists app role assignments for a user. Shows which enterprise apps the user has been granted access to and with which roles. Each entry has appRoleId, resourceDisplayName, and principalDisplayName."
   },
   {
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}/appRoleAssignedTo",
     "method": "get",
     "toolName": "list-sp-app-role-assignments",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Lists all users and groups assigned app roles on a service principal. Use to audit who has access to a specific enterprise application. Each entry has principalDisplayName, principalType, appRoleId."
   },
-
   {
     "pathPattern": "/identityProtection/riskyUsers/confirmCompromised",
     "method": "post",
     "toolName": "confirm-compromised-users",
-    "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
+    "appPermissions": [
+      "IdentityRiskyUser.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Confirms one or more users as compromised. Body: {\"userIds\": [\"user-id-1\", \"user-id-2\"]}. This sets riskState to confirmedCompromised and riskLevel to high, which triggers any Conditional Access policies targeting risky users. Use after confirming a breach."
   },
@@ -550,7 +688,9 @@
     "pathPattern": "/identityProtection/riskyUsers/dismiss",
     "method": "post",
     "toolName": "dismiss-risky-users",
-    "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
+    "appPermissions": [
+      "IdentityRiskyUser.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Dismisses risk for one or more users. Body: {\"userIds\": [\"user-id-1\", \"user-id-2\"]}. Sets riskState to dismissed. Use after investigating a risk detection and determining it is a false positive or has been remediated."
   },
@@ -558,929 +698,1139 @@
     "pathPattern": "/users/{user-id}/authentication/phoneMethods/{phoneAuthenticationMethod-id}",
     "method": "delete",
     "toolName": "delete-user-phone-auth-method",
-    "appPermissions": ["UserAuthenticationMethod.ReadWrite.All"],
+    "appPermissions": [
+      "UserAuthenticationMethod.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Deletes a phone authentication method for a user. Use list-user-auth-methods first to get the phoneAuthenticationMethod ID. Useful for removing a compromised phone number during incident response. Cannot delete if it is the user's only MFA method and MFA is required."
   },
-
   {
     "pathPattern": "/reports/getOneDriveUsageAccountDetail(period='{period}')",
     "method": "get",
     "toolName": "get-onedrive-usage-report",
-    "appPermissions": ["Reports.Read.All"],
-    "skipEncoding": ["period"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
+    "skipEncoding": [
+      "period"
+    ],
     "llmTip": "Gets OneDrive usage details per account. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with ownerDisplayName, ownerPrincipalName, siteUrl, storageUsedInBytes, fileCount, activeFileCount, lastActivityDate."
   },
   {
     "pathPattern": "/reports/getOffice365ActiveUserCounts(period='{period}')",
     "method": "get",
     "toolName": "get-active-user-counts-report",
-    "appPermissions": ["Reports.Read.All"],
-    "skipEncoding": ["period"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
+    "skipEncoding": [
+      "period"
+    ],
     "llmTip": "Gets daily active user counts across Microsoft 365 services. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with daily counts per service: office365, exchange, oneDrive, sharePoint, skypeForBusiness, yammer, teams."
   },
   {
     "pathPattern": "/reports/getMailboxUsageDetail(period='{period}')",
     "method": "get",
     "toolName": "get-mailbox-usage-report",
-    "appPermissions": ["Reports.Read.All"],
-    "skipEncoding": ["period"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
+    "skipEncoding": [
+      "period"
+    ],
     "llmTip": "Gets mailbox usage details per user. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with userPrincipalName, displayName, storageUsedInBytes, issueWarningQuotaInBytes, prohibitSendQuotaInBytes, itemCount, lastActivityDate."
   },
   {
     "pathPattern": "/reports/getM365AppUserDetail(period='{period}')",
     "method": "get",
     "toolName": "get-m365-apps-usage-report",
-    "appPermissions": ["Reports.Read.All"],
-    "skipEncoding": ["period"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
+    "skipEncoding": [
+      "period"
+    ],
     "llmTip": "Gets Microsoft 365 Apps usage details per user. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data showing which apps each user used (Outlook, Word, Excel, PowerPoint, OneNote, Teams) and on which platforms (Windows, Mac, Web, Mobile)."
   },
-
   {
     "pathPattern": "/security/attackSimulation/simulations",
     "method": "get",
     "toolName": "list-attack-simulations",
-    "appPermissions": ["AttackSimulation.Read.All"],
+    "appPermissions": [
+      "AttackSimulation.Read.All"
+    ],
     "llmTip": "Lists attack simulation campaigns (phishing simulations). Each simulation has displayName, status, attackType (social, credential harvest, etc.), launchDateTime, completionDateTime, report with overview (resolvedTargetsCount, compromisedRate). Useful for tracking security awareness training effectiveness."
   },
   {
     "pathPattern": "/security/attackSimulation/simulations/{simulation-id}",
     "method": "get",
     "toolName": "get-attack-simulation",
-    "appPermissions": ["AttackSimulation.Read.All"],
+    "appPermissions": [
+      "AttackSimulation.Read.All"
+    ],
     "llmTip": "Gets a specific attack simulation by ID. Returns full details including report with simulationEventsContent (users who clicked, reported, etc.) and trainingsContent."
   },
-
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions",
     "method": "get",
     "toolName": "list-access-review-definitions",
-    "appPermissions": ["AccessReview.Read.All"],
+    "appPermissions": [
+      "AccessReview.Read.All"
+    ],
     "llmTip": "Lists all access review schedule definitions. Each definition has displayName, status (NotStarted, InProgress, Completed, Applied), scope (what is being reviewed: group members, app role assignments, etc.), reviewers, and settings (autoApplyDecisions, mailNotificationsEnabled, recurrence). Use $filter=status eq 'InProgress' to find active reviews."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}",
     "method": "get",
     "toolName": "get-access-review-definition",
-    "appPermissions": ["AccessReview.Read.All"],
+    "appPermissions": [
+      "AccessReview.Read.All"
+    ],
     "llmTip": "Gets a specific access review schedule definition by ID. Returns full configuration including scope, reviewers, fallbackReviewers, settings, stageSettings, and instances."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances",
     "method": "get",
     "toolName": "list-access-review-instances",
-    "appPermissions": ["AccessReview.Read.All"],
+    "appPermissions": [
+      "AccessReview.Read.All"
+    ],
     "llmTip": "Lists instances of an access review definition. Each recurring review creates instances. Each instance has status, startDateTime, endDateTime, and scope. Use to track review progress over time."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}",
     "method": "get",
     "toolName": "get-access-review-instance",
-    "appPermissions": ["AccessReview.Read.All"],
+    "appPermissions": [
+      "AccessReview.Read.All"
+    ],
     "llmTip": "Gets a specific access review instance. Returns status, startDateTime, endDateTime, scope, and reviewers for this particular execution of the review."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}/decisions",
     "method": "get",
     "toolName": "list-access-review-decisions",
-    "appPermissions": ["AccessReview.Read.All"],
+    "appPermissions": [
+      "AccessReview.Read.All"
+    ],
     "llmTip": "Lists decisions made during an access review instance. Each decision has target (user/group), decision (Approve, Deny, NotReviewed, DontKnow), reviewedBy, justification, and appliedDateTime. Use to audit review outcomes and ensure decisions were applied."
   },
-
   {
     "pathPattern": "/identityGovernance/entitlementManagement/accessPackages",
     "method": "get",
     "toolName": "list-access-packages",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Lists all access packages in entitlement management. Each package bundles resources (group memberships, app roles, SharePoint sites) that can be requested. Use $select=displayName,description,isHidden,createdDateTime,modifiedDateTime. Use $expand=catalog to see which catalog each package belongs to."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}",
     "method": "get",
     "toolName": "get-access-package",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Gets a specific access package by ID. Use $expand=resourceRoleScopes($expand=role,scope) to see what resources the package grants access to."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/assignments",
     "method": "get",
     "toolName": "list-access-package-assignments",
-    "appPermissions": ["EntitlementManagement.Read.All"],
-    "llmTip": "Lists access package assignments — who has been granted which access packages. Use $filter=state eq 'Delivered' to find active assignments. Use $filter=targetId eq '{user-id}' to find all packages assigned to a user. Use $expand=target,accessPackage to get user and package details. Each assignment has state (Delivering, Delivered, Expired, DeliveryFailed), schedule, and targetId."
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
+    "llmTip": "Lists access package assignments \u2014 who has been granted which access packages. Use $filter=state eq 'Delivered' to find active assignments. Use $filter=targetId eq '{user-id}' to find all packages assigned to a user. Use $expand=target,accessPackage to get user and package details. Each assignment has state (Delivering, Delivered, Expired, DeliveryFailed), schedule, and targetId."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/assignmentRequests",
     "method": "get",
     "toolName": "list-access-package-requests",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Lists access package assignment requests. Use $filter=state eq 'submitted' to find pending requests. Each request has requestType (UserAdd, AdminAdd, AdminRemove), state (submitted, approved, denied, delivering, delivered, deliveryFailed), createdDateTime, and schedule."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/catalogs",
     "method": "get",
     "toolName": "list-access-package-catalogs",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Lists access package catalogs. Catalogs are containers for access packages and their resources. Each has displayName, description, catalogType (UserManaged, ServiceDefault), state (published, unpublished), isExternallyVisible, and createdDateTime."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/connectedOrganizations",
     "method": "get",
     "toolName": "list-connected-organizations",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Lists connected organizations in entitlement management. Connected organizations represent external organizations whose users can request access packages. Each has displayName, description, state (configured, proposed), identitySources (tenant IDs, domains), and createdDateTime."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/settings",
     "method": "get",
     "toolName": "get-entitlement-management-settings",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Gets entitlement management settings for the tenant. Returns externalUserLifecycleAction (None, BlockSignIn, BlockSignInAndDelete), daysUntilExternalUserDeletedAfterBlocked, and isB2BExternalCollab settings."
   },
-
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/workflows",
     "method": "get",
     "toolName": "list-lifecycle-workflows",
-    "appPermissions": ["LifecycleWorkflows.Read.All"],
+    "appPermissions": [
+      "LifecycleWorkflows.Read.All"
+    ],
     "llmTip": "Lists lifecycle workflows (joiner, mover, leaver). Each workflow has displayName, description, category (joiner, mover, leaver), isEnabled, isSchedulingEnabled, executionConditions (scope, trigger), and tasks. Useful for auditing automated onboarding/offboarding processes."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}",
     "method": "get",
     "toolName": "get-lifecycle-workflow",
-    "appPermissions": ["LifecycleWorkflows.Read.All"],
+    "appPermissions": [
+      "LifecycleWorkflows.Read.All"
+    ],
     "llmTip": "Gets a specific lifecycle workflow by ID. Returns full details including tasks, executionConditions, lastModifiedDateTime, and version. Use $expand=tasks to see all tasks in the workflow."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/taskDefinitions",
     "method": "get",
     "toolName": "list-lifecycle-task-definitions",
-    "appPermissions": ["LifecycleWorkflows.Read.All"],
+    "appPermissions": [
+      "LifecycleWorkflows.Read.All"
+    ],
     "llmTip": "Lists available task definitions for lifecycle workflows. Each has displayName, description, category (joiner, leaver), and parameters. Examples: Send welcome email, Add user to group, Remove user from group, Disable user account, Delete user."
   },
-
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/assignmentSchedules",
     "method": "get",
     "toolName": "list-pim-group-assignment-schedules",
-    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
+    "appPermissions": [
+      "PrivilegedAccess.Read.AzureADGroup"
+    ],
     "llmTip": "Lists PIM for Groups assignment schedules. Shows active role assignments on privileged groups (member or owner). Each has principalId, groupId, accessId (member, owner), status, scheduleInfo (startDateTime, expiration). Use to audit who has permanent access to privileged groups."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/eligibilitySchedules",
     "method": "get",
     "toolName": "list-pim-group-eligibility-schedules",
-    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
+    "appPermissions": [
+      "PrivilegedAccess.Read.AzureADGroup"
+    ],
     "llmTip": "Lists PIM for Groups eligibility schedules. Shows who is eligible (but not yet activated) for membership or ownership on privileged groups. Each has principalId, groupId, accessId (member, owner), status, scheduleInfo. Compare with assignment schedules to see eligible vs active."
   },
-
   {
     "pathPattern": "/identityGovernance/termsOfUse/agreements",
     "method": "get",
     "toolName": "list-terms-of-use-agreements",
-    "appPermissions": ["Agreement.Read.All"],
+    "appPermissions": [
+      "Agreement.Read.All"
+    ],
     "llmTip": "Lists terms of use agreements. Each agreement has displayName, isPerDeviceAcceptanceRequired, isViewingBeforeAcceptanceRequired, userReexpireFrequency, and termsExpiration. Useful for auditing compliance with organizational policies."
   },
   {
     "pathPattern": "/identityGovernance/termsOfUse/agreements/{agreement-id}",
     "method": "get",
     "toolName": "get-terms-of-use-agreement",
-    "appPermissions": ["Agreement.Read.All"],
+    "appPermissions": [
+      "Agreement.Read.All"
+    ],
     "llmTip": "Gets a specific terms of use agreement. Returns full details including acceptance status configuration and file content."
   },
   {
     "pathPattern": "/identityGovernance/termsOfUse/agreements/{agreement-id}/acceptances",
     "method": "get",
     "toolName": "list-terms-of-use-acceptances",
-    "appPermissions": ["Agreement.Read.All"],
+    "appPermissions": [
+      "Agreement.Read.All"
+    ],
     "llmTip": "Lists acceptances for a terms of use agreement. Each acceptance has userId, userDisplayName, userPrincipalName, state (accepted, declined), recordedDateTime, and expirationDateTime. Useful for compliance reporting on who has accepted terms."
   },
-
   {
     "pathPattern": "/identityGovernance/appConsent/appConsentRequests",
     "method": "get",
     "toolName": "list-app-consent-requests",
-    "appPermissions": ["ConsentRequest.Read.All"],
+    "appPermissions": [
+      "ConsentRequest.Read.All"
+    ],
     "llmTip": "Lists app consent requests. When users request access to apps that require admin consent, those requests appear here. Each has appId, appDisplayName, and pendingScopes. Use to review and manage pending consent requests."
   },
   {
     "pathPattern": "/identityGovernance/appConsent/appConsentRequests/{appConsentRequest-id}",
     "method": "get",
     "toolName": "get-app-consent-request",
-    "appPermissions": ["ConsentRequest.Read.All"],
+    "appPermissions": [
+      "ConsentRequest.Read.All"
+    ],
     "llmTip": "Gets a specific app consent request. Returns appId, appDisplayName, pendingScopes, and linked userConsentRequests showing which users requested access."
   },
   {
     "pathPattern": "/identityGovernance/appConsent/appConsentRequests/{appConsentRequest-id}/userConsentRequests",
     "method": "get",
     "toolName": "list-user-consent-requests",
-    "appPermissions": ["ConsentRequest.Read.All"],
+    "appPermissions": [
+      "ConsentRequest.Read.All"
+    ],
     "llmTip": "Lists user consent requests for a specific app consent request. Each has createdBy, status (Submitted, InProgress, Completed), and reason. Shows which individual users requested consent for the app."
   },
-
   {
     "pathPattern": "/deviceManagement/managedDevices",
     "method": "get",
     "toolName": "list-managed-devices",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Lists all Intune-managed devices. Use $filter=operatingSystem eq 'Windows' to filter by OS. Use $filter=complianceState eq 'noncompliant' to find non-compliant devices. Use $select=deviceName,operatingSystem,osVersion,complianceState,isEncrypted,managementAgent,enrolledDateTime,lastSyncDateTime,userPrincipalName. Use $filter=lastSyncDateTime le 2024-01-01T00:00:00Z to find stale devices."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}",
     "method": "get",
     "toolName": "get-managed-device",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Gets a specific Intune-managed device by ID. Returns full details: deviceName, operatingSystem, osVersion, complianceState, isEncrypted, jailBroken, managementAgent, enrolledDateTime, lastSyncDateTime, userPrincipalName, azureADDeviceId, model, manufacturer, serialNumber, wiFiMacAddress."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/deviceCompliancePolicyStates",
     "method": "get",
     "toolName": "list-device-compliance-states",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Lists compliance policy states for a specific managed device. Shows which compliance policies apply and their state (compliant, nonCompliant, notApplicable, error). Each has displayName, state, settingCount, settingStates."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/deviceConfigurationStates",
     "method": "get",
     "toolName": "list-device-configuration-states",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Lists configuration profile states for a specific managed device. Shows which configuration profiles apply and their state (notApplicable, success, error, conflict). Each has displayName, state, settingCount."
   },
-
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies",
     "method": "get",
     "toolName": "list-compliance-policies",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Lists all Intune device compliance policies. Each has displayName, description, @odata.type (platform-specific: windows10, iOS, androidWorkProfile, macOS), createdDateTime, lastModifiedDateTime, and version. Use to audit what compliance rules are in place."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
     "method": "get",
     "toolName": "get-compliance-policy",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Gets a specific compliance policy. Returns full details including platform-specific settings (password requirements, encryption, OS version, etc.)."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}/deviceStatuses",
     "method": "get",
     "toolName": "list-compliance-policy-device-statuses",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Lists device statuses for a specific compliance policy. Each has deviceDisplayName, userName, status (compliant, nonCompliant, error, conflict, notApplicable), lastReportedDateTime, and complianceGracePeriodExpirationDateTime."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}/deviceStatusOverview",
     "method": "get",
     "toolName": "get-compliance-policy-status-overview",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Gets the device status overview for a compliance policy. Returns aggregate counts: pendingCount, notApplicableCount, successCount, errorCount, failedCount, conflictCount, lastUpdateDateTime."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicyDeviceStateSummary",
     "method": "get",
     "toolName": "get-compliance-state-summary",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Gets the tenant-wide device compliance state summary. Returns aggregate counts: inGracePeriodCount, compliantDeviceCount, nonCompliantDeviceCount, remediatedDeviceCount, errorDeviceCount, conflictDeviceCount, unknownDeviceCount, notApplicableDeviceCount."
   },
-
   {
     "pathPattern": "/deviceManagement/deviceConfigurations",
     "method": "get",
     "toolName": "list-device-configurations",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Lists all Intune device configuration profiles. Each has displayName, description, @odata.type (platform-specific), createdDateTime, lastModifiedDateTime, and version. Covers Wi-Fi, VPN, email, certificates, device restrictions, endpoint protection, etc."
   },
   {
     "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
     "method": "get",
     "toolName": "get-device-configuration",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Gets a specific device configuration profile. Returns full details including platform-specific settings (Wi-Fi SSID, VPN config, device restrictions, etc.)."
   },
   {
     "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}/deviceStatusOverview",
     "method": "get",
     "toolName": "get-device-configuration-status-overview",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Gets device status overview for a configuration profile. Returns aggregate counts: pendingCount, notApplicableCount, successCount, errorCount, failedCount, conflictCount, lastUpdateDateTime."
   },
-
   {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
     "method": "get",
     "toolName": "list-enrollment-configurations",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists device enrollment configurations. Includes Windows Autopilot deployment profiles, enrollment restrictions (platform, device limit), and enrollment status page settings. Each has displayName, @odata.type, priority, createdDateTime."
   },
   {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations/{deviceEnrollmentConfiguration-id}",
     "method": "get",
     "toolName": "get-enrollment-configuration",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Gets a specific enrollment configuration. Returns full details including platform restrictions, device limits, or Autopilot profile settings depending on the type."
   },
-
   {
     "pathPattern": "/deviceManagement/deviceCategories",
     "method": "get",
     "toolName": "list-device-categories",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Lists Intune device categories. Categories allow organizing devices for dynamic group targeting. Each has displayName and description."
   },
-
   {
     "pathPattern": "/deviceManagement/windowsAutopilotDeviceIdentities",
     "method": "get",
     "toolName": "list-autopilot-devices",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists Windows Autopilot device identities. Each has serialNumber, model, manufacturer, groupTag, purchaseOrderIdentifier, enrollmentState, deploymentProfileAssignmentStatus, lastContactedDateTime. Use to audit Autopilot-registered devices and their deployment status."
   },
   {
     "pathPattern": "/deviceManagement/windowsAutopilotDeviceIdentities/{windowsAutopilotDeviceIdentity-id}",
     "method": "get",
     "toolName": "get-autopilot-device",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Gets a specific Autopilot device identity. Returns serialNumber, model, manufacturer, groupTag, enrollmentState, deploymentProfileAssignmentStatus, and assignedDeploymentProfile."
   },
-
   {
     "pathPattern": "/deviceManagement/detectedApps",
     "method": "get",
     "toolName": "list-detected-apps",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists all applications detected on Intune-managed devices. Each has displayName, version, sizeInByte, deviceCount, and platform. Use to audit software inventory and find unauthorized applications. Use $orderby=deviceCount desc to see most-installed apps."
   },
   {
     "pathPattern": "/deviceManagement/detectedApps/{detectedApp-id}",
     "method": "get",
     "toolName": "get-detected-app",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Gets a specific detected application. Returns displayName, version, sizeInByte, deviceCount, and platform."
   },
   {
     "pathPattern": "/deviceManagement/detectedApps/{detectedApp-id}/managedDevices",
     "method": "get",
     "toolName": "list-detected-app-devices",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists managed devices that have a specific application installed. Useful for finding all devices with a particular app version (e.g., outdated or unauthorized software)."
   },
-
   {
     "pathPattern": "/deviceManagement/managedDeviceOverview",
     "method": "get",
     "toolName": "get-managed-device-overview",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Gets a high-level overview of all managed devices. Returns aggregate counts by enrolledDeviceCount, mdmEnrolledCount, dualEnrolledDeviceCount, deviceOperatingSystemSummary (android, iOS, macOS, windows, windowsMobile), and deviceExchangeAccessStateSummary."
   },
-
   {
     "pathPattern": "/deviceManagement/auditEvents",
     "method": "get",
     "toolName": "list-intune-audit-events",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists Intune audit events. Each has displayName, componentName, activity, activityDateTime, activityType, actor (userPrincipalName, applicationDisplayName), and resources (displayName, type). Use $filter=activityDateTime ge 2024-01-01T00:00:00Z to filter by date. Use to track who changed Intune policies."
   },
-
   {
     "pathPattern": "/deviceManagement/softwareUpdateStatusSummary",
     "method": "get",
     "toolName": "get-software-update-summary",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Gets a summary of Windows update statuses across managed devices. Returns counts by status: compliantDeviceCount, nonCompliantDeviceCount, remediatedDeviceCount, errorDeviceCount, conflictDeviceCount, unknownDeviceCount, notApplicableDeviceCount."
   },
-
   {
     "pathPattern": "/deviceManagement/applePushNotificationCertificate",
     "method": "get",
     "toolName": "get-apple-push-certificate",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
-    "llmTip": "Gets the Apple Push Notification certificate info. Returns appleIdentifier, topicIdentifier, lastModifiedDateTime, expirationDateTime, and certificateSerialNumber. CRITICAL: monitor expirationDateTime — if it expires, all iOS/macOS device management stops."
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
+    "llmTip": "Gets the Apple Push Notification certificate info. Returns appleIdentifier, topicIdentifier, lastModifiedDateTime, expirationDateTime, and certificateSerialNumber. CRITICAL: monitor expirationDateTime \u2014 if it expires, all iOS/macOS device management stops."
   },
-
   {
     "pathPattern": "/deviceManagement/roleDefinitions",
     "method": "get",
     "toolName": "list-intune-role-definitions",
-    "appPermissions": ["DeviceManagementRBAC.Read.All"],
+    "appPermissions": [
+      "DeviceManagementRBAC.Read.All"
+    ],
     "llmTip": "Lists Intune RBAC role definitions. Each has displayName, description, isBuiltIn, permissions (actions), and roleAssignments. Built-in roles include Intune Administrator, Help Desk Operator, Read Only Operator, etc."
   },
   {
     "pathPattern": "/deviceManagement/roleAssignments",
     "method": "get",
     "toolName": "list-intune-role-assignments",
-    "appPermissions": ["DeviceManagementRBAC.Read.All"],
+    "appPermissions": [
+      "DeviceManagementRBAC.Read.All"
+    ],
     "llmTip": "Lists Intune RBAC role assignments. Each has displayName, description, resourceScopes, and members. Shows who has been granted which Intune admin roles and over which scope."
   },
-
   {
     "pathPattern": "/deviceManagement/termsAndConditions",
     "method": "get",
     "toolName": "list-intune-terms-and-conditions",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists Intune terms and conditions. Each has displayName, description, title, bodyText, acceptanceStatement, version, createdDateTime, and modifiedDateTime."
   },
   {
     "pathPattern": "/deviceManagement/termsAndConditions/{termsAndConditions-id}/acceptanceStatuses",
     "method": "get",
     "toolName": "list-intune-terms-acceptances",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists acceptance statuses for Intune terms and conditions. Each has userDisplayName, userPrincipalName, acceptedVersion, acceptedDateTime. Useful for compliance reporting."
   },
-
   {
     "pathPattern": "/deviceManagement/conditionalAccessSettings",
     "method": "get",
     "toolName": "get-intune-conditional-access-settings",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Gets Intune on-premises conditional access settings. Returns enabled status and which devices are included/excluded from conditional access to on-premises Exchange."
   },
-
   {
     "pathPattern": "/deviceManagement/mobileThreatDefenseConnectors",
     "method": "get",
     "toolName": "list-mtd-connectors",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists Mobile Threat Defense (MTD) connectors. Shows which MTD partners are integrated (Microsoft Defender, Lookout, Zimperium, etc.), their state (enabled/disabled), and platform support. Each has partnerState, androidEnabled, iosEnabled, lastHeartbeatDateTime."
   },
-
   {
     "pathPattern": "/deviceManagement/iosUpdateStatuses",
     "method": "get",
     "toolName": "list-ios-update-statuses",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "llmTip": "Lists iOS update installation statuses across managed devices. Each has deviceDisplayName, userName, osVersion, installStatus (downloading, installing, idle, available, etc.), lastReportedDateTime, deviceModel, deviceId."
   },
-
   {
     "pathPattern": "/admin/exchange/tracing/messageTraces",
     "method": "get",
     "toolName": "list-message-traces",
-    "appPermissions": ["MailboxSettings.Read"],
+    "appPermissions": [
+      "MailboxSettings.Read"
+    ],
     "llmTip": "Lists Exchange message traces for auditing mail flow. Each trace has senderAddress, recipientAddress, subject, messageId, receivedDateTime, status (Delivered, Failed, Quarantined, FilteredAsSpam, Expanded, etc.), and size. Use $filter=receivedDateTime ge 2024-01-01T00:00:00Z to filter by date. Use $filter=senderAddress eq 'user@domain.com' to filter by sender."
   },
   {
     "pathPattern": "/admin/exchange/tracing/messageTraces/{exchangeMessageTrace-id}",
     "method": "get",
     "toolName": "get-message-trace",
-    "appPermissions": ["MailboxSettings.Read"],
+    "appPermissions": [
+      "MailboxSettings.Read"
+    ],
     "llmTip": "Gets a specific message trace by ID. Returns full details including senderAddress, recipientAddress, subject, messageId, receivedDateTime, status, size, and additional routing information."
   },
-
   {
     "pathPattern": "/admin/exchange/mailboxes",
     "method": "get",
     "toolName": "list-exchange-mailboxes",
-    "appPermissions": ["Exchange.ManageAsApp"],
+    "appPermissions": [
+      "Exchange.ManageAsApp"
+    ],
     "llmTip": "Lists Exchange mailboxes in the tenant via admin API. Each mailbox has displayName, primarySmtpAddress, recipientType (UserMailbox, SharedMailbox, RoomMailbox, EquipmentMailbox), and identity. Useful for auditing mailbox types and finding shared/resource mailboxes."
   },
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}",
     "method": "get",
     "toolName": "get-exchange-mailbox",
-    "appPermissions": ["Exchange.ManageAsApp"],
+    "appPermissions": [
+      "Exchange.ManageAsApp"
+    ],
     "llmTip": "Gets a specific Exchange mailbox. Returns full details including displayName, primarySmtpAddress, recipientType, and mailbox configuration."
   },
-
   {
     "pathPattern": "/security/threatIntelligence/hosts",
     "method": "get",
     "toolName": "list-threat-intel-hosts",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists hosts tracked by Microsoft threat intelligence. Use $filter=id eq 'example.com' to look up a specific host. Returns host details including firstSeenDateTime, lastSeenDateTime, and registrar info."
   },
   {
     "pathPattern": "/security/threatIntelligence/hosts/{host-id}",
     "method": "get",
     "toolName": "get-threat-intel-host",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Gets threat intelligence for a specific host (domain or IP). The host-id is the hostname or IP address. Returns firstSeenDateTime, lastSeenDateTime, registrar, registrant info, and reputation data."
   },
   {
     "pathPattern": "/security/threatIntelligence/hosts/{host-id}/whois",
     "method": "get",
     "toolName": "get-threat-intel-host-whois",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Gets WHOIS information for a host. Returns registrar, registrant (name, organization, email, phone), nameservers, registrationDateTime, expirationDateTime. Useful for investigating suspicious domains."
   },
   {
     "pathPattern": "/security/threatIntelligence/hosts/{host-id}/hostPairs",
     "method": "get",
     "toolName": "list-threat-intel-host-pairs",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
-    "llmTip": "Lists host pairs for a given host — relationships between parent and child hosts (redirects, iframes, scripts, etc.). Each has parentHost, childHost, linkKind (redirect, script, etc.), firstSeenDateTime, lastSeenDateTime. Useful for mapping infrastructure."
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
+    "llmTip": "Lists host pairs for a given host \u2014 relationships between parent and child hosts (redirects, iframes, scripts, etc.). Each has parentHost, childHost, linkKind (redirect, script, etc.), firstSeenDateTime, lastSeenDateTime. Useful for mapping infrastructure."
   },
-
   {
     "pathPattern": "/security/threatIntelligence/articles",
     "method": "get",
     "toolName": "list-threat-intel-articles",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists Microsoft threat intelligence articles. Each has title, body, createdDateTime, lastUpdatedDateTime, tags, and indicators. These are curated reports about threat actors, campaigns, and vulnerabilities."
   },
   {
     "pathPattern": "/security/threatIntelligence/articles/{article-id}",
     "method": "get",
     "toolName": "get-threat-intel-article",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Gets a specific threat intelligence article by ID. Returns title, body (HTML), summary, tags, indicators, and linked intelligence profiles."
   },
   {
     "pathPattern": "/security/threatIntelligence/articles/{article-id}/indicators",
     "method": "get",
     "toolName": "list-threat-intel-article-indicators",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists indicators of compromise (IOCs) associated with a threat intelligence article. Each indicator has artifact (hostname, IP, URL, file hash), source, and pattern details."
   },
-
   {
     "pathPattern": "/security/threatIntelligence/intelProfiles",
     "method": "get",
     "toolName": "list-threat-intel-profiles",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists threat actor intelligence profiles. Each has title, kind (actor, tool, vulnerability), aliases, countriesOrRegionsOfOrigin, targets (industries, countries), firstActiveDateTime, and description. Profiles represent tracked threat actors and their TTPs."
   },
   {
     "pathPattern": "/security/threatIntelligence/intelProfiles/{intelligenceProfile-id}",
     "method": "get",
     "toolName": "get-threat-intel-profile",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Gets a specific threat actor intelligence profile. Returns full details including title, kind, description, aliases, countriesOrRegionsOfOrigin, targets, tradecraft summary, and linked indicators."
   },
   {
     "pathPattern": "/security/threatIntelligence/intelProfiles/{intelligenceProfile-id}/indicators",
     "method": "get",
     "toolName": "list-threat-intel-profile-indicators",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists indicators of compromise associated with a threat actor profile. Each indicator has artifact (hostname, IP, URL, file hash), source, and firstSeenDateTime."
   },
-
   {
     "pathPattern": "/security/threatIntelligence/vulnerabilities",
     "method": "get",
     "toolName": "list-threat-intel-vulnerabilities",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists known vulnerabilities tracked by Microsoft threat intelligence. Each has id (CVE ID), description, severity, publishedDateTime, lastModifiedDateTime, hasChatter, exploitsAvailable, and cvss scores. Use to check if known CVEs are being actively exploited."
   },
   {
     "pathPattern": "/security/threatIntelligence/vulnerabilities/{vulnerability-id}",
     "method": "get",
     "toolName": "get-threat-intel-vulnerability",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Gets a specific vulnerability by CVE ID (e.g. CVE-2024-1234). Returns description, severity, cvss scores, publishedDateTime, exploitsAvailable, activeExploitsObserved, hasChatter, priorityScore, and remediation info."
   },
-
   {
     "pathPattern": "/security/threatIntelligence/whoisRecords",
     "method": "get",
     "toolName": "list-threat-intel-whois-records",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists WHOIS records from threat intelligence. Use to search WHOIS data across domains. Each record has host, registrar, registrant, nameservers, and dates."
   },
   {
     "pathPattern": "/security/threatIntelligence/whoisRecords/{whoisRecord-id}",
     "method": "get",
     "toolName": "get-threat-intel-whois-record",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Gets a specific WHOIS record by ID. Returns full registrant and registrar details, nameservers, registration and expiration dates."
   },
-
   {
     "pathPattern": "/security/threatIntelligence/hostComponents",
     "method": "get",
     "toolName": "list-threat-intel-host-components",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists web components detected on hosts (web servers, frameworks, CMS, etc.). Each has host, name, version, category, firstSeenDateTime, lastSeenDateTime. Use to identify vulnerable software versions running on infrastructure."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostSslCertificates",
     "method": "get",
     "toolName": "list-threat-intel-ssl-certs",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists SSL certificates observed on hosts. Each has host, sslCertificate (issuer, subject, serialNumber, sha256, validityPeriod), firstSeenDateTime, lastSeenDateTime. Useful for tracking certificate changes and detecting suspicious certificates."
   },
-
   {
     "pathPattern": "/invitations",
     "method": "get",
     "toolName": "list-invitations",
-    "appPermissions": ["User.Invite.All"],
+    "appPermissions": [
+      "User.Invite.All"
+    ],
     "llmTip": "Lists guest user invitations. Each has invitedUserEmailAddress, invitedUserDisplayName, inviteRedeemUrl, status (PendingAcceptance, Completed, InProgress, Error), sendInvitationMessage, and invitedUserType (Guest, Member). Use to audit pending and completed B2B invitations."
   },
   {
     "pathPattern": "/invitations",
     "method": "post",
     "toolName": "create-invitation",
-    "appPermissions": ["User.Invite.All"],
+    "appPermissions": [
+      "User.Invite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Creates a new guest user invitation. Body must include: invitedUserEmailAddress (required), inviteRedirectUrl (required, URL user lands on after redeeming). Optional: invitedUserDisplayName, sendInvitationMessage (true/false), invitedUserMessageInfo, invitedUserType ('Guest' or 'Member'). Returns inviteRedeemUrl and invitedUser object with the created user ID."
   },
-
   {
     "pathPattern": "/identity/identityProviders",
     "method": "get",
     "toolName": "list-identity-providers",
-    "appPermissions": ["IdentityProvider.Read.All"],
+    "appPermissions": [
+      "IdentityProvider.Read.All"
+    ],
     "llmTip": "Lists identity providers configured for the tenant. Includes social providers (Google, Facebook, Apple), SAML/WS-Fed, and built-in providers (Azure AD, Microsoft Account). Each has displayName, @odata.type, clientId. Useful for auditing which external identity providers are trusted for B2B/B2C."
   },
   {
     "pathPattern": "/identity/identityProviders/{identityProviderBase-id}",
     "method": "get",
     "toolName": "get-identity-provider",
-    "appPermissions": ["IdentityProvider.Read.All"],
+    "appPermissions": [
+      "IdentityProvider.Read.All"
+    ],
     "llmTip": "Gets a specific identity provider. Returns displayName, @odata.type, clientId, and provider-specific configuration."
   },
-
   {
     "pathPattern": "/identity/b2xUserFlows",
     "method": "get",
     "toolName": "list-b2x-user-flows",
-    "appPermissions": ["IdentityUserFlow.Read.All"],
+    "appPermissions": [
+      "IdentityUserFlow.Read.All"
+    ],
     "llmTip": "Lists B2X (self-service sign-up) user flows. Each has id, userFlowType (signUpOrSignIn), userFlowTypeVersion, and apiConnectorConfiguration. B2X user flows control how external users can sign up as guests through self-service."
   },
   {
     "pathPattern": "/identity/b2xUserFlows/{b2xIdentityUserFlow-id}",
     "method": "get",
     "toolName": "get-b2x-user-flow",
-    "appPermissions": ["IdentityUserFlow.Read.All"],
+    "appPermissions": [
+      "IdentityUserFlow.Read.All"
+    ],
     "llmTip": "Gets a specific B2X user flow. Returns full configuration including apiConnectorConfiguration, identityProviders, userAttributeAssignments, and languages."
   },
-
   {
     "pathPattern": "/identity/apiConnectors",
     "method": "get",
     "toolName": "list-api-connectors",
-    "appPermissions": ["APIConnectors.Read.All"],
+    "appPermissions": [
+      "APIConnectors.Read.All"
+    ],
     "llmTip": "Lists API connectors used in self-service sign-up user flows. Each has displayName, targetUrl, and authenticationConfiguration. API connectors call external APIs during sign-up (e.g. for validation, enrichment, or approval). Audit these to ensure no unauthorized external endpoints are called."
   },
   {
     "pathPattern": "/identity/apiConnectors/{identityApiConnector-id}",
     "method": "get",
     "toolName": "get-api-connector",
-    "appPermissions": ["APIConnectors.Read.All"],
+    "appPermissions": [
+      "APIConnectors.Read.All"
+    ],
     "llmTip": "Gets a specific API connector. Returns displayName, targetUrl, and authenticationConfiguration (basic auth or client certificate)."
   },
-
   {
     "pathPattern": "/identity/customAuthenticationExtensions",
     "method": "get",
     "toolName": "list-custom-auth-extensions",
-    "appPermissions": ["CustomAuthenticationExtension.Read.All"],
+    "appPermissions": [
+      "CustomAuthenticationExtension.Read.All"
+    ],
     "llmTip": "Lists custom authentication extensions. These are webhook-based extensions that can be called during authentication flows (token issuance, attribute collection). Each has displayName, @odata.type, authenticationConfiguration, endpointConfiguration (targetUrl). Audit these to ensure no unauthorized custom logic in auth flows."
   },
   {
     "pathPattern": "/identity/customAuthenticationExtensions/{customAuthenticationExtension-id}",
     "method": "get",
     "toolName": "get-custom-auth-extension",
-    "appPermissions": ["CustomAuthenticationExtension.Read.All"],
+    "appPermissions": [
+      "CustomAuthenticationExtension.Read.All"
+    ],
     "llmTip": "Gets a specific custom authentication extension. Returns displayName, authenticationConfiguration, endpointConfiguration, and claimsForTokenConfiguration."
   },
-
   {
     "pathPattern": "/applications/{application-id}",
     "method": "get",
     "toolName": "get-application",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Gets a specific app registration by object ID. Use $select=displayName,appId,passwordCredentials,keyCredentials,signInAudience,requiredResourceAccess to audit credentials and permissions. passwordCredentials shows client secrets with displayName, endDateTime, and keyId. keyCredentials shows certificates. CRITICAL: check endDateTime on credentials to find expiring or expired secrets/certs."
   },
   {
     "pathPattern": "/applications/{application-id}/owners",
     "method": "get",
     "toolName": "list-application-owners",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Lists owners of an app registration. Owners can manage the app including adding credentials. Returns user objects. Audit this to ensure apps have appropriate owners and no orphaned apps exist."
   },
   {
     "pathPattern": "/applications/{application-id}/federatedIdentityCredentials",
     "method": "get",
     "toolName": "list-app-federated-credentials",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Lists federated identity credentials for an app (workload identity federation). Each has name, issuer, subject, audiences, and description. These allow external workloads (GitHub Actions, Kubernetes, etc.) to authenticate as the app without a secret. Audit to ensure only authorized external identities are trusted."
   },
   {
     "pathPattern": "/applications/{application-id}/federatedIdentityCredentials/{federatedIdentityCredential-id}",
     "method": "get",
     "toolName": "get-app-federated-credential",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Gets a specific federated identity credential. Returns name, issuer (e.g. https://token.actions.githubusercontent.com), subject (e.g. repo:org/repo:ref:refs/heads/main), audiences, and description."
   },
-
   {
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}",
     "method": "get",
     "toolName": "get-service-principal",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Gets a specific service principal (enterprise app) by ID. Use $select=displayName,appId,passwordCredentials,keyCredentials,servicePrincipalType,accountEnabled,appOwnerOrganizationId,loginUrl,notificationEmailAddresses. Check passwordCredentials and keyCredentials for credential audit."
   },
   {
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}/owners",
     "method": "get",
     "toolName": "list-service-principal-owners",
-    "appPermissions": ["Application.Read.All"],
+    "appPermissions": [
+      "Application.Read.All"
+    ],
     "llmTip": "Lists owners of a service principal. Returns user objects. Owners can manage the enterprise app configuration. Audit for orphaned service principals with no owners."
   },
   {
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}/oauth2PermissionGrants",
     "method": "get",
     "toolName": "list-sp-delegated-permissions",
-    "appPermissions": ["Directory.Read.All"],
+    "appPermissions": [
+      "Directory.Read.All"
+    ],
     "llmTip": "Lists delegated permission grants for a specific service principal. Shows which delegated permissions have been consented (admin or user). Each has consentType (AllPrincipals for admin consent, Principal for user consent), scope (space-separated permissions), and principalId."
   },
-
   {
     "pathPattern": "/policies/appManagementPolicies",
     "method": "get",
     "toolName": "list-app-management-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists app management policies. These policies restrict credential types and lifetimes for app registrations and service principals. Each has displayName, isEnabled, restrictions (passwordCredentials, keyCredentials with restrictForAppsCreatedAfterDateTime and maxLifetime). Useful for enforcing credential hygiene."
   },
   {
     "pathPattern": "/policies/appManagementPolicies/{appManagementPolicy-id}",
     "method": "get",
     "toolName": "get-app-management-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets a specific app management policy. Returns displayName, isEnabled, and detailed restrictions on password and key credentials including maxLifetime and restrictForAppsCreatedAfterDateTime."
   },
-
   {
     "pathPattern": "/security/cases/ediscoveryCases",
     "method": "get",
     "toolName": "list-ediscovery-cases",
-    "appPermissions": ["eDiscovery.Read.All"],
+    "appPermissions": [
+      "eDiscovery.Read.All"
+    ],
     "llmTip": "Lists eDiscovery cases in Microsoft Purview. Each case has displayName, description, status (active, closed, closedWithError), createdBy, createdDateTime, lastModifiedBy, lastModifiedDateTime, and externalId. Use $filter=status eq 'active' to see active cases. Use $top to limit results."
   },
-
   {
     "pathPattern": "/communications/callRecords",
     "method": "get",
     "toolName": "list-call-records",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Lists Teams call records. Each record has id, version, type (groupCall, peerToPeer), modalities (audio, video, videoBasedScreenSharing, data), startDateTime, endDateTime, organizer, and participants. Use $filter=startDateTime ge 2024-01-01T00:00:00Z to filter by date. Use $orderby=startDateTime desc. Use $top to limit."
   },
-
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/cloudPCs",
     "method": "get",
     "toolName": "list-cloud-pcs",
-    "appPermissions": ["CloudPC.Read.All"],
+    "appPermissions": [
+      "CloudPC.Read.All"
+    ],
     "llmTip": "Lists Cloud PCs (Windows 365) provisioned in the tenant. Each has displayName, managedDeviceName, userPrincipalName, status (provisioned, provisioning, failed, notProvisioned), provisioningPolicyId, imageDisplayName, lastModifiedDateTime, gracePeriodEndDateTime, and aadDeviceId. Use $filter=status eq 'provisioned' or status eq 'failed'. Use $top to limit."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/provisioningPolicies",
     "method": "get",
     "toolName": "list-cloud-pc-provisioning-policies",
-    "appPermissions": ["CloudPC.Read.All"],
+    "appPermissions": [
+      "CloudPC.Read.All"
+    ],
     "llmTip": "Lists Cloud PC provisioning policies. Each has displayName, description, imageId, imageDisplayName, imageType, onPremisesConnectionId, domainJoinConfigurations, windowsSetting, and provisioningType. These define how Cloud PCs are provisioned for users."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/deviceImages",
     "method": "get",
     "toolName": "list-cloud-pc-device-images",
-    "appPermissions": ["CloudPC.Read.All"],
+    "appPermissions": [
+      "CloudPC.Read.All"
+    ],
     "llmTip": "Lists custom OS images uploaded for Cloud PC provisioning. Each has displayName, version, operatingSystem, osBuildNumber, sourceImageResourceId, status (readyForUpload, pending, failed), statusDetails, and lastModifiedDateTime."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/galleryImages",
     "method": "get",
     "toolName": "list-cloud-pc-gallery-images",
-    "appPermissions": ["CloudPC.Read.All"],
+    "appPermissions": [
+      "CloudPC.Read.All"
+    ],
     "llmTip": "Lists gallery images available from Microsoft for Cloud PC provisioning. Each has displayName, offerDisplayName, publisherName, skuDisplayName, skuName, status, startDate, endDate, and expirationDate."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/onPremisesConnections",
     "method": "get",
     "toolName": "list-cloud-pc-on-premises-connections",
-    "appPermissions": ["CloudPC.Read.All"],
+    "appPermissions": [
+      "CloudPC.Read.All"
+    ],
     "llmTip": "Lists Azure network connections used by Cloud PCs. Each has displayName, type (azureADJoin, hybridAzureADJoin), subscriptionId, resourceGroupId, virtualNetworkId, subnetId, healthCheckStatus (passed, failed, running, warning), and healthCheckStatusDetail."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/userSettings",
     "method": "get",
     "toolName": "list-cloud-pc-user-settings",
-    "appPermissions": ["CloudPC.Read.All"],
+    "appPermissions": [
+      "CloudPC.Read.All"
+    ],
     "llmTip": "Lists Cloud PC user settings. Each has displayName, selfServiceEnabled, localAdminEnabled, restorePointSetting (frequencyType, userRestoreEnabled), and lastModifiedDateTime. User settings control end-user permissions on their Cloud PCs."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/auditEvents",
     "method": "get",
     "toolName": "list-cloud-pc-audit-events",
-    "appPermissions": ["CloudPC.Read.All"],
+    "appPermissions": [
+      "CloudPC.Read.All"
+    ],
     "llmTip": "Lists Cloud PC audit events. Each has displayName, componentName, activity, activityDateTime, activityType (create, delete, patch), activityOperationType, activityResult (success, failure), actor, and resources. Use $filter=activityDateTime ge 2024-01-01T00:00:00Z. Use $orderby=activityDateTime desc."
   },
-
   {
     "pathPattern": "/print/printers",
     "method": "get",
     "toolName": "list-printers",
-    "appPermissions": ["Printer.Read.All"],
+    "appPermissions": [
+      "Printer.Read.All"
+    ],
     "llmTip": "Lists printers registered in Universal Print. Each has displayName, manufacturer, model, status (state: idle, processing, stopped, unknownFutureValue), isShared, isAcceptingJobs, location, defaults, and capabilities. Use $filter to narrow results."
   },
   {
     "pathPattern": "/print/shares",
     "method": "get",
     "toolName": "list-print-shares",
-    "appPermissions": ["PrintJob.Read.All"],
+    "appPermissions": [
+      "PrintJob.Read.All"
+    ],
     "llmTip": "Lists printer shares in Universal Print. Each has displayName, createdDateTime, isAcceptingJobs, status, printer, and allowedUsers/allowedGroups. Printer shares make printers discoverable to users."
   },
   {
     "pathPattern": "/print/connectors",
     "method": "get",
     "toolName": "list-print-connectors",
-    "appPermissions": ["PrintConnector.Read.All"],
+    "appPermissions": [
+      "PrintConnector.Read.All"
+    ],
     "llmTip": "Lists Universal Print connectors. Each has displayName, fullyQualifiedDomainName, operatingSystem, appVersion, deviceHealth (lastConnectionTime), location, and registeredDateTime. Connectors bridge on-premises printers to Universal Print."
   },
   {
     "pathPattern": "/print/services",
     "method": "get",
     "toolName": "list-print-services",
-    "appPermissions": ["PrintJob.Read.All"],
+    "appPermissions": [
+      "PrintJob.Read.All"
+    ],
     "llmTip": "Lists Universal Print service instances. Each has endpoints with displayName and uri. These represent the service endpoints used by Universal Print."
   },
   {
     "pathPattern": "/print/operations",
     "method": "get",
     "toolName": "list-print-operations",
-    "appPermissions": ["PrintJob.Read.All"],
+    "appPermissions": [
+      "PrintJob.Read.All"
+    ],
     "llmTip": "Lists long-running Universal Print operations. Each has status (state: notStarted, running, succeeded, failed), createdDateTime, and lastActionDateTime."
   },
   {
     "pathPattern": "/print/taskDefinitions",
     "method": "get",
     "toolName": "list-print-task-definitions",
-    "appPermissions": ["PrintJob.Read.All"],
+    "appPermissions": [
+      "PrintJob.Read.All"
+    ],
     "llmTip": "Lists Universal Print task definitions. Task definitions describe tasks that can be triggered on various print events (e.g., jobStarted)."
   },
-
   {
     "pathPattern": "/informationProtection/bitlocker/recoveryKeys",
     "method": "get",
     "toolName": "list-bitlocker-recovery-keys",
-    "appPermissions": ["BitlockerKey.Read.All"],
+    "appPermissions": [
+      "BitlockerKey.Read.All"
+    ],
     "llmTip": "Lists BitLocker recovery keys stored in Entra ID. Each has id, createdDateTime, deviceId, volumeType (operatingSystemVolume, fixedDataVolume, removableDataVolume). The actual key value is NOT returned by default for security; use $select=key to include it (requires BitlockerKey.ReadBasic.All or BitlockerKey.Read.All). Use $filter=deviceId eq 'xxx' to find keys for a specific device."
   },
   {
     "pathPattern": "/informationProtection/threatAssessmentRequests",
     "method": "get",
     "toolName": "list-threat-assessment-requests",
-    "appPermissions": ["ThreatAssessment.Read.All"],
+    "appPermissions": [
+      "ThreatAssessment.Read.All"
+    ],
     "llmTip": "Lists threat assessment requests. Each has id, createdDateTime, contentType (mail, url, file), expectedAssessment (block, unblock), category (spam, phishing, malware), status (pending, completed), requestSource, createdBy, and results (with resultType and message). Use $top to limit."
   },
-
   {
     "pathPattern": "/admin/sharepoint/settings",
     "method": "get",
     "toolName": "get-sharepoint-settings",
-    "appPermissions": ["SharePointTenantSettings.Read.All"],
+    "appPermissions": [
+      "SharePointTenantSettings.Read.All"
+    ],
     "llmTip": "Gets SharePoint tenant-level settings. Returns allowedDomainGuidsForSyncApp, availableManagedPathsForSiteCreation, deletedUserPersonalSiteRetentionPeriodInDays, excludedFileExtensionsForSyncApp, idleSessionSignOut, imageTaggingOption, isCommentingOnSitePagesEnabled, isFileActivityNotificationEnabled, isLoopEnabled, isMacSyncAppEnabled, isResharingByExternalUsersEnabled, isSharePointMobileNotificationEnabled, isSharePointNewsfeedEnabled, isSiteCreationEnabled, isSiteCreationUIEnabled, isSitePagesCreationEnabled, isSitesStorageLimitAutomatic, knowledgeIntelligenceEnabled, personalSiteDefaultStorageLimitInMB, sharingAllowedDomainList, sharingBlockedDomainList, sharingCapability, sharingDomainRestrictionMode, siteCreationDefaultManagedPath, siteCreationDefaultStorageLimitInMB, tenantDefaultTimezone."
   },
-
   {
     "pathPattern": "/security/labels/retentionLabels",
     "method": "get",
     "toolName": "list-retention-labels",
-    "appPermissions": ["RecordsManagement.Read.All"],
+    "appPermissions": [
+      "RecordsManagement.Read.All"
+    ],
     "llmTip": "Lists retention labels from Microsoft Purview Records Management. Each has displayName, descriptionForAdmins, descriptionForUsers, retentionDuration, retentionTrigger, behaviorDuringRetentionPeriod, actionAfterRetentionPeriod (none, delete, startDispositionReview), isInUse, createdDateTime, lastModifiedDateTime, and labelToBeApplied."
   },
   {
     "pathPattern": "/security/labels/authorities",
     "method": "get",
     "toolName": "list-file-plan-authorities",
-    "appPermissions": ["RecordsManagement.Read.All"],
+    "appPermissions": [
+      "RecordsManagement.Read.All"
+    ],
     "llmTip": "Lists file plan authorities used in retention labels. Each has displayName and id. Authorities represent the regulatory body or organizational authority behind a retention policy."
   },
   {
     "pathPattern": "/security/labels/categories",
     "method": "get",
     "toolName": "list-file-plan-categories",
-    "appPermissions": ["RecordsManagement.Read.All"],
+    "appPermissions": [
+      "RecordsManagement.Read.All"
+    ],
     "llmTip": "Lists file plan categories used in retention labels. Each has displayName and id. Categories classify the content type for records management."
   },
   {
     "pathPattern": "/security/labels/citations",
     "method": "get",
     "toolName": "list-file-plan-citations",
-    "appPermissions": ["RecordsManagement.Read.All"],
+    "appPermissions": [
+      "RecordsManagement.Read.All"
+    ],
     "llmTip": "Lists file plan citations used in retention labels. Each has displayName, citationUrl, citationJurisdiction, and id. Citations reference the regulation or law that requires the retention."
   },
   {
     "pathPattern": "/security/labels/departments",
     "method": "get",
     "toolName": "list-file-plan-departments",
-    "appPermissions": ["RecordsManagement.Read.All"],
+    "appPermissions": [
+      "RecordsManagement.Read.All"
+    ],
     "llmTip": "Lists file plan departments used in retention labels. Each has displayName and id. Departments identify which organizational unit owns the retention policy."
   },
   {
     "pathPattern": "/security/labels/filePlanReferences",
     "method": "get",
     "toolName": "list-file-plan-references",
-    "appPermissions": ["RecordsManagement.Read.All"],
+    "appPermissions": [
+      "RecordsManagement.Read.All"
+    ],
     "llmTip": "Lists file plan references used in retention labels. Each has displayName and id. File plan references provide a unique identifier or reference number for the retention policy within the organization's file plan."
   },
-
   {
     "pathPattern": "/deviceManagement/reports/getDeviceNonComplianceReport",
     "method": "post",
     "toolName": "intune-device-noncompliance-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates an Intune device non-compliance report. POST body: {\"name\":\"DeviceNonCompliance\",\"filter\":\"(PolicyId eq 'xxx')\",\"select\":[\"DeviceName\",\"UPN\",\"ComplianceState\"],\"top\":50}. Returns device-level compliance status."
   },
@@ -1488,7 +1838,9 @@
     "pathPattern": "/deviceManagement/reports/getCompliancePolicyNonComplianceReport",
     "method": "post",
     "toolName": "intune-compliance-policy-noncompliance-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a report of devices non-compliant with a specific compliance policy. POST body: {\"name\":\"CompliancePolicyNonCompliance\",\"filter\":\"(PolicyId eq 'xxx')\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\",\"State\"],\"top\":50}."
   },
@@ -1496,7 +1848,9 @@
     "pathPattern": "/deviceManagement/reports/getCompliancePolicyNonComplianceSummaryReport",
     "method": "post",
     "toolName": "intune-compliance-policy-noncompliance-summary",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a summary of non-compliance by compliance policy. POST body: {\"name\":\"CompliancePolicyNonComplianceSummary\",\"select\":[\"PolicyName\",\"NonCompliantDeviceCount\",\"ErrorDeviceCount\"],\"top\":50}."
   },
@@ -1504,7 +1858,9 @@
     "pathPattern": "/deviceManagement/reports/getComplianceSettingNonComplianceReport",
     "method": "post",
     "toolName": "intune-compliance-setting-noncompliance-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a report of devices non-compliant for a specific compliance setting. POST body: {\"name\":\"ComplianceSettingNonCompliance\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\",\"CurrentValue\"],\"top\":50}."
   },
@@ -1512,7 +1868,9 @@
     "pathPattern": "/deviceManagement/reports/getConfigurationPolicyNonComplianceReport",
     "method": "post",
     "toolName": "intune-config-policy-noncompliance-report",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a report of devices non-compliant with a device configuration policy. POST body: {\"name\":\"ConfigurationPolicyNonCompliance\",\"filter\":\"(PolicyId eq 'xxx')\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\",\"State\"],\"top\":50}."
   },
@@ -1520,7 +1878,9 @@
     "pathPattern": "/deviceManagement/reports/getConfigurationPolicyNonComplianceSummaryReport",
     "method": "post",
     "toolName": "intune-config-policy-noncompliance-summary",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a summary of non-compliance by device configuration policy. POST body: {\"name\":\"ConfigurationPolicyNonComplianceSummary\",\"select\":[\"PolicyName\",\"NonCompliantDeviceCount\"],\"top\":50}."
   },
@@ -1528,7 +1888,9 @@
     "pathPattern": "/deviceManagement/reports/getConfigurationSettingNonComplianceReport",
     "method": "post",
     "toolName": "intune-config-setting-noncompliance-report",
-    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a report of devices non-compliant for a specific configuration setting. POST body: {\"name\":\"ConfigurationSettingNonCompliance\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\"],\"top\":50}."
   },
@@ -1536,7 +1898,9 @@
     "pathPattern": "/deviceManagement/reports/getDevicesWithoutCompliancePolicyReport",
     "method": "post",
     "toolName": "intune-devices-without-compliance-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a report of managed devices that have no compliance policy assigned. POST body: {\"name\":\"DevicesWithoutCompliancePolicy\",\"select\":[\"DeviceName\",\"UPN\",\"OS\"],\"top\":50}. Useful for identifying compliance coverage gaps."
   },
@@ -1544,7 +1908,9 @@
     "pathPattern": "/deviceManagement/reports/getNoncompliantDevicesAndSettingsReport",
     "method": "post",
     "toolName": "intune-noncompliant-devices-settings-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a combined report of non-compliant devices and the settings they violate. POST body: {\"name\":\"NoncompliantDevicesAndSettings\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\",\"State\"],\"top\":50}."
   },
@@ -1552,7 +1918,9 @@
     "pathPattern": "/deviceManagement/reports/getPolicyNonComplianceReport",
     "method": "post",
     "toolName": "intune-policy-noncompliance-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a general policy non-compliance report. POST body: {\"name\":\"PolicyNonCompliance\",\"select\":[\"PolicyName\",\"DeviceName\",\"UPN\",\"ComplianceState\"],\"top\":50}."
   },
@@ -1560,7 +1928,9 @@
     "pathPattern": "/deviceManagement/reports/getPolicyNonComplianceSummaryReport",
     "method": "post",
     "toolName": "intune-policy-noncompliance-summary",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a summary of non-compliance across all policies. POST body: {\"name\":\"PolicyNonComplianceSummary\",\"select\":[\"PolicyName\",\"NonCompliantDeviceCount\",\"ErrorDeviceCount\"],\"top\":50}."
   },
@@ -1568,7 +1938,9 @@
     "pathPattern": "/deviceManagement/reports/getPolicyNonComplianceMetadata",
     "method": "post",
     "toolName": "intune-policy-noncompliance-metadata",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Gets metadata about policy non-compliance (available columns and filters). POST body: {\"name\":\"PolicyNonComplianceMetadata\"}. Useful before generating other reports to discover available fields."
   },
@@ -1576,7 +1948,9 @@
     "pathPattern": "/deviceManagement/reports/getSettingNonComplianceReport",
     "method": "post",
     "toolName": "intune-setting-noncompliance-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a report of non-compliance grouped by setting. POST body: {\"name\":\"SettingNonCompliance\",\"select\":[\"SettingName\",\"NonCompliantDeviceCount\"],\"top\":50}."
   },
@@ -1584,7 +1958,9 @@
     "pathPattern": "/deviceManagement/reports/getReportFilters",
     "method": "post",
     "toolName": "intune-report-filters",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Gets available report filters for Intune reports. POST body: {\"name\":\"ReportName\"}. Returns available filter values. Use before other report endpoints to discover filter options."
   },
@@ -1592,7 +1968,9 @@
     "pathPattern": "/deviceManagement/reports/getHistoricalReport",
     "method": "post",
     "toolName": "intune-historical-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a historical Intune report. POST body: {\"name\":\"ReportName\",\"filter\":\"...\",\"select\":[...],\"top\":50}. Provides point-in-time data for trend analysis."
   },
@@ -1600,7 +1978,9 @@
     "pathPattern": "/deviceManagement/reports/getCachedReport",
     "method": "post",
     "toolName": "intune-cached-report",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Retrieves a previously generated cached Intune report by ID. POST body: {\"id\":\"report-id\",\"select\":[...],\"top\":50}. Faster than regenerating reports."
   },
@@ -1608,399 +1988,505 @@
     "pathPattern": "/deviceManagement/reports/exportJobs",
     "method": "get",
     "toolName": "list-intune-report-export-jobs",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Lists Intune report export jobs. Each has id, reportName, status (notStarted, inProgress, completed), requestDateTime, and url (download link when completed)."
   },
   {
     "pathPattern": "/deviceManagement/reports/retrieveDeviceAppInstallationStatusReport",
     "method": "post",
     "toolName": "intune-device-app-install-status-report",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Generates a report of app installation status per device. POST body: {\"name\":\"DeviceAppInstallationStatus\",\"filter\":\"(AppId eq 'xxx')\",\"select\":[\"DeviceName\",\"UPN\",\"AppName\",\"InstallState\"],\"top\":50}."
   },
-
   {
     "pathPattern": "/deviceManagement/complianceManagementPartners",
     "method": "get",
     "toolName": "list-compliance-management-partners",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Lists compliance management partners integrated with Intune. Each has displayName, partnerState, and supported platforms."
   },
   {
     "pathPattern": "/deviceManagement/deviceManagementPartners",
     "method": "get",
     "toolName": "list-device-management-partners",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Lists device management partners (DEP, Jamf, etc.) integrated with Intune. Each has displayName, partnerState, isConfigured, and partnerAppType."
   },
   {
     "pathPattern": "/deviceManagement/exchangeConnectors",
     "method": "get",
     "toolName": "list-exchange-connectors",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists Exchange connectors for Intune on-premises Exchange integration. Each has connectorName, status, serverName, exchangeConnectorType, and version."
   },
   {
     "pathPattern": "/deviceManagement/remoteAssistancePartners",
     "method": "get",
     "toolName": "list-remote-assistance-partners",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists remote assistance partners (TeamViewer, etc.) integrated with Intune. Each has displayName, onboardingStatus, and lastConnectionDateTime."
   },
   {
     "pathPattern": "/deviceManagement/notificationMessageTemplates",
     "method": "get",
     "toolName": "list-notification-message-templates",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists Intune notification message templates. These are compliance notification templates sent to users when their devices are non-compliant. Each has displayName, defaultLocale, brandingOptions, and roleScopeTagIds."
   },
   {
     "pathPattern": "/deviceManagement/resourceOperations",
     "method": "get",
     "toolName": "list-intune-resource-operations",
-    "appPermissions": ["DeviceManagementRBAC.Read.All"],
+    "appPermissions": [
+      "DeviceManagementRBAC.Read.All"
+    ],
     "llmTip": "Lists Intune RBAC resource operations. Each has resourceName, actionName, and description. Shows all available operations that can be assigned to Intune roles."
   },
   {
     "pathPattern": "/deviceManagement/importedWindowsAutopilotDeviceIdentities",
     "method": "get",
     "toolName": "list-imported-autopilot-devices",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists imported Windows Autopilot device identities. Each has serialNumber, productKey, hardwareIdentifier, state (importState), and importedDateTime. Use to track Autopilot device import status."
   },
   {
     "pathPattern": "/deviceManagement/windowsMalwareInformation",
     "method": "get",
     "toolName": "list-windows-malware-info",
-    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.Read.All"
+    ],
     "llmTip": "Lists Windows malware information detected across Intune-managed devices. Each has displayName, category, severity, additionalInformationUrl, and deviceMalwareStates. Use for threat landscape visibility."
   },
-
   {
     "pathPattern": "/deviceAppManagement/mobileApps",
     "method": "get",
     "toolName": "list-intune-mobile-apps",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists mobile apps managed by Intune. Each has displayName, publisher, createdDateTime, lastModifiedDateTime, isAssigned, isFeatured, publishingState. Includes Win32, iOS, Android, macOS, and web apps. Use $filter=isAssigned eq true to see assigned apps."
   },
   {
     "pathPattern": "/deviceAppManagement/mobileAppCategories",
     "method": "get",
     "toolName": "list-intune-app-categories",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists Intune mobile app categories. Each has displayName and id. Categories help organize apps in the Company Portal."
   },
   {
     "pathPattern": "/deviceAppManagement/mobileAppConfigurations",
     "method": "get",
     "toolName": "list-intune-app-configurations",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists Intune app configuration policies. Each has displayName, description, targetedMobileApps, settings, and createdDateTime. Used to push configuration to managed apps."
   },
   {
     "pathPattern": "/deviceAppManagement/managedAppPolicies",
     "method": "get",
     "toolName": "list-managed-app-policies",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists Intune managed app protection policies (MAM). Each has displayName, description, createdDateTime, version. Shows all app protection policies across platforms."
   },
   {
     "pathPattern": "/deviceAppManagement/managedAppRegistrations",
     "method": "get",
     "toolName": "list-managed-app-registrations",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists managed app registrations. Each registration represents a user+device+app combination where MAM policy applies. Has appIdentifier, createdDateTime, deviceName, managementSdkVersion, and userId."
   },
   {
     "pathPattern": "/deviceAppManagement/managedAppStatuses",
     "method": "get",
     "toolName": "list-managed-app-statuses",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists managed app status reports. Returns status summaries for Intune app protection policies including deployment and user status."
   },
   {
     "pathPattern": "/deviceAppManagement/androidManagedAppProtections",
     "method": "get",
     "toolName": "list-android-app-protections",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists Android managed app protection policies (MAM). Each has displayName, description, periodOfflineBeforeWipeIsEnforced, pinRequired, minimumPinLength, managedBrowser, allowedDataStorageLocations, and organizationalCredentialsRequired."
   },
   {
     "pathPattern": "/deviceAppManagement/iosManagedAppProtections",
     "method": "get",
     "toolName": "list-ios-app-protections",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists iOS managed app protection policies (MAM). Each has displayName, description, periodOfflineBeforeWipeIsEnforced, pinRequired, minimumPinLength, faceIdBlocked, and allowedDataStorageLocations."
   },
   {
     "pathPattern": "/deviceAppManagement/defaultManagedAppProtections",
     "method": "get",
     "toolName": "list-default-app-protections",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists default managed app protection policies. These are cross-platform MAM policies that apply when no platform-specific policy exists."
   },
   {
     "pathPattern": "/deviceAppManagement/targetedManagedAppConfigurations",
     "method": "get",
     "toolName": "list-targeted-app-configurations",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists targeted managed app configuration policies. Each has displayName, description, targetedMobileApps, customSettings, and isAssigned. These push configuration to specific groups of users."
   },
   {
     "pathPattern": "/deviceAppManagement/mdmWindowsInformationProtectionPolicies",
     "method": "get",
     "toolName": "list-mdm-wip-policies",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists MDM Windows Information Protection (WIP) policies. Each has displayName, enforcementLevel, protectedApps, exemptApps, enterpriseNetworkDomainNames, and enterpriseProtectedDomainNames."
   },
   {
     "pathPattern": "/deviceAppManagement/windowsInformationProtectionPolicies",
     "method": "get",
     "toolName": "list-mam-wip-policies",
-    "appPermissions": ["DeviceManagementApps.Read.All"],
+    "appPermissions": [
+      "DeviceManagementApps.Read.All"
+    ],
     "llmTip": "Lists MAM Windows Information Protection (WIP) policies (without MDM enrollment). Each has displayName, enforcementLevel, protectedApps, exemptApps, and isAssigned."
   },
   {
     "pathPattern": "/deviceAppManagement/vppTokens",
     "method": "get",
     "toolName": "list-vpp-tokens",
-    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
+    "appPermissions": [
+      "DeviceManagementServiceConfig.Read.All"
+    ],
     "llmTip": "Lists Apple Volume Purchase Program (VPP) tokens. Each has organizationName, appleId, state (valid, expired, invalid), expirationDateTime, lastSyncDateTime, lastSyncStatus, and automaticallyUpdateApps."
   },
-
   {
     "pathPattern": "/policies/activityBasedTimeoutPolicies",
     "method": "get",
     "toolName": "list-activity-timeout-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists activity-based timeout policies. These enforce idle session timeout for web applications. Each has displayName, isOrganizationDefault, and definition (JSON with ActivityBasedTimeoutPolicy settings)."
   },
   {
     "pathPattern": "/policies/authorizationPolicy",
     "method": "get",
     "toolName": "get-authorization-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the tenant authorization policy. Returns allowedToSignUpEmailBasedSubscriptions, allowedToUseSSPR, allowEmailVerifiedUsersToJoinOrganization, allowInvitesFrom, blockMsolPowerShell, defaultUserRolePermissions (allowedToCreateApps, allowedToCreateSecurityGroups, allowedToReadBitlockerKeysForOwnedDevice, allowedToReadOtherUsers), and guestUserRoleId."
   },
   {
     "pathPattern": "/policies/authenticationFlowsPolicy",
     "method": "get",
     "toolName": "get-auth-flows-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the authentication flows policy. Returns selfServiceSignUp configuration (isEnabled) which controls whether external users can sign up via user flows."
   },
   {
     "pathPattern": "/policies/claimsMappingPolicies",
     "method": "get",
     "toolName": "list-claims-mapping-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists claims mapping policies. These customize token claims for specific applications. Each has displayName, isOrganizationDefault, and definition (JSON with ClaimsMappingPolicy including IncludeBasicClaimSet and ClaimsSchema)."
   },
   {
     "pathPattern": "/policies/conditionalAccessPolicies",
     "method": "get",
     "toolName": "list-conditional-access-policies-v2",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists all conditional access policies using the policies endpoint. Each has displayName, state (enabled, disabled, enabledForReportingButNotEnforced), conditions, grantControls, and sessionControls. Alternative to list-conditional-access-policies."
   },
   {
     "pathPattern": "/policies/defaultAppManagementPolicy",
     "method": "get",
     "toolName": "get-default-app-management-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the default app management policy for the tenant. Returns the default restrictions on password and key credentials for app registrations and service principals when no specific policy is assigned."
   },
   {
     "pathPattern": "/policies/deviceRegistrationPolicy",
     "method": "get",
     "toolName": "get-device-registration-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the device registration policy. Returns multiFactorAuthConfiguration, azureADRegistration (allowedToRegister, isAdminConfigurable), azureADJoin (allowedToJoin, isAdminConfigurable), and localAdminPassword settings. Critical for controlling which users can join/register devices."
   },
   {
     "pathPattern": "/policies/featureRolloutPolicies",
     "method": "get",
     "toolName": "list-feature-rollout-policies",
-    "appPermissions": ["Directory.Read.All"],
+    "appPermissions": [
+      "Directory.Read.All"
+    ],
     "llmTip": "Lists feature rollout policies. These enable staged rollout of Entra ID features (like passwordHashSync, seamlessSSO, passthroughAuthentication) to specific groups before tenant-wide enablement. Each has displayName, feature, isEnabled, and isAppliedToOrganization."
   },
   {
     "pathPattern": "/policies/homeRealmDiscoveryPolicies",
     "method": "get",
     "toolName": "list-home-realm-discovery-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists home realm discovery policies. These control authentication behavior for federated domains (auto-acceleration, preferred domain, etc.). Each has displayName, isOrganizationDefault, and definition (JSON with HomeRealmDiscoveryPolicy)."
   },
   {
     "pathPattern": "/policies/permissionGrantPolicies",
     "method": "get",
     "toolName": "list-permission-grant-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists permission grant policies. These control which permissions users/admins can consent to. Each has displayName, includes (conditions that match), and excludes (conditions that block). Critical for app consent security."
   },
   {
     "pathPattern": "/policies/roleManagementPolicies",
     "method": "get",
     "toolName": "list-role-management-policies",
-    "appPermissions": ["RoleManagementPolicy.Read.Directory"],
+    "appPermissions": [
+      "RoleManagementPolicy.Read.Directory"
+    ],
     "llmTip": "Lists PIM role management policies. Each policy defines activation rules (MFA, justification, approval, max duration), assignment rules (permanent eligible/active, expiration), and notification rules for a specific role. Use $expand=rules to see all settings."
   },
   {
     "pathPattern": "/policies/roleManagementPolicyAssignments",
     "method": "get",
     "toolName": "list-role-management-policy-assignments",
-    "appPermissions": ["RoleManagementPolicy.Read.Directory"],
+    "appPermissions": [
+      "RoleManagementPolicy.Read.Directory"
+    ],
     "llmTip": "Lists PIM role management policy assignments. Links policies to specific roles. Each has policyId, scopeId, scopeType, and roleDefinitionId. Use $expand=policy($expand=rules) to include the full policy details."
   },
   {
     "pathPattern": "/policies/tokenIssuancePolicies",
     "method": "get",
     "toolName": "list-token-issuance-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists token issuance policies. These control how SAML tokens are issued (token format, signing algorithm, etc.). Each has displayName, isOrganizationDefault, and definition."
   },
   {
     "pathPattern": "/policies/tokenLifetimePolicies",
     "method": "get",
     "toolName": "list-token-lifetime-policies",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists token lifetime policies. These override default token lifetimes for specific applications. Each has displayName, isOrganizationDefault, and definition (JSON with TokenLifetimePolicy including AccessTokenLifetime and MaxAgeSessionSingleFactor)."
   },
   {
     "pathPattern": "/policies/crossTenantAccessPolicy/default",
     "method": "get",
     "toolName": "get-cross-tenant-default-policy",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Gets the default cross-tenant access policy. Returns the default inbound/outbound settings (b2bCollaboration, b2bDirectConnect, organizationDefault) that apply to all tenants not covered by a partner-specific policy. Critical for controlling external collaboration defaults."
   },
-
   {
     "pathPattern": "/identityGovernance/entitlementManagement/assignmentPolicies",
     "method": "get",
     "toolName": "list-entitlement-assignment-policies",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Lists entitlement management assignment policies. Each defines who can request an access package, approval requirements, and access review settings. Has displayName, accessPackageId, requestApprovalSettings, requestorSettings, and reviewSettings."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/resources",
     "method": "get",
     "toolName": "list-entitlement-resources",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Lists resources available in entitlement management catalogs. Resources are groups, apps, or SharePoint sites that can be included in access packages."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/resourceEnvironments",
     "method": "get",
     "toolName": "list-entitlement-resource-environments",
-    "appPermissions": ["EntitlementManagement.Read.All"],
+    "appPermissions": [
+      "EntitlementManagement.Read.All"
+    ],
     "llmTip": "Lists resource environments in entitlement management. Environments represent connected systems (like other tenants) that provide resources for access packages."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/workflowTemplates",
     "method": "get",
     "toolName": "list-lifecycle-workflow-templates",
-    "appPermissions": ["LifecycleWorkflows.Read.All"],
+    "appPermissions": [
+      "LifecycleWorkflows.Read.All"
+    ],
     "llmTip": "Lists available lifecycle workflow templates. Templates provide pre-built workflows for common scenarios (onboarding, offboarding, job change). Each has displayName, description, category (joiner, leaver, mover), and executionConditions."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/settings",
     "method": "get",
     "toolName": "get-lifecycle-workflow-settings",
-    "appPermissions": ["LifecycleWorkflows.Read.All"],
+    "appPermissions": [
+      "LifecycleWorkflows.Read.All"
+    ],
     "llmTip": "Gets lifecycle workflows global settings. Returns workflowScheduleIntervalInHours (how often workflows are evaluated) and emailSettings."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/customTaskExtensions",
     "method": "get",
     "toolName": "list-lifecycle-custom-task-extensions",
-    "appPermissions": ["LifecycleWorkflows.Read.All"],
+    "appPermissions": [
+      "LifecycleWorkflows.Read.All"
+    ],
     "llmTip": "Lists custom task extensions for lifecycle workflows. These are Logic App-based custom actions that can be added to workflow steps. Each has displayName, endpointConfiguration, callbackConfiguration, and createdDateTime."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/deletedItems/workflows",
     "method": "get",
     "toolName": "list-deleted-lifecycle-workflows",
-    "appPermissions": ["LifecycleWorkflows.Read.All"],
+    "appPermissions": [
+      "LifecycleWorkflows.Read.All"
+    ],
     "llmTip": "Lists recently deleted lifecycle workflows. Deleted workflows can be restored within 30 days. Each has displayName, category, deletedDateTime."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/assignmentScheduleRequests",
     "method": "get",
     "toolName": "list-pim-group-assignment-requests",
-    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
+    "appPermissions": [
+      "PrivilegedAccess.Read.AzureADGroup"
+    ],
     "llmTip": "Lists PIM for Groups assignment schedule requests. Each request represents an activation or assignment operation. Has action (adminAssign, adminRemove, selfActivate, selfDeactivate), principalId, groupId, accessId (member, owner), scheduleInfo, and status."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/assignmentScheduleInstances",
     "method": "get",
     "toolName": "list-pim-group-assignment-instances",
-    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
+    "appPermissions": [
+      "PrivilegedAccess.Read.AzureADGroup"
+    ],
     "llmTip": "Lists active PIM for Groups assignment instances. Shows who currently has active (not just eligible) group membership/ownership via PIM. Has principalId, groupId, accessId, assignmentType (assigned, activated), startDateTime, endDateTime."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/eligibilityScheduleRequests",
     "method": "get",
     "toolName": "list-pim-group-eligibility-requests",
-    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
+    "appPermissions": [
+      "PrivilegedAccess.Read.AzureADGroup"
+    ],
     "llmTip": "Lists PIM for Groups eligibility schedule requests. Shows requests to make users eligible for group membership/ownership. Has action, principalId, groupId, accessId, scheduleInfo, and status."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/eligibilityScheduleInstances",
     "method": "get",
     "toolName": "list-pim-group-eligibility-instances",
-    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
+    "appPermissions": [
+      "PrivilegedAccess.Read.AzureADGroup"
+    ],
     "llmTip": "Lists active PIM for Groups eligibility instances. Shows who is currently eligible to activate group membership/ownership. Has principalId, groupId, accessId, startDateTime, endDateTime, and memberType."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/historyDefinitions",
     "method": "get",
     "toolName": "list-access-review-history",
-    "appPermissions": ["AccessReview.Read.All"],
+    "appPermissions": [
+      "AccessReview.Read.All"
+    ],
     "llmTip": "Lists access review history definitions. These are scheduled exports of access review decisions. Each has displayName, reviewHistoryPeriodStartDateTime, reviewHistoryPeriodEndDateTime, status, and decisions (approve, deny, dontKnow, notReviewed)."
   },
-
   {
     "pathPattern": "/roleManagement/directory/roleAssignmentScheduleRequests",
     "method": "get",
     "toolName": "list-pim-role-assignment-requests",
-    "appPermissions": ["RoleAssignmentSchedule.Read.Directory"],
+    "appPermissions": [
+      "RoleAssignmentSchedule.Read.Directory"
+    ],
     "llmTip": "Lists PIM role assignment schedule requests. Each request represents an activation or assignment of a directory role. Has action (adminAssign, adminRemove, selfActivate, selfDeactivate), principalId, roleDefinitionId, directoryScopeId, scheduleInfo, and status."
   },
   {
     "pathPattern": "/roleManagement/directory/roleAssignmentSchedules",
     "method": "get",
     "toolName": "list-pim-role-assignment-schedules",
-    "appPermissions": ["RoleAssignmentSchedule.Read.Directory"],
+    "appPermissions": [
+      "RoleAssignmentSchedule.Read.Directory"
+    ],
     "llmTip": "Lists PIM role assignment schedules. Shows the schedule (start/end dates) for active role assignments. Has principalId, roleDefinitionId, directoryScopeId, assignmentType (assigned, activated), scheduleInfo, and memberType."
   },
   {
     "pathPattern": "/roleManagement/directory/roleEligibilityScheduleRequests",
     "method": "get",
     "toolName": "list-pim-role-eligibility-requests",
-    "appPermissions": ["RoleEligibilitySchedule.Read.Directory"],
+    "appPermissions": [
+      "RoleEligibilitySchedule.Read.Directory"
+    ],
     "llmTip": "Lists PIM role eligibility schedule requests. Shows requests to make users eligible for directory roles. Has action, principalId, roleDefinitionId, directoryScopeId, scheduleInfo, and status."
   },
   {
     "pathPattern": "/roleManagement/directory/roleEligibilitySchedules",
     "method": "get",
     "toolName": "list-pim-role-eligibility-schedules",
-    "appPermissions": ["RoleEligibilitySchedule.Read.Directory"],
+    "appPermissions": [
+      "RoleEligibilitySchedule.Read.Directory"
+    ],
     "llmTip": "Lists PIM role eligibility schedules. Shows all users currently eligible to activate directory roles with their schedule details. Has principalId, roleDefinitionId, directoryScopeId, scheduleInfo, and memberType."
   },
   {
     "pathPattern": "/roleManagement/directory/resourceNamespaces",
     "method": "get",
     "toolName": "list-role-resource-namespaces",
-    "appPermissions": ["RoleManagement.Read.Directory"],
+    "appPermissions": [
+      "RoleManagement.Read.Directory"
+    ],
     "llmTip": "Lists RBAC resource namespaces for directory roles. Each namespace represents a resource provider (microsoft.directory, microsoft.aad.b2c, etc.) with resourceActions defining available permissions."
   },
-
   {
     "pathPattern": "/identityProtection/riskyServicePrincipals/confirmCompromised",
     "method": "post",
     "toolName": "confirm-compromised-service-principals",
-    "appPermissions": ["IdentityRiskyServicePrincipal.ReadWrite.All"],
+    "appPermissions": [
+      "IdentityRiskyServicePrincipal.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Confirms one or more service principals as compromised. Body: {\"servicePrincipalIds\":[\"sp-id-1\"]}. Sets riskState to confirmedCompromised. Use after investigating a risky service principal and confirming the threat is real."
   },
@@ -2008,7 +2494,9 @@
     "pathPattern": "/identityProtection/riskyServicePrincipals/dismiss",
     "method": "post",
     "toolName": "dismiss-risky-service-principals",
-    "appPermissions": ["IdentityRiskyServicePrincipal.ReadWrite.All"],
+    "appPermissions": [
+      "IdentityRiskyServicePrincipal.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Dismisses risk for one or more service principals. Body: {\"servicePrincipalIds\":[\"sp-id-1\"]}. Sets riskState to dismissed. Use after investigating and determining the risk is a false positive."
   },
@@ -2016,23 +2504,28 @@
     "pathPattern": "/identityProtection/servicePrincipalRiskDetections",
     "method": "get",
     "toolName": "list-service-principal-risk-detections",
-    "appPermissions": ["IdentityRiskEvent.Read.All"],
+    "appPermissions": [
+      "IdentityRiskEvent.Read.All"
+    ],
     "llmTip": "Lists risk detections for service principals. Each has riskEventType, riskLevel, riskState, riskDetail, detectedDateTime, activity, source, servicePrincipalId, and appId. Use $filter=riskState eq 'atRisk' to see active risks."
   },
   {
     "pathPattern": "/identityProtection/riskyUsers/confirmSafe",
     "method": "post",
     "toolName": "confirm-safe-users",
-    "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
+    "appPermissions": [
+      "IdentityRiskyUser.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Confirms one or more users as safe (not compromised). Body: {\"userIds\":[\"user-id-1\"]}. Sets riskState to remediated. Use after investigating a risky user and confirming the account is not compromised."
   },
-
   {
     "pathPattern": "/security/microsoft.graph.security.runHuntingQuery",
     "method": "post",
     "toolName": "run-hunting-query",
-    "appPermissions": ["ThreatHunting.Read.All"],
+    "appPermissions": [
+      "ThreatHunting.Read.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Runs an advanced hunting query using KQL (Kusto Query Language) against Microsoft 365 Defender data. Body: {\"query\":\"DeviceProcessEvents | where Timestamp > ago(1d) | take 10\"}. Tables include DeviceEvents, DeviceProcessEvents, DeviceNetworkEvents, DeviceFileEvents, EmailEvents, AlertEvidence, IdentityLogonEvents, CloudAppEvents. Powerful for threat investigation."
   },
@@ -2040,235 +2533,288 @@
     "pathPattern": "/security/identities/healthIssues",
     "method": "get",
     "toolName": "list-identity-health-issues",
-    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
+    "appPermissions": [
+      "SecurityIdentitiesHealth.Read.All"
+    ],
     "llmTip": "Lists Microsoft Defender for Identity health issues. Each has healthIssueType, severity (low, medium, high), displayName, description, recommendedActionCommands, status (open, closed, suppressed), domainName, sensorDNSName, and issueTypeId. Use to monitor Defender for Identity sensor health."
   },
   {
     "pathPattern": "/security/identities/sensors",
     "method": "get",
     "toolName": "list-identity-sensors",
-    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
+    "appPermissions": [
+      "SecurityIdentitiesHealth.Read.All"
+    ],
     "llmTip": "Lists Microsoft Defender for Identity sensors. Each has displayName, sensorType (adConnectIntegrated, adcsIntegrated, adfsIntegrated, domainControllerIntegrated), healthStatus (healthy, notHealthy, offline), openHealthIssuesCount, domainName, version, and deploymentStatus."
   },
   {
     "pathPattern": "/security/identities/settings",
     "method": "get",
     "toolName": "get-identity-security-settings",
-    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
+    "appPermissions": [
+      "SecurityIdentitiesHealth.Read.All"
+    ],
     "llmTip": "Gets Microsoft Defender for Identity global settings. Returns configuration for identity-based threat detection."
   },
   {
     "pathPattern": "/security/triggers/retentionEvents",
     "method": "get",
     "toolName": "list-retention-events",
-    "appPermissions": ["RecordsManagement.Read.All"],
+    "appPermissions": [
+      "RecordsManagement.Read.All"
+    ],
     "llmTip": "Lists retention events that trigger event-based retention labels. Each has displayName, description, eventTriggerDateTime, retentionEventType, createdDateTime, and status. These events start the retention period for event-based labels."
   },
   {
     "pathPattern": "/security/triggerTypes/retentionEventTypes",
     "method": "get",
     "toolName": "list-retention-event-types",
-    "appPermissions": ["RecordsManagement.Read.All"],
+    "appPermissions": [
+      "RecordsManagement.Read.All"
+    ],
     "llmTip": "Lists retention event types. Each has displayName, description, and createdDateTime. Event types categorize retention events (e.g., 'Employee Departure', 'Contract Expiration')."
   },
   {
     "pathPattern": "/security/subjectRightsRequests",
     "method": "get",
     "toolName": "list-subject-rights-requests",
-    "appPermissions": ["SubjectRightsRequest.Read.All"],
+    "appPermissions": [
+      "SubjectRightsRequest.Read.All"
+    ],
     "llmTip": "Lists data subject rights requests (DSAR) for privacy compliance. Each has displayName, type (access, delete, export, tagForAction), status (active, closed), dataSubjectType, createdDateTime, createdBy, stages, and regulation. Used for GDPR/privacy compliance."
   },
   {
     "pathPattern": "/security/attackSimulation/simulationAutomations",
     "method": "get",
     "toolName": "list-simulation-automations",
-    "appPermissions": ["AttackSimulation.Read.All"],
+    "appPermissions": [
+      "AttackSimulation.Read.All"
+    ],
     "llmTip": "Lists attack simulation automations. Each has displayName, description, status (enabled, disabled, notRunning), createdDateTime, lastRunDateTime, nextRunDateTime, and attackType. These automate recurring phishing simulations."
   },
   {
     "pathPattern": "/security/attackSimulation/trainings",
     "method": "get",
     "toolName": "list-simulation-trainings",
-    "appPermissions": ["AttackSimulation.Read.All"],
+    "appPermissions": [
+      "AttackSimulation.Read.All"
+    ],
     "llmTip": "Lists available training content for attack simulations. Each has displayName, description, source (microsoft, global, tenant), type (assigned, notAssigned, unknown), availabilityStatus, durationInMinutes, and supportedLocales."
   },
   {
     "pathPattern": "/security/attackSimulation/payloads",
     "method": "get",
     "toolName": "list-simulation-payloads",
-    "appPermissions": ["AttackSimulation.Read.All"],
+    "appPermissions": [
+      "AttackSimulation.Read.All"
+    ],
     "llmTip": "Lists attack simulation payloads. Each has displayName, description, source (microsoft, global, tenant), status, platform, simulationAttackType (social, credential), technique (phishing, malware), language, and complexity."
   },
   {
     "pathPattern": "/security/attackSimulation/endUserNotifications",
     "method": "get",
     "toolName": "list-simulation-end-user-notifications",
-    "appPermissions": ["AttackSimulation.Read.All"],
+    "appPermissions": [
+      "AttackSimulation.Read.All"
+    ],
     "llmTip": "Lists end-user notification templates for attack simulations. These are the emails sent to users during/after simulations."
   },
   {
     "pathPattern": "/security/attackSimulation/landingPages",
     "method": "get",
     "toolName": "list-simulation-landing-pages",
-    "appPermissions": ["AttackSimulation.Read.All"],
+    "appPermissions": [
+      "AttackSimulation.Read.All"
+    ],
     "llmTip": "Lists landing page templates for attack simulations. These are the phishing pages shown when a user clicks a simulation link."
   },
   {
     "pathPattern": "/security/attackSimulation/loginPages",
     "method": "get",
     "toolName": "list-simulation-login-pages",
-    "appPermissions": ["AttackSimulation.Read.All"],
+    "appPermissions": [
+      "AttackSimulation.Read.All"
+    ],
     "llmTip": "Lists login page templates for attack simulations. These are credential harvest pages used in phishing simulations."
   },
   {
     "pathPattern": "/security/threatIntelligence/passiveDnsRecords",
     "method": "get",
     "toolName": "list-passive-dns-records",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists passive DNS records from Microsoft Defender Threat Intelligence. Each has firstSeenDateTime, lastSeenDateTime, recordType, and associated host/parentHost. Use $filter=host/id eq 'example.com' to find DNS history for a domain."
   },
   {
     "pathPattern": "/security/threatIntelligence/sslCertificates",
     "method": "get",
     "toolName": "list-ssl-certificates",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists SSL certificates from Microsoft Defender Threat Intelligence. Each has sha1, issuer, subject, serialNumber, firstSeenDateTime, lastSeenDateTime, and relatedHosts. Useful for infrastructure attribution."
   },
   {
     "pathPattern": "/security/threatIntelligence/subdomains",
     "method": "get",
     "toolName": "list-threat-intel-subdomains",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists subdomains from Threat Intelligence. Each has value (the subdomain), firstSeenDateTime, and host. Use $filter=host/id eq 'example.com' to enumerate subdomains."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostPorts",
     "method": "get",
     "toolName": "list-threat-intel-host-ports",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists open ports observed on hosts from Threat Intelligence. Each has port, protocol, status, firstSeenDateTime, lastSeenDateTime, and associated host/service/banner. Use $filter=host/id eq 'x.x.x.x' for a specific host."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostTrackers",
     "method": "get",
     "toolName": "list-threat-intel-host-trackers",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists web trackers (analytics IDs, etc.) observed on hosts from Threat Intelligence. Each has kind (GoogleAnalyticsID, JarmHash, etc.), value, firstSeenDateTime, lastSeenDateTime, and host. Useful for infrastructure correlation."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostCookies",
     "method": "get",
     "toolName": "list-threat-intel-host-cookies",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
+    "appPermissions": [
+      "ThreatIntelligence.Read.All"
+    ],
     "llmTip": "Lists cookies observed on hosts from Threat Intelligence. Each has name, domain, firstSeenDateTime, lastSeenDateTime, and host."
   },
-  {
-    "pathPattern": "/security/threatIntelligence/hostPairs",
-    "method": "get",
-    "toolName": "list-threat-intel-host-pairs",
-    "appPermissions": ["ThreatIntelligence.Read.All"],
-    "llmTip": "Lists host pairs (parent-child relationships) from Threat Intelligence. Each has linkKind (redirect, script, img, etc.), firstSeenDateTime, lastSeenDateTime, parentHost, and childHost. Use to trace infrastructure chains."
-  },
-
   {
     "pathPattern": "/reports/authenticationMethods/userRegistrationDetails",
     "method": "get",
     "toolName": "list-user-registration-details",
-    "appPermissions": ["UserAuthenticationMethod.Read.All"],
+    "appPermissions": [
+      "UserAuthenticationMethod.Read.All"
+    ],
     "llmTip": "Lists MFA/SSPR registration details for all users. Each has userPrincipalName, userDisplayName, isMfaRegistered, isMfaCapable, isSsprRegistered, isSsprEnabled, isSsprCapable, isPasswordlessCapable, methodsRegistered, and defaultMfaMethod. Powerful for MFA adoption reporting."
   },
   {
     "pathPattern": "/reports/dailyPrintUsageByPrinter",
     "method": "get",
     "toolName": "list-daily-print-usage-by-printer",
-    "appPermissions": ["Reports.Read.All"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
     "llmTip": "Lists daily Universal Print usage summarized by printer. Each has printerName, printerId, usageDate, completedBlackAndWhiteJobCount, completedColorJobCount, incompleteJobCount, and pagesPrinted."
   },
   {
     "pathPattern": "/reports/dailyPrintUsageByUser",
     "method": "get",
     "toolName": "list-daily-print-usage-by-user",
-    "appPermissions": ["Reports.Read.All"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
     "llmTip": "Lists daily Universal Print usage summarized by user. Each has userPrincipalName, usageDate, completedBlackAndWhiteJobCount, completedColorJobCount, incompleteJobCount, and pagesPrinted."
   },
   {
     "pathPattern": "/reports/monthlyPrintUsageByPrinter",
     "method": "get",
     "toolName": "list-monthly-print-usage-by-printer",
-    "appPermissions": ["Reports.Read.All"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
     "llmTip": "Lists monthly Universal Print usage summarized by printer. Each has printerName, usageDate, completedBlackAndWhiteJobCount, completedColorJobCount, incompleteJobCount, and pagesPrinted."
   },
   {
     "pathPattern": "/reports/monthlyPrintUsageByUser",
     "method": "get",
     "toolName": "list-monthly-print-usage-by-user",
-    "appPermissions": ["Reports.Read.All"],
+    "appPermissions": [
+      "Reports.Read.All"
+    ],
     "llmTip": "Lists monthly Universal Print usage summarized by user. Each has userPrincipalName, usageDate, completedBlackAndWhiteJobCount, completedColorJobCount, incompleteJobCount, and pagesPrinted."
   },
-
   {
     "pathPattern": "/copilot/admin/settings",
     "method": "get",
     "toolName": "get-copilot-admin-settings",
-    "appPermissions": ["CopilotSettings-Internal.ReadWrite.All"],
+    "appPermissions": [
+      "CopilotSettings-Internal.ReadWrite.All"
+    ],
     "llmTip": "Gets Microsoft 365 Copilot admin settings for the tenant. Returns configuration controlling Copilot behavior and availability."
   },
   {
     "pathPattern": "/copilot/admin/settings/limitedMode",
     "method": "get",
     "toolName": "get-copilot-limited-mode",
-    "appPermissions": ["CopilotSettings-Internal.ReadWrite.All"],
+    "appPermissions": [
+      "CopilotSettings-Internal.ReadWrite.All"
+    ],
     "llmTip": "Gets Copilot limited mode configuration. Returns isEnabledForGroup, groupId, and whether Copilot features are restricted for specific user groups."
   },
-
   {
     "pathPattern": "/directory/attributeSets",
     "method": "get",
     "toolName": "list-attribute-sets",
-    "appPermissions": ["CustomSecAttributeDefinition.Read.All"],
+    "appPermissions": [
+      "CustomSecAttributeDefinition.Read.All"
+    ],
     "llmTip": "Lists custom security attribute sets. Each set is a container of custom security attributes. Has displayName, description, id, maxAttributesPerSet, and isLocked."
   },
   {
     "pathPattern": "/directory/customSecurityAttributeDefinitions",
     "method": "get",
     "toolName": "list-custom-security-attributes",
-    "appPermissions": ["CustomSecAttributeDefinition.Read.All"],
+    "appPermissions": [
+      "CustomSecAttributeDefinition.Read.All"
+    ],
     "llmTip": "Lists custom security attribute definitions. Each has attributeSet, name, type (String, Integer, Boolean), isSearchable, isCollection, usePreDefinedValuesOnly, status (Available, Deprecated), and description. Custom security attributes provide flexible tagging for Entra objects."
   },
   {
     "pathPattern": "/directory/deviceLocalCredentials",
     "method": "get",
     "toolName": "list-device-local-credentials",
-    "appPermissions": ["DeviceLocalCredential.Read.All"],
+    "appPermissions": [
+      "DeviceLocalCredential.Read.All"
+    ],
     "llmTip": "Lists device local admin credentials managed by Entra ID (LAPS - Local Admin Password Solution). Each has deviceName, lastBackupDateTime, and refreshDateTime. The actual password requires DeviceLocalCredential.Read.All and a separate GET by ID."
   },
   {
     "pathPattern": "/directory/federationConfigurations",
     "method": "get",
     "toolName": "list-federation-configurations",
-    "appPermissions": ["Domain.Read.All"],
+    "appPermissions": [
+      "Domain.Read.All"
+    ],
     "llmTip": "Lists federation configurations for the directory. Each has displayName, audiences, issuerUri, metadataExchangeUri, passiveSignInUri, signingCertificateUpdateStatus, and preferredAuthenticationProtocol."
   },
   {
     "pathPattern": "/directory/onPremisesSynchronization",
     "method": "get",
     "toolName": "list-on-premises-sync",
-    "appPermissions": ["OnPremDirectorySynchronization.Read.All"],
+    "appPermissions": [
+      "OnPremDirectorySynchronization.Read.All"
+    ],
     "llmTip": "Lists on-premises directory synchronization (Entra Connect) configurations. Returns features enabled (passwordHashSync, passwordWriteback, seamlessSSO, cloudSync), configuration details, and sync status."
   },
-
   {
     "pathPattern": "/teams",
     "method": "get",
     "toolName": "list-teams",
-    "appPermissions": ["Team.ReadBasic.All"],
+    "appPermissions": [
+      "Team.ReadBasic.All"
+    ],
     "llmTip": "Lists all teams in the tenant. Use $filter=displayName eq 'name' to find specific teams. Use $select=id,displayName,description to limit fields. Returns id, displayName, description, visibility, isArchived."
   },
   {
     "pathPattern": "/teams",
     "method": "post",
     "toolName": "create-team",
-    "appPermissions": ["Team.Create"],
+    "appPermissions": [
+      "Team.Create"
+    ],
     "riskLevel": "medium",
     "llmTip": "Creates a new team. Body requires template@odata.bind, displayName, description. Example: {\"template@odata.bind\":\"https://graph.microsoft.com/v1.0/teamsTemplates('standard')\",\"displayName\":\"My Team\",\"description\":\"desc\"}."
   },
@@ -2276,14 +2822,18 @@
     "pathPattern": "/teams/{team-id}",
     "method": "get",
     "toolName": "get-team",
-    "appPermissions": ["Team.ReadBasic.All"],
+    "appPermissions": [
+      "Team.ReadBasic.All"
+    ],
     "llmTip": "Gets a specific team by ID. Returns displayName, description, visibility (public/private), isArchived, memberSettings, guestSettings, messagingSettings, funSettings, discoverySettings."
   },
   {
     "pathPattern": "/teams/{team-id}",
     "method": "patch",
     "toolName": "update-team",
-    "appPermissions": ["Team.ReadWrite.All"],
+    "appPermissions": [
+      "Team.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates a team's settings. Body can include displayName, description, visibility, memberSettings, guestSettings, messagingSettings, funSettings."
   },
@@ -2291,7 +2841,9 @@
     "pathPattern": "/teams/{team-id}",
     "method": "delete",
     "toolName": "delete-team",
-    "appPermissions": ["Group.ReadWrite.All"],
+    "appPermissions": [
+      "Group.ReadWrite.All"
+    ],
     "riskLevel": "critical",
     "llmTip": "Deletes a team and its associated group. This is irreversible. The team and all its content (channels, messages, files) will be permanently deleted."
   },
@@ -2299,14 +2851,18 @@
     "pathPattern": "/teams/{team-id}/channels",
     "method": "get",
     "toolName": "list-team-admin-channels",
-    "appPermissions": ["Channel.ReadBasic.All"],
+    "appPermissions": [
+      "Channel.ReadBasic.All"
+    ],
     "llmTip": "Lists channels in a team. Returns id, displayName, description, membershipType (standard/private/shared), createdDateTime, email, webUrl."
   },
   {
     "pathPattern": "/teams/{team-id}/channels",
     "method": "post",
     "toolName": "create-team-admin-channel",
-    "appPermissions": ["Channel.Create"],
+    "appPermissions": [
+      "Channel.Create"
+    ],
     "riskLevel": "low",
     "llmTip": "Creates a new channel in a team. Body requires displayName. Optional: description, membershipType (standard/private/shared)."
   },
@@ -2314,14 +2870,18 @@
     "pathPattern": "/teams/{team-id}/channels/{channel-id}",
     "method": "get",
     "toolName": "get-team-admin-channel",
-    "appPermissions": ["Channel.ReadBasic.All"],
+    "appPermissions": [
+      "Channel.ReadBasic.All"
+    ],
     "llmTip": "Gets a specific channel by ID. Returns displayName, description, membershipType, createdDateTime, email, webUrl, tenantId."
   },
   {
     "pathPattern": "/teams/{team-id}/channels/{channel-id}",
     "method": "delete",
     "toolName": "delete-team-admin-channel",
-    "appPermissions": ["Channel.Delete.All"],
+    "appPermissions": [
+      "Channel.Delete.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Deletes a channel from a team. All messages and files in the channel will be deleted."
   },
@@ -2329,14 +2889,18 @@
     "pathPattern": "/teams/{team-id}/members",
     "method": "get",
     "toolName": "list-team-admin-members",
-    "appPermissions": ["TeamMember.Read.All"],
+    "appPermissions": [
+      "TeamMember.Read.All"
+    ],
     "llmTip": "Lists members of a team. Returns each member's id, displayName, roles (owner/member/guest), userId, email."
   },
   {
     "pathPattern": "/teams/{team-id}/members/add",
     "method": "post",
     "toolName": "add-team-admin-members",
-    "appPermissions": ["TeamMember.ReadWrite.All"],
+    "appPermissions": [
+      "TeamMember.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Adds members to a team in bulk. Body: {\"values\":[{\"@odata.type\":\"microsoft.graph.aadUserConversationMember\",\"roles\":[],\"user@odata.bind\":\"https://graph.microsoft.com/v1.0/users('userId')\"}]}."
   },
@@ -2344,7 +2908,9 @@
     "pathPattern": "/teams/{team-id}/members/remove",
     "method": "post",
     "toolName": "remove-team-admin-members",
-    "appPermissions": ["TeamMember.ReadWrite.All"],
+    "appPermissions": [
+      "TeamMember.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Removes members from a team in bulk. Body: {\"values\":[{\"id\":\"conversationMemberId\"}]}."
   },
@@ -2352,21 +2918,27 @@
     "pathPattern": "/teams/{team-id}/members/{conversationMember-id}",
     "method": "get",
     "toolName": "get-team-admin-member",
-    "appPermissions": ["TeamMember.Read.All"],
+    "appPermissions": [
+      "TeamMember.Read.All"
+    ],
     "llmTip": "Gets a specific member of a team. Returns displayName, roles, userId, email, visibleHistoryStartDateTime."
   },
   {
     "pathPattern": "/teams/{team-id}/installedApps",
     "method": "get",
     "toolName": "list-team-installed-apps",
-    "appPermissions": ["TeamsAppInstallation.ReadForTeam.All"],
+    "appPermissions": [
+      "TeamsAppInstallation.ReadForTeam.All"
+    ],
     "llmTip": "Lists apps installed in a team. Use $expand=teamsAppDefinition to get app details. Returns teamsApp, teamsAppDefinition with displayName, version, description."
   },
   {
     "pathPattern": "/teams/{team-id}/archive",
     "method": "post",
     "toolName": "archive-team",
-    "appPermissions": ["Team.ReadWrite.All"],
+    "appPermissions": [
+      "Team.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Archives a team. Archived teams become read-only. Optional body: {\"shouldSetSpoSiteReadOnlyForMembers\": true} to also make the SharePoint site read-only."
   },
@@ -2374,7 +2946,9 @@
     "pathPattern": "/teams/{team-id}/unarchive",
     "method": "post",
     "toolName": "unarchive-team",
-    "appPermissions": ["Team.ReadWrite.All"],
+    "appPermissions": [
+      "Team.ReadWrite.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Unarchives a team, restoring it to active state and allowing users to send messages and edit the team again."
   },
@@ -2382,7 +2956,9 @@
     "pathPattern": "/teams/{team-id}/clone",
     "method": "post",
     "toolName": "clone-team",
-    "appPermissions": ["Team.Create"],
+    "appPermissions": [
+      "Team.Create"
+    ],
     "riskLevel": "medium",
     "llmTip": "Clones a team. Body requires displayName, description, mailNickname, partsToClone (apps,tabs,settings,channels,members). classification and visibility are optional."
   },
@@ -2390,28 +2966,36 @@
     "pathPattern": "/teams/{team-id}/operations",
     "method": "get",
     "toolName": "list-team-operations",
-    "appPermissions": ["Team.ReadBasic.All"],
+    "appPermissions": [
+      "Team.ReadBasic.All"
+    ],
     "llmTip": "Lists async operations on a team (archive, clone, etc.). Returns operationType, status (notStarted/running/succeeded/failed), createdDateTime, lastActionDateTime, error."
   },
   {
     "pathPattern": "/teams/{team-id}/permissionGrants",
     "method": "get",
     "toolName": "list-team-permission-grants",
-    "appPermissions": ["TeamsAppInstallation.ReadForTeam.All"],
+    "appPermissions": [
+      "TeamsAppInstallation.ReadForTeam.All"
+    ],
     "llmTip": "Lists resource-specific permission grants on a team. Shows which apps have been granted specific permissions (e.g., ChannelMessage.Read.Group)."
   },
   {
     "pathPattern": "/teamwork/teamsAppSettings",
     "method": "get",
     "toolName": "get-teams-app-settings",
-    "appPermissions": ["TeamworkAppSettings.Read.All"],
+    "appPermissions": [
+      "TeamworkAppSettings.Read.All"
+    ],
     "llmTip": "Gets tenant-wide Teams app settings. Returns allowUserRequestsForAppAccess (whether users can request admin approval for apps) and isUserPersonalScopeResourceSpecificConsentEnabled."
   },
   {
     "pathPattern": "/teamwork/teamsAppSettings",
     "method": "patch",
     "toolName": "update-teams-app-settings",
-    "appPermissions": ["TeamworkAppSettings.ReadWrite.All"],
+    "appPermissions": [
+      "TeamworkAppSettings.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Updates tenant-wide Teams app settings. Body can include allowUserRequestsForAppAccess and isUserPersonalScopeResourceSpecificConsentEnabled."
   },
@@ -2419,85 +3003,108 @@
     "pathPattern": "/teamwork/deletedTeams",
     "method": "get",
     "toolName": "list-deleted-teams",
-    "appPermissions": ["Team.ReadBasic.All"],
+    "appPermissions": [
+      "Team.ReadBasic.All"
+    ],
     "llmTip": "Lists recently deleted teams. Returns id and displayName. Deleted teams can be restored within 30 days."
   },
   {
     "pathPattern": "/appCatalogs/teamsApps",
     "method": "get",
     "toolName": "list-teams-catalog-apps",
-    "appPermissions": ["AppCatalog.Read.All"],
+    "appPermissions": [
+      "AppCatalog.Read.All"
+    ],
     "llmTip": "Lists apps in the Teams app catalog (tenant and store). Use $filter=distributionMethod eq 'organization' for tenant-only apps. Returns id, displayName, externalId, distributionMethod."
   },
   {
     "pathPattern": "/appCatalogs/teamsApps/{teamsApp-id}",
     "method": "get",
     "toolName": "get-teams-catalog-app",
-    "appPermissions": ["AppCatalog.Read.All"],
+    "appPermissions": [
+      "AppCatalog.Read.All"
+    ],
     "llmTip": "Gets a specific app from the Teams app catalog. Use $expand=appDefinitions to get version details."
   },
   {
     "pathPattern": "/appCatalogs/teamsApps/{teamsApp-id}/appDefinitions",
     "method": "get",
     "toolName": "list-teams-app-definitions",
-    "appPermissions": ["AppCatalog.Read.All"],
+    "appPermissions": [
+      "AppCatalog.Read.All"
+    ],
     "llmTip": "Lists all versions (definitions) of a Teams app. Each definition has displayName, description, version, publishingState, shortDescription, teamsAppId."
   },
   {
     "pathPattern": "/admin/teams",
     "method": "get",
     "toolName": "get-teams-admin-settings",
-    "appPermissions": ["TeamworkDevice.Read.All"],
+    "appPermissions": [
+      "TeamworkDevice.Read.All"
+    ],
     "llmTip": "Gets Teams admin settings for the tenant."
   },
   {
     "pathPattern": "/admin/teams/userConfigurations",
     "method": "get",
     "toolName": "list-teams-user-configurations",
-    "appPermissions": ["TeamworkDevice.Read.All"],
+    "appPermissions": [
+      "TeamworkDevice.Read.All"
+    ],
     "llmTip": "Lists Teams user configurations in the tenant."
   },
   {
     "pathPattern": "/admin/teams/policy",
     "method": "get",
     "toolName": "get-teams-admin-policy",
-    "appPermissions": ["TeamworkDevice.Read.All"],
+    "appPermissions": [
+      "TeamworkDevice.Read.All"
+    ],
     "llmTip": "Gets Teams admin policy settings."
   },
   {
     "pathPattern": "/admin/teams/policy/userAssignments",
     "method": "get",
     "toolName": "list-teams-policy-assignments",
-    "appPermissions": ["TeamworkDevice.Read.All"],
+    "appPermissions": [
+      "TeamworkDevice.Read.All"
+    ],
     "llmTip": "Lists Teams policy user assignments."
   },
   {
     "pathPattern": "/admin/teams/telephoneNumberManagement/numberAssignments",
     "method": "get",
     "toolName": "list-teams-phone-assignments",
-    "appPermissions": ["TeamworkDevice.Read.All"],
+    "appPermissions": [
+      "TeamworkDevice.Read.All"
+    ],
     "llmTip": "Lists telephone number assignments for Teams. Shows which phone numbers are assigned to which users or resources."
   },
-
   {
     "pathPattern": "/sites",
     "method": "get",
     "toolName": "list-sharepoint-sites",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Lists or searches SharePoint sites. Use $search='keyword' to search by site name/URL. Use $filter to filter. Use $select=id,displayName,webUrl to limit fields. Returns id, displayName, webUrl, createdDateTime, lastModifiedDateTime."
   },
   {
     "pathPattern": "/sites/{site-id}",
     "method": "get",
     "toolName": "get-sharepoint-site",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Gets a specific SharePoint site by ID. The site-id format is {hostname}:{server-relative-path} or a GUID. Returns displayName, webUrl, root, siteCollection, createdDateTime."
   },
   {
     "pathPattern": "/sites/{site-id}",
     "method": "patch",
     "toolName": "update-sharepoint-site",
-    "appPermissions": ["Sites.ReadWrite.All"],
+    "appPermissions": [
+      "Sites.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates a SharePoint site's properties. Body can include displayName and description."
   },
@@ -2505,232 +3112,298 @@
     "pathPattern": "/sites/{site-id}/drives",
     "method": "get",
     "toolName": "list-site-drives",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Lists document libraries (drives) in a SharePoint site. Returns id, name, driveType, webUrl, quota, owner for each drive."
   },
   {
     "pathPattern": "/sites/{site-id}/drive",
     "method": "get",
     "toolName": "get-site-default-drive",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Gets the default document library (drive) for a SharePoint site. Returns id, name, driveType, webUrl, quota."
   },
   {
     "pathPattern": "/sites/{site-id}/lists",
     "method": "get",
     "toolName": "list-site-lists",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Lists SharePoint lists in a site. Returns id, displayName, list (template, contentTypesEnabled, hidden), createdDateTime, webUrl for each list."
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}",
     "method": "get",
     "toolName": "get-site-list",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Gets a specific SharePoint list by ID. Returns displayName, list settings, columns, contentTypes, webUrl."
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
     "method": "get",
     "toolName": "list-site-list-items",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Lists items in a SharePoint list. Use $expand=fields to get column values. Use $filter on fields/ColumnName for filtering."
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}/columns",
     "method": "get",
     "toolName": "list-site-list-columns",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Lists column definitions for a SharePoint list. Returns each column's name, displayName, type (text, number, choice, etc.), description."
   },
   {
     "pathPattern": "/sites/{site-id}/columns",
     "method": "get",
     "toolName": "list-site-columns",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Lists site-level column definitions. Returns each column's name, displayName, type, description."
   },
   {
     "pathPattern": "/sites/{site-id}/contentTypes",
     "method": "get",
     "toolName": "list-site-content-types",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Lists content types defined in a SharePoint site. Returns id, name, description, group, isBuiltIn, parentId."
   },
   {
     "pathPattern": "/sites/{site-id}/permissions",
     "method": "get",
     "toolName": "list-site-permissions",
-    "appPermissions": ["Sites.FullControl.All"],
+    "appPermissions": [
+      "Sites.FullControl.All"
+    ],
     "llmTip": "Lists permissions granted on a SharePoint site. Returns each permission's id, roles, grantedToIdentities (application or user)."
   },
   {
     "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
     "method": "get",
     "toolName": "get-site-permission",
-    "appPermissions": ["Sites.FullControl.All"],
+    "appPermissions": [
+      "Sites.FullControl.All"
+    ],
     "llmTip": "Gets a specific permission on a SharePoint site by ID. Returns id, roles, grantedToIdentities."
   },
   {
     "pathPattern": "/sites/{site-id}/analytics",
     "method": "get",
     "toolName": "get-site-analytics",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Gets analytics for a SharePoint site. Returns allTime and lastSevenDays access counts."
   },
   {
     "pathPattern": "/sites/{site-id}/sites",
     "method": "get",
     "toolName": "list-site-subsites",
-    "appPermissions": ["Sites.Read.All"],
+    "appPermissions": [
+      "Sites.Read.All"
+    ],
     "llmTip": "Lists subsites of a SharePoint site. Returns displayName, webUrl, createdDateTime for each subsite."
   },
-
   {
     "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels",
     "method": "get",
     "toolName": "list-sensitivity-labels",
-    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "appPermissions": [
+      "InformationProtectionPolicy.Read.All"
+    ],
     "llmTip": "Lists sensitivity labels defined in the tenant. Returns id, name, description, tooltip, color, isActive, priority, parent. Labels are used for data classification and protection."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}",
     "method": "get",
     "toolName": "get-sensitivity-label",
-    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "appPermissions": [
+      "InformationProtectionPolicy.Read.All"
+    ],
     "llmTip": "Gets a specific sensitivity label by ID. Returns name, description, tooltip, color, isActive, priority, parent, contentFormats, autoLabeling settings."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}/sublabels",
     "method": "get",
     "toolName": "list-sensitivity-sublabels",
-    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "appPermissions": [
+      "InformationProtectionPolicy.Read.All"
+    ],
     "llmTip": "Lists sublabels under a parent sensitivity label. Returns id, name, description, tooltip, color, isActive, priority."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}/rights",
     "method": "get",
     "toolName": "get-sensitivity-label-rights",
-    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "appPermissions": [
+      "InformationProtectionPolicy.Read.All"
+    ],
     "llmTip": "Gets the rights associated with a sensitivity label, including encryption settings and usage rights."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/protectionScopes",
     "method": "get",
     "toolName": "get-protection-scopes",
-    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "appPermissions": [
+      "InformationProtectionPolicy.Read.All"
+    ],
     "llmTip": "Gets the data security and governance protection scopes configured for the tenant."
   },
-
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/folders",
     "method": "get",
     "toolName": "list-exchange-mailbox-folders",
-    "appPermissions": ["Exchange.ManageAsApp"],
+    "appPermissions": [
+      "Exchange.ManageAsApp"
+    ],
     "llmTip": "Lists mailbox folders for an Exchange mailbox (admin). Returns id, displayName, totalItemCount, unreadItemCount, childFolderCount, parentFolderId."
   },
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/folders/{mailboxFolder-id}",
     "method": "get",
     "toolName": "get-exchange-mailbox-folder",
-    "appPermissions": ["Exchange.ManageAsApp"],
+    "appPermissions": [
+      "Exchange.ManageAsApp"
+    ],
     "llmTip": "Gets a specific mailbox folder by ID (admin). Returns displayName, totalItemCount, unreadItemCount, childFolderCount."
   },
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/exportItems",
     "method": "post",
     "toolName": "export-exchange-mailbox-items",
-    "appPermissions": ["Exchange.ManageAsApp"],
+    "appPermissions": [
+      "Exchange.ManageAsApp"
+    ],
     "riskLevel": "medium",
     "llmTip": "Exports items from an Exchange mailbox. Body: {\"itemIds\":[\"itemId1\",\"itemId2\"]}. Returns exportedItems with data (base64)."
   },
-
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}",
     "method": "get",
     "toolName": "get-call-record",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Gets a specific call record by ID. Returns type (groupCall/peerToPeer), modalities (audio/video/screenSharing), startDateTime, endDateTime, organizer, participants, version."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/sessions",
     "method": "get",
     "toolName": "list-call-record-sessions",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Lists sessions within a call record. Each session represents a participant's connection. Returns caller, callee, startDateTime, endDateTime, modalities, failureInfo."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}",
     "method": "get",
     "toolName": "get-call-record-session",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Gets a specific session within a call record. Returns detailed caller/callee info, modalities, startDateTime, endDateTime, failureInfo, isTest."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}/segments",
     "method": "get",
     "toolName": "list-call-session-segments",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Lists segments within a call session. Each segment has media streams with detailed quality metrics: jitter, packetLoss, roundTripTime, averageAudioDegradation, etc."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}/segments/{segment-id}",
     "method": "get",
     "toolName": "get-call-session-segment",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Gets a specific segment of a call session. Returns detailed media stream quality metrics including jitter, packetLoss, roundTripTime for audio/video/screenSharing."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/participants_v2",
     "method": "get",
     "toolName": "list-call-record-participants",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Lists participants in a call record (v2 API). Returns each participant's identity (user, phone, application), and participant details."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/participants_v2/{participant-id}",
     "method": "get",
     "toolName": "get-call-record-participant",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Gets a specific participant in a call record (v2 API). Returns participant identity and details."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/organizer_v2",
     "method": "get",
     "toolName": "get-call-record-organizer",
-    "appPermissions": ["CallRecords.Read.All"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
     "llmTip": "Gets the organizer of a call record (v2 API). Returns the organizer's identity (user or application)."
   },
   {
     "pathPattern": "/communications/callRecords/microsoft.graph.callRecords.getPstnCalls(fromDateTime={fromDateTime},toDateTime={toDateTime})",
     "method": "get",
     "toolName": "get-pstn-calls",
-    "appPermissions": ["CallRecords.Read.All"],
-    "skipEncoding": ["fromDateTime", "toDateTime"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
+    "skipEncoding": [
+      "fromDateTime",
+      "toDateTime"
+    ],
     "llmTip": "Gets PSTN (Public Switched Telephone Network) call records for a date range. Parameters are ISO 8601 dates. Returns callId, userId, userPrincipalName, callerNumber, calleeNumber, duration, charge, callType, currency."
   },
   {
     "pathPattern": "/communications/callRecords/microsoft.graph.callRecords.getDirectRoutingCalls(fromDateTime={fromDateTime},toDateTime={toDateTime})",
     "method": "get",
     "toolName": "get-direct-routing-calls",
-    "appPermissions": ["CallRecords.Read.All"],
-    "skipEncoding": ["fromDateTime", "toDateTime"],
+    "appPermissions": [
+      "CallRecords.Read.All"
+    ],
+    "skipEncoding": [
+      "fromDateTime",
+      "toDateTime"
+    ],
     "llmTip": "Gets Direct Routing call records for a date range. Parameters are ISO 8601 dates. Returns callId, correlationId, userId, callerNumber, calleeNumber, duration, startDateTime, failureDateTime, finalSipCode, mediaPathLocation."
   },
-
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/wipe",
     "method": "post",
     "toolName": "wipe-managed-device",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "critical",
-    "llmTip": "Wipes a managed device (factory reset). IRREVERSIBLE — all data on the device will be erased. Optional body: {\"keepEnrollmentData\":false,\"keepUserData\":false,\"macOsUnlockCode\":\"pin\"}. Always confirm with operator before executing."
+    "llmTip": "Wipes a managed device (factory reset). IRREVERSIBLE \u2014 all data on the device will be erased. Optional body: {\"keepEnrollmentData\":false,\"keepUserData\":false,\"macOsUnlockCode\":\"pin\"}. Always confirm with operator before executing."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/retire",
     "method": "post",
     "toolName": "retire-managed-device",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Retires a managed device. Removes company data (apps, email, Wi-Fi, VPN profiles) but keeps personal data. The device is unenrolled from Intune management."
   },
@@ -2738,7 +3411,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/syncDevice",
     "method": "post",
     "toolName": "sync-managed-device",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Triggers an immediate sync of the managed device with Intune. Forces the device to check in and apply any pending policies, apps, or configurations."
   },
@@ -2746,7 +3421,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/rebootNow",
     "method": "post",
     "toolName": "reboot-managed-device",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Reboots a managed device immediately. The user will lose unsaved work. Windows devices only."
   },
@@ -2754,7 +3431,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/remoteLock",
     "method": "post",
     "toolName": "remote-lock-device",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Remotely locks a managed device. The device owner must use their passcode/PIN to unlock. Useful for lost/stolen devices."
   },
@@ -2762,7 +3441,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/resetPasscode",
     "method": "post",
     "toolName": "reset-device-passcode",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Resets the passcode on a managed device. Behavior varies by platform: Android generates a new passcode, iOS removes the passcode."
   },
@@ -2770,7 +3451,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/shutDown",
     "method": "post",
     "toolName": "shutdown-managed-device",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Shuts down a managed device. The user will lose unsaved work."
   },
@@ -2778,7 +3461,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/disableLostMode",
     "method": "post",
     "toolName": "disable-lost-mode",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Disables Lost Mode on a supervised iOS device. The device returns to normal operation."
   },
@@ -2786,7 +3471,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/locateDevice",
     "method": "post",
     "toolName": "locate-managed-device",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Locates a managed device (iOS supervised). Returns the device's GPS coordinates. Use get-managed-device after to read deviceActionResults for the location."
   },
@@ -2794,7 +3481,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/bypassActivationLock",
     "method": "post",
     "toolName": "bypass-activation-lock",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Bypasses the Activation Lock on a supervised iOS device. Used when a device needs to be reactivated without the original Apple ID credentials."
   },
@@ -2802,7 +3491,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/windowsDefenderScan",
     "method": "post",
     "toolName": "trigger-defender-scan",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Triggers a Windows Defender antivirus scan on the device. Body: {\"quickScan\": true} for quick scan, or {\"quickScan\": false} for full scan."
   },
@@ -2810,7 +3501,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/windowsDefenderUpdateSignatures",
     "method": "post",
     "toolName": "update-defender-signatures",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Forces a Windows Defender signature update on the device. Ensures the latest antivirus definitions are installed."
   },
@@ -2818,7 +3511,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/cleanWindowsDevice",
     "method": "post",
     "toolName": "clean-windows-device",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "critical",
     "llmTip": "Cleans a Windows device (fresh start). Body: {\"keepUserData\": false}. Removes all installed apps and resets to default Windows. IRREVERSIBLE."
   },
@@ -2826,7 +3521,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/logoutSharedAppleDeviceActiveUser",
     "method": "post",
     "toolName": "logout-shared-apple-user",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Logs out the active user from a shared Apple device (iPad). The device returns to the login screen."
   },
@@ -2834,7 +3531,9 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/deleteUserFromSharedAppleDevice",
     "method": "post",
     "toolName": "delete-shared-apple-user",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Deletes a user and their data from a shared Apple device. Body: {\"userPrincipalName\": \"user@contoso.com\"}."
   },
@@ -2842,39 +3541,39 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/updateWindowsDeviceAccount",
     "method": "post",
     "toolName": "update-windows-device-account",
-    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "appPermissions": [
+      "DeviceManagementManagedDevices.PrivilegedOperations.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates the account on a Windows device (Surface Hub). Body: {\"updateWindowsDeviceAccountActionParameter\": {\"deviceAccount\": {\"email\": \"room@contoso.com\"}, \"passwordRotationEnabled\": true}}."
   },
-
   {
     "pathPattern": "/identity/conditionalAccess/policies",
     "method": "post",
     "toolName": "create-conditional-access-policy",
-    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "appPermissions": [
+      "Policy.ReadWrite.ConditionalAccess"
+    ],
     "riskLevel": "high",
     "llmTip": "Creates a new Conditional Access policy. Body requires displayName, state (enabled/disabled/enabledForReportingButNotEnforced), conditions (users, applications, locations, platforms, signInRiskLevels), grantControls or sessionControls. Start with state='disabled' or 'enabledForReportingButNotEnforced' for safety."
   },
   {
     "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
-    "method": "get",
-    "toolName": "get-conditional-access-policy",
-    "appPermissions": ["Policy.Read.All"],
-    "llmTip": "Gets a specific Conditional Access policy by ID. Returns displayName, state, conditions (users, applications, locations, platforms, signInRiskLevels, clientAppTypes), grantControls, sessionControls, createdDateTime, modifiedDateTime."
-  },
-  {
-    "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
     "method": "patch",
     "toolName": "update-conditional-access-policy",
-    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "appPermissions": [
+      "Policy.ReadWrite.ConditionalAccess"
+    ],
     "riskLevel": "high",
-    "llmTip": "Updates a Conditional Access policy. Body can include displayName, state, conditions, grantControls, sessionControls. Changing state to 'enabled' activates enforcement — verify conditions before enabling."
+    "llmTip": "Updates a Conditional Access policy. Body can include displayName, state, conditions, grantControls, sessionControls. Changing state to 'enabled' activates enforcement \u2014 verify conditions before enabling."
   },
   {
     "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
     "method": "delete",
     "toolName": "delete-conditional-access-policy",
-    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "appPermissions": [
+      "Policy.ReadWrite.ConditionalAccess"
+    ],
     "riskLevel": "critical",
     "llmTip": "Deletes a Conditional Access policy. IRREVERSIBLE. Consider disabling (state='disabled') instead of deleting."
   },
@@ -2882,7 +3581,9 @@
     "pathPattern": "/identity/conditionalAccess/namedLocations",
     "method": "post",
     "toolName": "create-named-location",
-    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "appPermissions": [
+      "Policy.ReadWrite.ConditionalAccess"
+    ],
     "riskLevel": "medium",
     "llmTip": "Creates a named location for Conditional Access. For IP ranges: {\"@odata.type\":\"#microsoft.graph.ipNamedLocation\",\"displayName\":\"Corp IPs\",\"isTrusted\":true,\"ipRanges\":[{\"@odata.type\":\"#microsoft.graph.iPv4CidrRange\",\"cidrAddress\":\"10.0.0.0/8\"}]}."
   },
@@ -2890,7 +3591,9 @@
     "pathPattern": "/identity/conditionalAccess/namedLocations/{namedLocation-id}",
     "method": "patch",
     "toolName": "update-named-location",
-    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "appPermissions": [
+      "Policy.ReadWrite.ConditionalAccess"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates a named location. Body can include displayName, isTrusted, ipRanges (for IP locations) or countriesAndRegions, includeUnknownCountriesAndRegions (for country locations)."
   },
@@ -2898,7 +3601,9 @@
     "pathPattern": "/identity/conditionalAccess/namedLocations/{namedLocation-id}",
     "method": "delete",
     "toolName": "delete-named-location",
-    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "appPermissions": [
+      "Policy.ReadWrite.ConditionalAccess"
+    ],
     "riskLevel": "high",
     "llmTip": "Deletes a named location. If in use by a Conditional Access policy, the location reference must be removed from the policy first."
   },
@@ -2906,15 +3611,18 @@
     "pathPattern": "/identity/conditionalAccess/templates",
     "method": "get",
     "toolName": "list-conditional-access-templates",
-    "appPermissions": ["Policy.Read.All"],
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
     "llmTip": "Lists Conditional Access policy templates provided by Microsoft. Templates can be used as starting points for new policies. Returns id, name, description, scenarios, details."
   },
-
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies",
     "method": "post",
     "toolName": "create-compliance-policy",
-    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Creates a new device compliance policy. Body varies by platform. Example for Windows: {\"@odata.type\":\"#microsoft.graph.windows10CompliancePolicy\",\"displayName\":\"Win10 Compliance\",\"passwordRequired\":true,\"bitLockerEnabled\":true}."
   },
@@ -2922,7 +3630,9 @@
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
     "method": "patch",
     "toolName": "update-compliance-policy",
-    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates an existing device compliance policy. Body can include any compliance settings for the platform type."
   },
@@ -2930,7 +3640,9 @@
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
     "method": "delete",
     "toolName": "delete-compliance-policy",
-    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Deletes a device compliance policy. Devices assigned to this policy will no longer be evaluated for compliance."
   },
@@ -2938,7 +3650,9 @@
     "pathPattern": "/deviceManagement/deviceConfigurations",
     "method": "post",
     "toolName": "create-device-configuration",
-    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Creates a new device configuration profile. Body varies by platform and profile type. Example: {\"@odata.type\":\"#microsoft.graph.windows10GeneralConfiguration\",\"displayName\":\"Win10 Config\",\"passwordBlockSimple\":true}."
   },
@@ -2946,7 +3660,9 @@
     "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
     "method": "patch",
     "toolName": "update-device-configuration",
-    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates an existing device configuration profile. Body can include any configuration settings for the profile type."
   },
@@ -2954,16 +3670,19 @@
     "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
     "method": "delete",
     "toolName": "delete-device-configuration",
-    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "appPermissions": [
+      "DeviceManagementConfiguration.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Deletes a device configuration profile. Devices assigned to this profile will no longer receive these settings."
   },
-
   {
     "pathPattern": "/sites/{site-id}/permissions",
     "method": "post",
     "toolName": "create-site-permission",
-    "appPermissions": ["Sites.FullControl.All"],
+    "appPermissions": [
+      "Sites.FullControl.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Grants a permission on a SharePoint site. Body: {\"roles\":[\"write\"],\"grantedToIdentities\":[{\"application\":{\"id\":\"app-id\",\"displayName\":\"App Name\"}}]}. Roles: read, write, owner."
   },
@@ -2971,7 +3690,9 @@
     "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
     "method": "patch",
     "toolName": "update-site-permission",
-    "appPermissions": ["Sites.FullControl.All"],
+    "appPermissions": [
+      "Sites.FullControl.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates a permission on a SharePoint site. Body: {\"roles\":[\"read\"]} to change the role."
   },
@@ -2979,7 +3700,9 @@
     "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
     "method": "delete",
     "toolName": "delete-site-permission",
-    "appPermissions": ["Sites.FullControl.All"],
+    "appPermissions": [
+      "Sites.FullControl.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Deletes a permission from a SharePoint site. The app or user will lose access to the site."
   },
@@ -2987,7 +3710,9 @@
     "pathPattern": "/sites/{site-id}/lists",
     "method": "post",
     "toolName": "create-site-list",
-    "appPermissions": ["Sites.ReadWrite.All"],
+    "appPermissions": [
+      "Sites.ReadWrite.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Creates a new SharePoint list. Body: {\"displayName\":\"My List\",\"list\":{\"template\":\"genericList\"}}. Templates: genericList, documentLibrary, events, tasks, contacts, etc."
   },
@@ -2995,7 +3720,9 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}",
     "method": "patch",
     "toolName": "update-site-list",
-    "appPermissions": ["Sites.ReadWrite.All"],
+    "appPermissions": [
+      "Sites.ReadWrite.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Updates a SharePoint list. Body can include displayName and description."
   },
@@ -3003,7 +3730,9 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}",
     "method": "delete",
     "toolName": "delete-site-list",
-    "appPermissions": ["Sites.ReadWrite.All"],
+    "appPermissions": [
+      "Sites.ReadWrite.All"
+    ],
     "riskLevel": "high",
     "llmTip": "Deletes a SharePoint list and all its items."
   },
@@ -3011,7 +3740,9 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
     "method": "post",
     "toolName": "create-site-list-item",
-    "appPermissions": ["Sites.ReadWrite.All"],
+    "appPermissions": [
+      "Sites.ReadWrite.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Creates a new item in a SharePoint list. Body: {\"fields\":{\"Title\":\"Item title\",\"ColumnName\":\"value\"}}."
   },
@@ -3019,7 +3750,9 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
     "method": "patch",
     "toolName": "update-site-list-item",
-    "appPermissions": ["Sites.ReadWrite.All"],
+    "appPermissions": [
+      "Sites.ReadWrite.All"
+    ],
     "riskLevel": "low",
     "llmTip": "Updates a SharePoint list item. Body: {\"fields\":{\"ColumnName\":\"new value\"}}."
   },
@@ -3027,16 +3760,19 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
     "method": "delete",
     "toolName": "delete-site-list-item",
-    "appPermissions": ["Sites.ReadWrite.All"],
+    "appPermissions": [
+      "Sites.ReadWrite.All"
+    ],
     "riskLevel": "medium",
     "llmTip": "Deletes a SharePoint list item."
   },
-
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}",
     "method": "patch",
     "toolName": "update-exchange-mailbox",
-    "appPermissions": ["Exchange.ManageAsApp"],
+    "appPermissions": [
+      "Exchange.ManageAsApp"
+    ],
     "riskLevel": "medium",
     "llmTip": "Updates an Exchange mailbox configuration (admin). Body can include settings like archiveEnabled."
   },
@@ -3044,8 +3780,370 @@
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}",
     "method": "delete",
     "toolName": "delete-exchange-mailbox",
-    "appPermissions": ["Exchange.ManageAsApp"],
+    "appPermissions": [
+      "Exchange.ManageAsApp"
+    ],
     "riskLevel": "critical",
-    "llmTip": "Deletes an Exchange mailbox (admin). IRREVERSIBLE — all mailbox data will be permanently removed. Always confirm with operator before executing."
+    "llmTip": "Deletes an Exchange mailbox (admin). IRREVERSIBLE \u2014 all mailbox data will be permanently removed. Always confirm with operator before executing."
+  },
+  {
+    "pathPattern": "/users",
+    "method": "post",
+    "toolName": "create-user",
+    "appPermissions": [
+      "User.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Creates a new user in the directory. Body requires displayName, mailNickname, userPrincipalName, accountEnabled, and passwordProfile."
+  },
+  {
+    "pathPattern": "/users/{user-id}",
+    "method": "delete",
+    "toolName": "delete-user",
+    "appPermissions": [
+      "User.ReadWrite.All"
+    ],
+    "riskLevel": "critical",
+    "llmTip": "Deletes a user from the directory. The user is moved to deletedItems and can be restored within 30 days. Always confirm with operator before executing."
+  },
+  {
+    "pathPattern": "/users/{user-id}/assignLicense",
+    "method": "post",
+    "toolName": "assign-user-license",
+    "appPermissions": [
+      "User.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Assigns or removes licenses for a user. Body requires addLicenses (array of {disabledPlans, skuId}) and removeLicenses (array of skuId GUIDs)."
+  },
+  {
+    "pathPattern": "/users/{user-id}/reprocessLicenseAssignment",
+    "method": "post",
+    "toolName": "reprocess-user-license",
+    "appPermissions": [
+      "User.ReadWrite.All"
+    ],
+    "riskLevel": "low",
+    "llmTip": "Reprocesses all group-based license assignments for a user. Useful when license assignment is in an error state."
+  },
+  {
+    "pathPattern": "/users/{user-id}/changePassword",
+    "method": "post",
+    "toolName": "change-user-password",
+    "appPermissions": [
+      "Directory.AccessAsUser.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Changes the signed-in user's password. Body requires currentPassword and newPassword. This is a delegated-only operation."
+  },
+  {
+    "pathPattern": "/groups",
+    "method": "post",
+    "toolName": "create-group",
+    "appPermissions": [
+      "Group.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Creates a new group. Body requires displayName, mailEnabled, mailNickname, securityEnabled. Set groupTypes=['Unified'] for Microsoft 365 group."
+  },
+  {
+    "pathPattern": "/groups/{group-id}",
+    "method": "patch",
+    "toolName": "update-group",
+    "appPermissions": [
+      "Group.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Updates group properties (displayName, description, visibility, etc.)."
+  },
+  {
+    "pathPattern": "/groups/{group-id}",
+    "method": "delete",
+    "toolName": "delete-group",
+    "appPermissions": [
+      "Group.ReadWrite.All"
+    ],
+    "riskLevel": "critical",
+    "llmTip": "Deletes a group. For Microsoft 365 groups, can be restored within 30 days. Security groups are permanently deleted. Always confirm with operator."
+  },
+  {
+    "pathPattern": "/groups/{group-id}/members/$ref",
+    "method": "post",
+    "toolName": "add-group-member",
+    "appPermissions": [
+      "GroupMember.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Adds a member to a group. Body requires @odata.id pointing to the directoryObject (e.g., https://graph.microsoft.com/v1.0/users/{id})."
+  },
+  {
+    "pathPattern": "/applications/{application-id}",
+    "method": "patch",
+    "toolName": "update-application",
+    "appPermissions": [
+      "Application.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Updates an application registration (displayName, identifierUris, web redirect URIs, requiredResourceAccess, etc.)."
+  },
+  {
+    "pathPattern": "/applications/{application-id}",
+    "method": "delete",
+    "toolName": "delete-application",
+    "appPermissions": [
+      "Application.ReadWrite.All"
+    ],
+    "riskLevel": "critical",
+    "llmTip": "Deletes an application registration. Can be restored from deletedItems within 30 days. Always confirm with operator."
+  },
+  {
+    "pathPattern": "/servicePrincipals/{servicePrincipal-id}",
+    "method": "patch",
+    "toolName": "update-service-principal",
+    "appPermissions": [
+      "Application.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Updates a service principal (displayName, appRoleAssignmentRequired, notes, tags, etc.)."
+  },
+  {
+    "pathPattern": "/directoryRoles/{directoryRole-id}/members/$ref",
+    "method": "post",
+    "toolName": "add-directory-role-member",
+    "appPermissions": [
+      "RoleManagement.ReadWrite.Directory"
+    ],
+    "riskLevel": "critical",
+    "llmTip": "Adds a member to a directory role. Body requires @odata.id pointing to the user or service principal. CRITICAL: grants admin privileges."
+  },
+  {
+    "pathPattern": "/domains",
+    "method": "post",
+    "toolName": "create-domain",
+    "appPermissions": [
+      "Domain.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Adds a new domain to the tenant. Body requires id (the domain name, e.g., 'contoso.com'). Domain must be verified after creation."
+  },
+  {
+    "pathPattern": "/domains/{domain-id}/verify",
+    "method": "post",
+    "toolName": "verify-domain",
+    "appPermissions": [
+      "Domain.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Verifies domain ownership. DNS records (TXT or MX) must be configured before calling. Returns the verified domain object."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
+    "method": "post",
+    "toolName": "create-enrollment-configuration",
+    "appPermissions": [
+      "DeviceManagementServiceConfig.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Creates a new device enrollment configuration (enrollment restrictions, ESP profile, etc.)."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations/{deviceEnrollmentConfiguration-id}",
+    "method": "patch",
+    "toolName": "update-enrollment-configuration",
+    "appPermissions": [
+      "DeviceManagementServiceConfig.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Updates a device enrollment configuration (displayName, description, priority, etc.)."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations/{deviceEnrollmentConfiguration-id}",
+    "method": "delete",
+    "toolName": "delete-enrollment-configuration",
+    "appPermissions": [
+      "DeviceManagementServiceConfig.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Deletes a device enrollment configuration. Cannot delete default configurations."
+  },
+  {
+    "pathPattern": "/deviceManagement/windowsAutopilotDeviceIdentities/{windowsAutopilotDeviceIdentity-id}",
+    "method": "patch",
+    "toolName": "update-autopilot-device",
+    "appPermissions": [
+      "DeviceManagementServiceConfig.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Updates properties of an Autopilot device identity (groupTag, displayName, etc.)."
+  },
+  {
+    "pathPattern": "/deviceManagement/windowsAutopilotDeviceIdentities/{windowsAutopilotDeviceIdentity-id}",
+    "method": "delete",
+    "toolName": "delete-autopilot-device",
+    "appPermissions": [
+      "DeviceManagementServiceConfig.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Deletes an Autopilot device identity from Intune. The physical device is not affected."
+  },
+  {
+    "pathPattern": "/deviceManagement/importedWindowsAutopilotDeviceIdentities",
+    "method": "post",
+    "toolName": "import-autopilot-device",
+    "appPermissions": [
+      "DeviceManagementServiceConfig.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Imports a new Autopilot device identity. Body requires serialNumber and hardwareIdentifier (base64-encoded hardware hash)."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}",
+    "method": "delete",
+    "toolName": "delete-managed-device",
+    "appPermissions": [
+      "DeviceManagementManagedDevices.ReadWrite.All"
+    ],
+    "riskLevel": "critical",
+    "llmTip": "Deletes a managed device record from Intune. Does NOT wipe the physical device. Use wipe-managed-device for factory reset."
+  },
+  {
+    "pathPattern": "/directory/administrativeUnits",
+    "method": "post",
+    "toolName": "create-administrative-unit",
+    "appPermissions": [
+      "AdministrativeUnit.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Creates a new administrative unit. Body requires displayName. Optional: description, visibility ('HiddenMembership' or null)."
+  },
+  {
+    "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}",
+    "method": "patch",
+    "toolName": "update-administrative-unit",
+    "appPermissions": [
+      "AdministrativeUnit.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Updates an administrative unit (displayName, description, visibility)."
+  },
+  {
+    "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}",
+    "method": "delete",
+    "toolName": "delete-administrative-unit",
+    "appPermissions": [
+      "AdministrativeUnit.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Deletes an administrative unit. All scoped role assignments are also removed."
+  },
+  {
+    "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}/members/$ref",
+    "method": "post",
+    "toolName": "add-administrative-unit-member",
+    "appPermissions": [
+      "AdministrativeUnit.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Adds a member (user or group) to an administrative unit. Body requires @odata.id pointing to the directory object."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/authenticationStrength/policies",
+    "method": "post",
+    "toolName": "create-auth-strength-policy",
+    "appPermissions": [
+      "Policy.ReadWrite.AuthenticationMethod"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Creates a custom authentication strength policy. Body requires displayName and allowedCombinations (array of auth method combos like 'password,microsoftAuthenticatorPush')."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/authenticationStrength/policies/{authenticationStrengthPolicy-id}",
+    "method": "get",
+    "toolName": "get-auth-strength-policy",
+    "appPermissions": [
+      "Policy.Read.All"
+    ],
+    "riskLevel": "low",
+    "llmTip": "Gets a specific authentication strength policy by ID."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/authenticationStrength/policies/{authenticationStrengthPolicy-id}",
+    "method": "patch",
+    "toolName": "update-auth-strength-policy",
+    "appPermissions": [
+      "Policy.ReadWrite.AuthenticationMethod"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Updates a custom authentication strength policy (displayName, description, allowedCombinations). Built-in policies cannot be modified."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/authenticationStrength/policies/{authenticationStrengthPolicy-id}",
+    "method": "delete",
+    "toolName": "delete-auth-strength-policy",
+    "appPermissions": [
+      "Policy.ReadWrite.AuthenticationMethod"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Deletes a custom authentication strength policy. Built-in policies cannot be deleted. Fails if policy is referenced by a Conditional Access policy."
+  },
+  {
+    "pathPattern": "/security/attackSimulation/simulations",
+    "method": "post",
+    "toolName": "create-attack-simulation",
+    "appPermissions": [
+      "AttackSimulation.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Creates a new attack simulation campaign. Body requires displayName, attackTechnique, status, and payload configuration."
+  },
+  {
+    "pathPattern": "/security/attackSimulation/simulations/{simulation-id}",
+    "method": "patch",
+    "toolName": "update-attack-simulation",
+    "appPermissions": [
+      "AttackSimulation.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Updates an attack simulation (displayName, status, etc.). Can be used to launch or cancel a simulation."
+  },
+  {
+    "pathPattern": "/security/attackSimulation/simulations/{simulation-id}",
+    "method": "delete",
+    "toolName": "delete-attack-simulation",
+    "appPermissions": [
+      "AttackSimulation.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Deletes an attack simulation campaign."
+  },
+  {
+    "pathPattern": "/deviceManagement/virtualEndpoint/provisioningPolicies",
+    "method": "post",
+    "toolName": "create-cloud-pc-provisioning-policy",
+    "appPermissions": [
+      "CloudPC.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Creates a new Cloud PC provisioning policy. Body requires displayName, imageId or imageDisplayName, imageType, and onPremisesConnectionId."
+  },
+  {
+    "pathPattern": "/deviceManagement/virtualEndpoint/provisioningPolicies/{cloudPcProvisioningPolicy-id}",
+    "method": "patch",
+    "toolName": "update-cloud-pc-provisioning-policy",
+    "appPermissions": [
+      "CloudPC.ReadWrite.All"
+    ],
+    "riskLevel": "medium",
+    "llmTip": "Updates a Cloud PC provisioning policy (displayName, description, imageId, onPremisesConnectionId, etc.)."
+  },
+  {
+    "pathPattern": "/deviceManagement/virtualEndpoint/provisioningPolicies/{cloudPcProvisioningPolicy-id}",
+    "method": "delete",
+    "toolName": "delete-cloud-pc-provisioning-policy",
+    "appPermissions": [
+      "CloudPC.ReadWrite.All"
+    ],
+    "riskLevel": "high",
+    "llmTip": "Deletes a Cloud PC provisioning policy. Existing Cloud PCs provisioned with this policy are not affected."
   }
 ]

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -3,27 +3,21 @@
     "pathPattern": "/security/alerts_v2",
     "method": "get",
     "toolName": "list-security-alerts",
-    "appPermissions": [
-      "SecurityAlert.Read.All"
-    ],
+    "appPermissions": ["SecurityAlert.Read.All"],
     "llmTip": "Lists security alerts from Microsoft 365 Defender. Use $filter=status eq 'new' or status eq 'inProgress' to filter by status. Use $filter=severity eq 'high' to filter by severity (informational, low, medium, high). Use $orderby=createdDateTime desc to sort by newest. Use $top to limit results. Each alert has title, description, severity, status, category, serviceSource, detectionSource, and evidence."
   },
   {
     "pathPattern": "/security/alerts_v2/{alert-id}",
     "method": "get",
     "toolName": "get-security-alert",
-    "appPermissions": [
-      "SecurityAlert.Read.All"
-    ],
+    "appPermissions": ["SecurityAlert.Read.All"],
     "llmTip": "Gets a specific security alert by ID. Returns full alert details including title, description, severity, status, category, serviceSource, evidence, mitreTechniques, actorDisplayName, and recommendedActions."
   },
   {
     "pathPattern": "/security/alerts_v2/{alert-id}",
     "method": "patch",
     "toolName": "update-security-alert",
-    "appPermissions": [
-      "SecurityAlert.ReadWrite.All"
-    ],
+    "appPermissions": ["SecurityAlert.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates a security alert. Body can include: status ('new', 'inProgress', 'resolved'), assignedTo (email), classification ('truePositive', 'falsePositive', 'informationalExpectedActivity'), determination, comment."
   },
@@ -31,27 +25,21 @@
     "pathPattern": "/security/incidents",
     "method": "get",
     "toolName": "list-security-incidents",
-    "appPermissions": [
-      "SecurityIncident.Read.All"
-    ],
+    "appPermissions": ["SecurityIncident.Read.All"],
     "llmTip": "Lists security incidents from Microsoft 365 Defender. An incident correlates multiple alerts from the same attack. Use $filter=status eq 'active' to filter active incidents. Use $filter=severity eq 'high' to filter by severity. Use $orderby=createdDateTime desc. Each incident has displayName, severity, status, assignedTo, classification, and linked alerts."
   },
   {
     "pathPattern": "/security/incidents/{incident-id}",
     "method": "get",
     "toolName": "get-security-incident",
-    "appPermissions": [
-      "SecurityIncident.Read.All"
-    ],
+    "appPermissions": ["SecurityIncident.Read.All"],
     "llmTip": "Gets a specific security incident by ID. Returns full details including displayName, severity, status, assignedTo, classification, determination, description, and linked alerts."
   },
   {
     "pathPattern": "/security/incidents/{incident-id}",
     "method": "patch",
     "toolName": "update-security-incident",
-    "appPermissions": [
-      "SecurityIncident.ReadWrite.All"
-    ],
+    "appPermissions": ["SecurityIncident.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates a security incident. Body can include: status ('active', 'resolved', 'redirected'), assignedTo (email), classification ('truePositive', 'falsePositive', 'informationalExpectedActivity'), determination, customTags."
   },
@@ -59,300 +47,228 @@
     "pathPattern": "/auditLogs/directoryAudits",
     "method": "get",
     "toolName": "list-directory-audits",
-    "appPermissions": [
-      "AuditLog.Read.All"
-    ],
+    "appPermissions": ["AuditLog.Read.All"],
     "llmTip": "Lists Azure AD directory audit logs. Use $filter=activityDateTime ge 2024-01-01T00:00:00Z to filter by date. Use $filter=category eq 'UserManagement' to filter by category. Use $filter=activityDisplayName eq 'Add user' to find specific activities. Each entry has activityDisplayName, category, result, initiatedBy, targetResources, and activityDateTime."
   },
   {
     "pathPattern": "/auditLogs/signIns",
     "method": "get",
     "toolName": "list-sign-ins",
-    "appPermissions": [
-      "AuditLog.Read.All"
-    ],
+    "appPermissions": ["AuditLog.Read.All"],
     "llmTip": "Lists Azure AD sign-in logs. Use $filter=createdDateTime ge 2024-01-01T00:00:00Z to filter by date. Use $filter=userPrincipalName eq 'user@domain.com' to filter by user. Use $filter=status/errorCode ne 0 to find failed sign-ins. Each entry has userDisplayName, userPrincipalName, appDisplayName, ipAddress, location, status, conditionalAccessStatus, and riskState."
   },
   {
     "pathPattern": "/auditLogs/provisioning",
     "method": "get",
     "toolName": "list-provisioning-logs",
-    "appPermissions": [
-      "AuditLog.Read.All"
-    ],
+    "appPermissions": ["AuditLog.Read.All"],
     "llmTip": "Lists provisioning logs for Azure AD and third-party integrations. Use $filter=statusInfo/status eq 'failure' to find failed provisioning events. Use $filter=provisioningAction eq 'create' to filter by action type (create, update, delete, disable). Each entry has sourceSystem, targetSystem, provisioningAction, initiatedBy, sourceIdentity, targetIdentity, and statusInfo."
   },
   {
     "pathPattern": "/admin/serviceAnnouncement/healthOverviews",
     "method": "get",
     "toolName": "list-service-health",
-    "appPermissions": [
-      "ServiceHealth.Read.All"
-    ],
+    "appPermissions": ["ServiceHealth.Read.All"],
     "llmTip": "Lists health status for all Microsoft 365 services. Each entry has service name (Exchange Online, Microsoft Teams, etc.) and status (serviceDegradation, serviceOperational, etc.). Use $select=service,status to get a quick overview."
   },
   {
     "pathPattern": "/admin/serviceAnnouncement/issues",
     "method": "get",
     "toolName": "list-service-issues",
-    "appPermissions": [
-      "ServiceHealth.Read.All"
-    ],
+    "appPermissions": ["ServiceHealth.Read.All"],
     "llmTip": "Lists active and recent service health issues. Use $filter=isResolved eq false to see only active issues. Each issue has title, service, status (investigating, serviceRestored, etc.), classification (advisory, incident), startDateTime, and posts with updates."
   },
   {
     "pathPattern": "/admin/serviceAnnouncement/messages",
     "method": "get",
     "toolName": "list-service-messages",
-    "appPermissions": [
-      "ServiceMessage.Read.All"
-    ],
+    "appPermissions": ["ServiceMessage.Read.All"],
     "llmTip": "Lists Message Center posts about planned changes, new features, and actions required. Use $filter=services/any(s:s eq 'Exchange Online') to filter by service. Use $filter=category eq 'planForChange' to filter by category (planForChange, stayInformed, preventOrFixIssue). Each message has title, body, services, tags, startDateTime, endDateTime, and actionRequiredByDateTime."
   },
   {
     "pathPattern": "/reports/getTeamsUserActivityCounts(period='{period}')",
     "method": "get",
     "toolName": "get-teams-activity-report",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
-    "skipEncoding": [
-      "period"
-    ],
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
     "llmTip": "Gets Teams user activity counts for the specified period. The period parameter must be one of: D7, D30, D90, D180 (last 7/30/90/180 days). Returns CSV data with daily counts of teamChatMessages, privateChatMessages, calls, and meetings."
   },
   {
     "pathPattern": "/reports/getEmailActivityCounts(period='{period}')",
     "method": "get",
     "toolName": "get-email-activity-report",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
-    "skipEncoding": [
-      "period"
-    ],
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
     "llmTip": "Gets email activity counts for the specified period. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with daily counts of send, receive, and read email activities."
   },
   {
     "pathPattern": "/reports/getOffice365ActiveUserDetail(period='{period}')",
     "method": "get",
     "toolName": "get-active-users-report",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
-    "skipEncoding": [
-      "period"
-    ],
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
     "llmTip": "Gets details about active Microsoft 365 users. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with per-user details: displayName, isDeleted, lastActivityDate, and product-specific activity dates (Exchange, OneDrive, SharePoint, Teams, etc.)."
   },
   {
     "pathPattern": "/reports/getSharePointSiteUsageDetail(period='{period}')",
     "method": "get",
     "toolName": "get-sharepoint-usage-report",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
-    "skipEncoding": [
-      "period"
-    ],
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
     "llmTip": "Gets SharePoint site usage details. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with per-site details: siteUrl, ownerDisplayName, storageUsedInBytes, fileCount, activeFileCount, pageViewCount, lastActivityDate."
   },
   {
     "pathPattern": "/users",
     "method": "get",
     "toolName": "list-users",
-    "appPermissions": [
-      "User.Read.All"
-    ],
+    "appPermissions": ["User.Read.All"],
     "llmTip": "Lists all users in the tenant. Use $filter=accountEnabled eq true/false to find enabled/disabled accounts. Use $select=displayName,userPrincipalName,accountEnabled,signInActivity,createdDateTime to get key fields. Use $filter=signInActivity/lastSignInDateTime le 2024-01-01T00:00:00Z to find inactive users. Use $top to paginate, follow @odata.nextLink for more. Max $top=999 for users."
   },
   {
     "pathPattern": "/users/{user-id}",
     "method": "get",
     "toolName": "get-user",
-    "appPermissions": [
-      "User.Read.All"
-    ],
+    "appPermissions": ["User.Read.All"],
     "llmTip": "Gets a single user by ID or userPrincipalName. Use $select=displayName,userPrincipalName,accountEnabled,signInActivity,assignedLicenses,memberOf to get detailed info. signInActivity requires AuditLog.Read.All in addition to User.Read.All."
   },
   {
     "pathPattern": "/users/{user-id}/memberOf",
     "method": "get",
     "toolName": "list-user-memberships",
-    "appPermissions": [
-      "Directory.Read.All"
-    ],
+    "appPermissions": ["Directory.Read.All"],
     "llmTip": "Lists all groups and directory roles a user is a member of. Returns directoryRole and group objects. Use $select=displayName,id to reduce payload. Useful for auditing a user's access."
   },
   {
     "pathPattern": "/users/{user-id}/authentication/methods",
     "method": "get",
     "toolName": "list-user-auth-methods",
-    "appPermissions": [
-      "UserAuthenticationMethod.Read.All"
-    ],
+    "appPermissions": ["UserAuthenticationMethod.Read.All"],
     "llmTip": "Lists authentication methods registered for a user (phone, email, FIDO2, Microsoft Authenticator, etc.). Useful for MFA coverage audits. Each method has @odata.type to identify the method kind."
   },
   {
     "pathPattern": "/users/{user-id}/registeredDevices",
     "method": "get",
     "toolName": "list-user-devices",
-    "appPermissions": [
-      "Directory.Read.All"
-    ],
+    "appPermissions": ["Directory.Read.All"],
     "llmTip": "Lists devices registered to a user. Returns device objects with displayName, operatingSystem, operatingSystemVersion, isCompliant, isManaged, approximateLastSignInDateTime."
   },
   {
     "pathPattern": "/groups",
     "method": "get",
     "toolName": "list-groups",
-    "appPermissions": [
-      "Group.Read.All"
-    ],
+    "appPermissions": ["Group.Read.All"],
     "llmTip": "Lists all groups. Use $filter=groupTypes/any(c:c eq 'Unified') for Microsoft 365 groups. Use $filter=securityEnabled eq true for security groups. Use $filter=onPremisesSyncEnabled eq true for hybrid-synced groups. Use $select=displayName,mail,groupTypes,securityEnabled,membershipRule to get key fields."
   },
   {
     "pathPattern": "/groups/{group-id}",
     "method": "get",
     "toolName": "get-group",
-    "appPermissions": [
-      "Group.Read.All"
-    ],
+    "appPermissions": ["Group.Read.All"],
     "llmTip": "Gets a single group by ID. Use $select=displayName,description,groupTypes,securityEnabled,membershipRule,membershipRuleProcessingState for policy details."
   },
   {
     "pathPattern": "/groups/{group-id}/members",
     "method": "get",
     "toolName": "list-group-members",
-    "appPermissions": [
-      "GroupMember.Read.All"
-    ],
+    "appPermissions": ["GroupMember.Read.All"],
     "llmTip": "Lists members of a group. Returns user and servicePrincipal objects. Use $select=displayName,userPrincipalName,id. Use $top to paginate. For large groups, use $count=true with ConsistencyLevel=eventual header."
   },
   {
     "pathPattern": "/groups/{group-id}/owners",
     "method": "get",
     "toolName": "list-group-owners",
-    "appPermissions": [
-      "GroupMember.Read.All"
-    ],
+    "appPermissions": ["GroupMember.Read.All"],
     "llmTip": "Lists owners of a group. Useful for auditing ownerless groups. Returns user objects."
   },
   {
     "pathPattern": "/directoryRoles",
     "method": "get",
     "toolName": "list-directory-roles",
-    "appPermissions": [
-      "RoleManagement.Read.Directory"
-    ],
+    "appPermissions": ["RoleManagement.Read.Directory"],
     "llmTip": "Lists activated directory roles in the tenant. Only roles that have been activated (have at least one member) appear here. Use $expand=members to see who holds each role. Key roles to audit: Global Administrator, Privileged Role Administrator, Security Administrator."
   },
   {
     "pathPattern": "/directoryRoles/{directoryRole-id}/members",
     "method": "get",
     "toolName": "list-role-members",
-    "appPermissions": [
-      "RoleManagement.Read.Directory"
-    ],
+    "appPermissions": ["RoleManagement.Read.Directory"],
     "llmTip": "Lists members of a specific directory role. Use this to audit who has Global Admin, Exchange Admin, etc. Returns user and servicePrincipal objects."
   },
   {
     "pathPattern": "/roleManagement/directory/roleAssignments",
     "method": "get",
     "toolName": "list-role-assignments",
-    "appPermissions": [
-      "RoleManagement.Read.Directory"
-    ],
+    "appPermissions": ["RoleManagement.Read.Directory"],
     "llmTip": "Lists all role assignments in the directory. Use $filter=principalId eq '{user-id}' to find all roles for a specific user. Use $expand=principal to get user details. Includes both permanent and PIM-eligible assignments."
   },
   {
     "pathPattern": "/roleManagement/directory/roleDefinitions",
     "method": "get",
     "toolName": "list-role-definitions",
-    "appPermissions": [
-      "RoleManagement.Read.Directory"
-    ],
+    "appPermissions": ["RoleManagement.Read.Directory"],
     "llmTip": "Lists all role definitions (built-in and custom). Each has displayName, description, isBuiltIn, rolePermissions. Useful for understanding what each role can do."
   },
   {
     "pathPattern": "/identity/conditionalAccess/policies",
     "method": "get",
     "toolName": "list-conditional-access-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists all Conditional Access policies. Each policy has displayName, state (enabled/disabled/enabledForReportingButNotEnforced), conditions (users, applications, locations, platforms, signInRiskLevels), and grantControls (MFA, compliant device, etc.). Use this to audit MFA enforcement and access controls."
   },
   {
     "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
     "method": "get",
     "toolName": "get-conditional-access-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets a single Conditional Access policy by ID. Returns full policy details including conditions, grantControls, and sessionControls."
   },
   {
     "pathPattern": "/identity/conditionalAccess/namedLocations",
     "method": "get",
     "toolName": "list-named-locations",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists named locations used in Conditional Access policies. Shows trusted IP ranges and country-based locations. Useful for auditing geographic access controls."
   },
   {
     "pathPattern": "/applications",
     "method": "get",
     "toolName": "list-applications",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Lists all app registrations in the tenant. Use $select=displayName,appId,signInAudience,requiredResourceAccess,passwordCredentials,keyCredentials to audit app permissions and credentials. Use $filter=passwordCredentials/any(p:p/endDateTime le 2024-06-01T00:00:00Z) to find apps with expiring secrets (beta)."
   },
   {
     "pathPattern": "/servicePrincipals",
     "method": "get",
     "toolName": "list-service-principals",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Lists all service principals (enterprise apps). Use $filter=appOwnerOrganizationId ne '{tenant-id}' to find third-party apps. Use $select=displayName,appId,appOwnerOrganizationId,servicePrincipalType,accountEnabled to audit external access."
   },
   {
     "pathPattern": "/oauth2PermissionGrants",
     "method": "get",
     "toolName": "list-oauth2-grants",
-    "appPermissions": [
-      "Directory.Read.All"
-    ],
+    "appPermissions": ["Directory.Read.All"],
     "llmTip": "Lists all delegated permission grants (OAuth2 consent). Shows which apps have been granted what permissions by whom (admin consent vs user consent). Use $filter=consentType eq 'AllPrincipals' to find admin-consented grants. Critical for auditing overpermissioned apps."
   },
   {
     "pathPattern": "/organization",
     "method": "get",
     "toolName": "get-organization",
-    "appPermissions": [
-      "Organization.Read.All"
-    ],
+    "appPermissions": ["Organization.Read.All"],
     "llmTip": "Gets tenant organization info. Returns displayName, verifiedDomains, securityComplianceNotificationPhones, technicalNotificationMails, tenantType. Useful for basic tenant identity verification."
   },
   {
     "pathPattern": "/domains",
     "method": "get",
     "toolName": "list-domains",
-    "appPermissions": [
-      "Domain.Read.All"
-    ],
+    "appPermissions": ["Domain.Read.All"],
     "llmTip": "Lists all domains registered in the tenant. Shows isVerified, isDefault, authenticationType (Managed vs Federated). Useful for auditing federated domains and finding unverified domains."
   },
   {
     "pathPattern": "/users/{user-id}",
     "method": "patch",
     "toolName": "disable-user-account",
-    "appPermissions": [
-      "User.ReadWrite.All"
-    ],
+    "appPermissions": ["User.ReadWrite.All"],
     "riskLevel": "critical",
     "llmTip": "Disables a user account by setting accountEnabled to false. Body MUST be: {\"accountEnabled\": false}. This blocks all sign-ins immediately. Use for compromised accounts. CRITICAL: verify the user-id carefully \u2014 disabling the wrong account locks out a legitimate user. To re-enable, send {\"accountEnabled\": true}."
   },
@@ -360,9 +276,7 @@
     "pathPattern": "/users/{user-id}/revokeSignInSessions",
     "method": "post",
     "toolName": "revoke-user-sessions",
-    "appPermissions": [
-      "User.ReadWrite.All"
-    ],
+    "appPermissions": ["User.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Revokes all refresh tokens and session cookies for a user, forcing re-authentication everywhere. No request body needed. Use after password reset or account compromise. Effect is not instant \u2014 cached tokens may remain valid for up to 1 hour. Combine with disable-user-account for immediate containment."
   },
@@ -370,9 +284,7 @@
     "pathPattern": "/security/alerts_v2/{alert-id}/comments",
     "method": "post",
     "toolName": "add-security-alert-comment",
-    "appPermissions": [
-      "SecurityAlert.ReadWrite.All"
-    ],
+    "appPermissions": ["SecurityAlert.ReadWrite.All"],
     "riskLevel": "low",
     "llmTip": "Adds a comment to a security alert for tracking investigation progress. Body: {\"comment\": \"your comment text\"}. Use to document triage decisions and findings."
   },
@@ -380,9 +292,7 @@
     "pathPattern": "/devices/{device-id}",
     "method": "patch",
     "toolName": "update-device",
-    "appPermissions": [
-      "Device.ReadWrite.All"
-    ],
+    "appPermissions": ["Device.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Updates device properties. Use {\"accountEnabled\": false} to disable a device in Entra ID. This prevents the device from authenticating. Useful for lost/stolen devices or compromised endpoints."
   },
@@ -390,297 +300,231 @@
     "pathPattern": "/subscribedSkus",
     "method": "get",
     "toolName": "list-subscribed-skus",
-    "appPermissions": [
-      "Organization.Read.All"
-    ],
+    "appPermissions": ["Organization.Read.All"],
     "llmTip": "Lists all commercial subscriptions (licenses) in the tenant. Each SKU has skuPartNumber (e.g. ENTERPRISEPACK for E3), prepaidUnits, consumedUnits. Use to audit license allocation and find unused licenses."
   },
   {
     "pathPattern": "/subscribedSkus/{subscribedSku-id}",
     "method": "get",
     "toolName": "get-subscribed-sku",
-    "appPermissions": [
-      "Organization.Read.All"
-    ],
+    "appPermissions": ["Organization.Read.All"],
     "llmTip": "Gets details for a specific license SKU by ID. Returns prepaidUnits (enabled, suspended, warning), consumedUnits, and servicePlans with their provisioning status."
   },
   {
     "pathPattern": "/security/secureScores",
     "method": "get",
     "toolName": "list-secure-scores",
-    "appPermissions": [
-      "SecurityEvents.Read.All"
-    ],
+    "appPermissions": ["SecurityEvents.Read.All"],
     "llmTip": "Lists Secure Score snapshots over time. Each entry has currentScore, maxScore, and controlScores array. Use $top=1&$orderby=createdDateTime desc to get the latest score. Useful for tracking security posture improvement."
   },
   {
     "pathPattern": "/security/secureScores/{secureScore-id}",
     "method": "get",
     "toolName": "get-secure-score",
-    "appPermissions": [
-      "SecurityEvents.Read.All"
-    ],
+    "appPermissions": ["SecurityEvents.Read.All"],
     "llmTip": "Gets a specific Secure Score snapshot. Returns currentScore, maxScore, averageComparativeScores (comparison with similar tenants), and controlScores with detailed per-control scoring."
   },
   {
     "pathPattern": "/security/secureScoreControlProfiles",
     "method": "get",
     "toolName": "list-secure-score-controls",
-    "appPermissions": [
-      "SecurityEvents.Read.All"
-    ],
+    "appPermissions": ["SecurityEvents.Read.All"],
     "llmTip": "Lists all Secure Score control profiles. Each has title, maxScore, implementationStatus, and actionUrl. Useful to prioritize security improvements."
   },
   {
     "pathPattern": "/security/secureScoreControlProfiles/{secureScoreControlProfile-id}",
     "method": "get",
     "toolName": "get-secure-score-control",
-    "appPermissions": [
-      "SecurityEvents.Read.All"
-    ],
+    "appPermissions": ["SecurityEvents.Read.All"],
     "llmTip": "Gets a specific Secure Score control profile. Returns remediation impact, implementation cost, threats addressed, and compliance information."
   },
   {
     "pathPattern": "/identityProtection/riskyUsers",
     "method": "get",
     "toolName": "list-risky-users",
-    "appPermissions": [
-      "IdentityRiskyUser.Read.All"
-    ],
+    "appPermissions": ["IdentityRiskyUser.Read.All"],
     "llmTip": "Lists users flagged as risky by Identity Protection. Use $filter=riskLevel eq 'high' to find high-risk users. Each entry has riskLevel (low, medium, high), riskState (atRisk, confirmedCompromised, remediated, dismissed), riskDetail, and riskLastUpdatedDateTime."
   },
   {
     "pathPattern": "/identityProtection/riskyUsers/{riskyUser-id}",
     "method": "get",
     "toolName": "get-risky-user",
-    "appPermissions": [
-      "IdentityRiskyUser.Read.All"
-    ],
+    "appPermissions": ["IdentityRiskyUser.Read.All"],
     "llmTip": "Gets details for a specific risky user. Returns full risk information including riskLevel, riskState, riskDetail, and history."
   },
   {
     "pathPattern": "/identityProtection/riskyUsers/{riskyUser-id}/history",
     "method": "get",
     "toolName": "list-risky-user-history",
-    "appPermissions": [
-      "IdentityRiskyUser.Read.All"
-    ],
+    "appPermissions": ["IdentityRiskyUser.Read.All"],
     "llmTip": "Lists the risk history for a specific user. Shows how risk level changed over time and what triggered each risk event."
   },
   {
     "pathPattern": "/identityProtection/riskyServicePrincipals",
     "method": "get",
     "toolName": "list-risky-service-principals",
-    "appPermissions": [
-      "IdentityRiskyServicePrincipal.Read.All"
-    ],
+    "appPermissions": ["IdentityRiskyServicePrincipal.Read.All"],
     "llmTip": "Lists service principals flagged as risky. Useful for detecting compromised applications and service accounts."
   },
   {
     "pathPattern": "/identityProtection/riskyServicePrincipals/{riskyServicePrincipal-id}",
     "method": "get",
     "toolName": "get-risky-service-principal",
-    "appPermissions": [
-      "IdentityRiskyServicePrincipal.Read.All"
-    ],
+    "appPermissions": ["IdentityRiskyServicePrincipal.Read.All"],
     "llmTip": "Gets details for a specific risky service principal. Returns riskLevel, riskState, and riskDetail."
   },
   {
     "pathPattern": "/policies/authenticationMethodsPolicy",
     "method": "get",
     "toolName": "get-auth-methods-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the tenant authentication methods policy. Shows which authentication methods are enabled (FIDO2, Microsoft Authenticator, SMS, etc.) and their configuration. Critical for auditing MFA enforcement."
   },
   {
     "pathPattern": "/policies/authenticationMethodsPolicy/authenticationMethodConfigurations",
     "method": "get",
     "toolName": "list-auth-method-configs",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists all authentication method configurations. Each has id (method type), state (enabled/disabled), and method-specific settings. Useful to verify FIDO2, Authenticator, and passwordless policies."
   },
   {
     "pathPattern": "/policies/authenticationMethodsPolicy/authenticationMethodConfigurations/{authenticationMethodConfiguration-id}",
     "method": "get",
     "toolName": "get-auth-method-config",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets a specific authentication method configuration. IDs include: microsoftAuthenticator, fido2, email, sms, temporaryAccessPass, x509Certificate, etc."
   },
   {
     "pathPattern": "/policies/identitySecurityDefaultsEnforcementPolicy",
     "method": "get",
     "toolName": "get-security-defaults",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the security defaults policy. Returns isEnabled (true/false). Security defaults enforce MFA for all users, block legacy auth, and require MFA for admin roles. Should be disabled only if Conditional Access is used instead."
   },
   {
     "pathPattern": "/policies/adminConsentRequestPolicy",
     "method": "get",
     "toolName": "get-admin-consent-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the admin consent request policy. Shows isEnabled, notifyReviewers, remindersEnabled, and reviewers list. Controls whether users can request admin consent for apps they want to use."
   },
   {
     "pathPattern": "/devices",
     "method": "get",
     "toolName": "list-devices",
-    "appPermissions": [
-      "Device.Read.All"
-    ],
+    "appPermissions": ["Device.Read.All"],
     "llmTip": "Lists all devices registered in the tenant. Use $filter=isCompliant eq false to find non-compliant devices. Use $filter=isManaged eq true for Intune-managed devices. Use $filter=operatingSystem eq 'Windows' to filter by OS. Use $select=displayName,operatingSystem,operatingSystemVersion,isCompliant,isManaged,accountEnabled,approximateLastSignInDateTime. Use $filter=approximateLastSignInDateTime le 2024-01-01T00:00:00Z to find stale devices."
   },
   {
     "pathPattern": "/devices/{device-id}",
     "method": "get",
     "toolName": "get-device",
-    "appPermissions": [
-      "Device.Read.All"
-    ],
+    "appPermissions": ["Device.Read.All"],
     "llmTip": "Gets a specific device by ID. Returns displayName, operatingSystem, operatingSystemVersion, isCompliant, isManaged, accountEnabled, trustType, approximateLastSignInDateTime, and deviceId."
   },
   {
     "pathPattern": "/identityProtection/riskDetections",
     "method": "get",
     "toolName": "list-risk-detections",
-    "appPermissions": [
-      "IdentityRiskEvent.Read.All"
-    ],
+    "appPermissions": ["IdentityRiskEvent.Read.All"],
     "llmTip": "Lists individual risk detections from Identity Protection. Use $filter=riskLevel eq 'high' to find high-risk events. Use $filter=detectedDateTime ge 2024-01-01T00:00:00Z to filter by date. Each detection has riskEventType (e.g. anonymizedIPAddress, leakedCredentials, malwareInfectedIPAddress), riskLevel, riskState, userPrincipalName, ipAddress, location, and activityType (signin, user)."
   },
   {
     "pathPattern": "/identityProtection/riskDetections/{riskDetection-id}",
     "method": "get",
     "toolName": "get-risk-detection",
-    "appPermissions": [
-      "IdentityRiskEvent.Read.All"
-    ],
+    "appPermissions": ["IdentityRiskEvent.Read.All"],
     "llmTip": "Gets a specific risk detection by ID. Returns full details including riskEventType, riskLevel, detectionTimingType (realtime, offline), source, ipAddress, location, userPrincipalName, and additionalInfo."
   },
   {
     "pathPattern": "/directory/deletedItems/graph.user",
     "method": "get",
     "toolName": "list-deleted-users",
-    "appPermissions": [
-      "User.Read.All"
-    ],
+    "appPermissions": ["User.Read.All"],
     "llmTip": "Lists recently deleted users (recoverable within 30 days). Use $select=displayName,userPrincipalName,deletedDateTime to see when each user was deleted. Useful for auditing account deletions and potential recovery."
   },
   {
     "pathPattern": "/directory/deletedItems/graph.group",
     "method": "get",
     "toolName": "list-deleted-groups",
-    "appPermissions": [
-      "Group.Read.All"
-    ],
+    "appPermissions": ["Group.Read.All"],
     "llmTip": "Lists recently deleted groups (recoverable within 30 days). Only Microsoft 365 groups (unified groups) are soft-deleted and recoverable. Use $select=displayName,deletedDateTime,groupTypes."
   },
   {
     "pathPattern": "/directory/administrativeUnits",
     "method": "get",
     "toolName": "list-administrative-units",
-    "appPermissions": [
-      "AdministrativeUnit.Read.All"
-    ],
+    "appPermissions": ["AdministrativeUnit.Read.All"],
     "llmTip": "Lists all administrative units in the tenant. Administrative units scope admin roles to a subset of users/groups/devices. Use $select=displayName,description,membershipType,membershipRule. membershipType can be 'Assigned' or 'Dynamic'."
   },
   {
     "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}",
     "method": "get",
     "toolName": "get-administrative-unit",
-    "appPermissions": [
-      "AdministrativeUnit.Read.All"
-    ],
+    "appPermissions": ["AdministrativeUnit.Read.All"],
     "llmTip": "Gets a specific administrative unit by ID. Returns displayName, description, membershipType, membershipRule, and visibility."
   },
   {
     "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}/members",
     "method": "get",
     "toolName": "list-administrative-unit-members",
-    "appPermissions": [
-      "AdministrativeUnit.Read.All"
-    ],
+    "appPermissions": ["AdministrativeUnit.Read.All"],
     "llmTip": "Lists members (users, groups, devices) of an administrative unit. Returns directory objects. Use $select=displayName,userPrincipalName for users."
   },
   {
     "pathPattern": "/policies/authenticationStrengthPolicies",
     "method": "get",
     "toolName": "list-auth-strength-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists authentication strength policies. These define which MFA method combinations are acceptable (e.g. phishing-resistant MFA, passwordless). Built-in policies include 'MFA', 'Passwordless MFA', and 'Phishing-resistant MFA'. Custom policies can restrict to specific methods. Used by Conditional Access grant controls."
   },
   {
     "pathPattern": "/policies/crossTenantAccessPolicy",
     "method": "get",
     "toolName": "get-cross-tenant-access-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the cross-tenant access policy. Controls B2B collaboration and B2B direct connect defaults. Returns allowedCloudEndpoints and default inbound/outbound settings for users, applications, and organizations."
   },
   {
     "pathPattern": "/policies/crossTenantAccessPolicy/partners",
     "method": "get",
     "toolName": "list-cross-tenant-partners",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists partner-specific cross-tenant access configurations. Each entry has tenantId and overrides for inbound/outbound B2B collaboration and direct connect settings. Useful for auditing which external organizations have special access."
   },
   {
     "pathPattern": "/roleManagement/directory/roleEligibilityScheduleInstances",
     "method": "get",
     "toolName": "list-pim-eligible-assignments",
-    "appPermissions": [
-      "RoleEligibilitySchedule.Read.Directory"
-    ],
+    "appPermissions": ["RoleEligibilitySchedule.Read.Directory"],
     "llmTip": "Lists PIM (Privileged Identity Management) eligible role assignments. These are just-in-time assignments that users must activate. Use $filter=principalId eq '{user-id}' to find eligible roles for a specific user. Use $expand=roleDefinition to get role names. Compare with list-role-assignments to distinguish permanent vs eligible assignments."
   },
   {
     "pathPattern": "/roleManagement/directory/roleAssignmentScheduleInstances",
     "method": "get",
     "toolName": "list-pim-active-assignments",
-    "appPermissions": [
-      "RoleAssignmentSchedule.Read.Directory"
-    ],
+    "appPermissions": ["RoleAssignmentSchedule.Read.Directory"],
     "llmTip": "Lists PIM active role assignment schedule instances, including time-bound and activated assignments. Use $filter=principalId eq '{user-id}' to find active assignments for a user. Shows assignmentType (Assigned or Activated), startDateTime, endDateTime. Useful for auditing who currently has active privileged roles."
   },
   {
     "pathPattern": "/users/{user-id}/appRoleAssignments",
     "method": "get",
     "toolName": "list-user-app-role-assignments",
-    "appPermissions": [
-      "AppRoleAssignment.Read.All"
-    ],
+    "appPermissions": ["AppRoleAssignment.Read.All"],
     "llmTip": "Lists app role assignments for a user. Shows which enterprise apps the user has been granted access to and with which roles. Each entry has appRoleId, resourceDisplayName, and principalDisplayName."
   },
   {
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}/appRoleAssignedTo",
     "method": "get",
     "toolName": "list-sp-app-role-assignments",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Lists all users and groups assigned app roles on a service principal. Use to audit who has access to a specific enterprise application. Each entry has principalDisplayName, principalType, appRoleId."
   },
   {
     "pathPattern": "/identityProtection/riskyUsers/confirmCompromised",
     "method": "post",
     "toolName": "confirm-compromised-users",
-    "appPermissions": [
-      "IdentityRiskyUser.ReadWrite.All"
-    ],
+    "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Confirms one or more users as compromised. Body: {\"userIds\": [\"user-id-1\", \"user-id-2\"]}. This sets riskState to confirmedCompromised and riskLevel to high, which triggers any Conditional Access policies targeting risky users. Use after confirming a breach."
   },
@@ -688,9 +532,7 @@
     "pathPattern": "/identityProtection/riskyUsers/dismiss",
     "method": "post",
     "toolName": "dismiss-risky-users",
-    "appPermissions": [
-      "IdentityRiskyUser.ReadWrite.All"
-    ],
+    "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Dismisses risk for one or more users. Body: {\"userIds\": [\"user-id-1\", \"user-id-2\"]}. Sets riskState to dismissed. Use after investigating a risk detection and determining it is a false positive or has been remediated."
   },
@@ -698,9 +540,7 @@
     "pathPattern": "/users/{user-id}/authentication/phoneMethods/{phoneAuthenticationMethod-id}",
     "method": "delete",
     "toolName": "delete-user-phone-auth-method",
-    "appPermissions": [
-      "UserAuthenticationMethod.ReadWrite.All"
-    ],
+    "appPermissions": ["UserAuthenticationMethod.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a phone authentication method for a user. Use list-user-auth-methods first to get the phoneAuthenticationMethod ID. Useful for removing a compromised phone number during incident response. Cannot delete if it is the user's only MFA method and MFA is required."
   },
@@ -708,750 +548,578 @@
     "pathPattern": "/reports/getOneDriveUsageAccountDetail(period='{period}')",
     "method": "get",
     "toolName": "get-onedrive-usage-report",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
-    "skipEncoding": [
-      "period"
-    ],
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
     "llmTip": "Gets OneDrive usage details per account. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with ownerDisplayName, ownerPrincipalName, siteUrl, storageUsedInBytes, fileCount, activeFileCount, lastActivityDate."
   },
   {
     "pathPattern": "/reports/getOffice365ActiveUserCounts(period='{period}')",
     "method": "get",
     "toolName": "get-active-user-counts-report",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
-    "skipEncoding": [
-      "period"
-    ],
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
     "llmTip": "Gets daily active user counts across Microsoft 365 services. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with daily counts per service: office365, exchange, oneDrive, sharePoint, skypeForBusiness, yammer, teams."
   },
   {
     "pathPattern": "/reports/getMailboxUsageDetail(period='{period}')",
     "method": "get",
     "toolName": "get-mailbox-usage-report",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
-    "skipEncoding": [
-      "period"
-    ],
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
     "llmTip": "Gets mailbox usage details per user. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data with userPrincipalName, displayName, storageUsedInBytes, issueWarningQuotaInBytes, prohibitSendQuotaInBytes, itemCount, lastActivityDate."
   },
   {
     "pathPattern": "/reports/getM365AppUserDetail(period='{period}')",
     "method": "get",
     "toolName": "get-m365-apps-usage-report",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
-    "skipEncoding": [
-      "period"
-    ],
+    "appPermissions": ["Reports.Read.All"],
+    "skipEncoding": ["period"],
     "llmTip": "Gets Microsoft 365 Apps usage details per user. The period parameter must be one of: D7, D30, D90, D180. Returns CSV data showing which apps each user used (Outlook, Word, Excel, PowerPoint, OneNote, Teams) and on which platforms (Windows, Mac, Web, Mobile)."
   },
   {
     "pathPattern": "/security/attackSimulation/simulations",
     "method": "get",
     "toolName": "list-attack-simulations",
-    "appPermissions": [
-      "AttackSimulation.Read.All"
-    ],
+    "appPermissions": ["AttackSimulation.Read.All"],
     "llmTip": "Lists attack simulation campaigns (phishing simulations). Each simulation has displayName, status, attackType (social, credential harvest, etc.), launchDateTime, completionDateTime, report with overview (resolvedTargetsCount, compromisedRate). Useful for tracking security awareness training effectiveness."
   },
   {
     "pathPattern": "/security/attackSimulation/simulations/{simulation-id}",
     "method": "get",
     "toolName": "get-attack-simulation",
-    "appPermissions": [
-      "AttackSimulation.Read.All"
-    ],
+    "appPermissions": ["AttackSimulation.Read.All"],
     "llmTip": "Gets a specific attack simulation by ID. Returns full details including report with simulationEventsContent (users who clicked, reported, etc.) and trainingsContent."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions",
     "method": "get",
     "toolName": "list-access-review-definitions",
-    "appPermissions": [
-      "AccessReview.Read.All"
-    ],
+    "appPermissions": ["AccessReview.Read.All"],
     "llmTip": "Lists all access review schedule definitions. Each definition has displayName, status (NotStarted, InProgress, Completed, Applied), scope (what is being reviewed: group members, app role assignments, etc.), reviewers, and settings (autoApplyDecisions, mailNotificationsEnabled, recurrence). Use $filter=status eq 'InProgress' to find active reviews."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}",
     "method": "get",
     "toolName": "get-access-review-definition",
-    "appPermissions": [
-      "AccessReview.Read.All"
-    ],
+    "appPermissions": ["AccessReview.Read.All"],
     "llmTip": "Gets a specific access review schedule definition by ID. Returns full configuration including scope, reviewers, fallbackReviewers, settings, stageSettings, and instances."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances",
     "method": "get",
     "toolName": "list-access-review-instances",
-    "appPermissions": [
-      "AccessReview.Read.All"
-    ],
+    "appPermissions": ["AccessReview.Read.All"],
     "llmTip": "Lists instances of an access review definition. Each recurring review creates instances. Each instance has status, startDateTime, endDateTime, and scope. Use to track review progress over time."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}",
     "method": "get",
     "toolName": "get-access-review-instance",
-    "appPermissions": [
-      "AccessReview.Read.All"
-    ],
+    "appPermissions": ["AccessReview.Read.All"],
     "llmTip": "Gets a specific access review instance. Returns status, startDateTime, endDateTime, scope, and reviewers for this particular execution of the review."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/definitions/{accessReviewScheduleDefinition-id}/instances/{accessReviewInstance-id}/decisions",
     "method": "get",
     "toolName": "list-access-review-decisions",
-    "appPermissions": [
-      "AccessReview.Read.All"
-    ],
+    "appPermissions": ["AccessReview.Read.All"],
     "llmTip": "Lists decisions made during an access review instance. Each decision has target (user/group), decision (Approve, Deny, NotReviewed, DontKnow), reviewedBy, justification, and appliedDateTime. Use to audit review outcomes and ensure decisions were applied."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/accessPackages",
     "method": "get",
     "toolName": "list-access-packages",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Lists all access packages in entitlement management. Each package bundles resources (group memberships, app roles, SharePoint sites) that can be requested. Use $select=displayName,description,isHidden,createdDateTime,modifiedDateTime. Use $expand=catalog to see which catalog each package belongs to."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/accessPackages/{accessPackage-id}",
     "method": "get",
     "toolName": "get-access-package",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Gets a specific access package by ID. Use $expand=resourceRoleScopes($expand=role,scope) to see what resources the package grants access to."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/assignments",
     "method": "get",
     "toolName": "list-access-package-assignments",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Lists access package assignments \u2014 who has been granted which access packages. Use $filter=state eq 'Delivered' to find active assignments. Use $filter=targetId eq '{user-id}' to find all packages assigned to a user. Use $expand=target,accessPackage to get user and package details. Each assignment has state (Delivering, Delivered, Expired, DeliveryFailed), schedule, and targetId."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/assignmentRequests",
     "method": "get",
     "toolName": "list-access-package-requests",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Lists access package assignment requests. Use $filter=state eq 'submitted' to find pending requests. Each request has requestType (UserAdd, AdminAdd, AdminRemove), state (submitted, approved, denied, delivering, delivered, deliveryFailed), createdDateTime, and schedule."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/catalogs",
     "method": "get",
     "toolName": "list-access-package-catalogs",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Lists access package catalogs. Catalogs are containers for access packages and their resources. Each has displayName, description, catalogType (UserManaged, ServiceDefault), state (published, unpublished), isExternallyVisible, and createdDateTime."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/connectedOrganizations",
     "method": "get",
     "toolName": "list-connected-organizations",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Lists connected organizations in entitlement management. Connected organizations represent external organizations whose users can request access packages. Each has displayName, description, state (configured, proposed), identitySources (tenant IDs, domains), and createdDateTime."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/settings",
     "method": "get",
     "toolName": "get-entitlement-management-settings",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Gets entitlement management settings for the tenant. Returns externalUserLifecycleAction (None, BlockSignIn, BlockSignInAndDelete), daysUntilExternalUserDeletedAfterBlocked, and isB2BExternalCollab settings."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/workflows",
     "method": "get",
     "toolName": "list-lifecycle-workflows",
-    "appPermissions": [
-      "LifecycleWorkflows.Read.All"
-    ],
+    "appPermissions": ["LifecycleWorkflows.Read.All"],
     "llmTip": "Lists lifecycle workflows (joiner, mover, leaver). Each workflow has displayName, description, category (joiner, mover, leaver), isEnabled, isSchedulingEnabled, executionConditions (scope, trigger), and tasks. Useful for auditing automated onboarding/offboarding processes."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/workflows/{workflow-id}",
     "method": "get",
     "toolName": "get-lifecycle-workflow",
-    "appPermissions": [
-      "LifecycleWorkflows.Read.All"
-    ],
+    "appPermissions": ["LifecycleWorkflows.Read.All"],
     "llmTip": "Gets a specific lifecycle workflow by ID. Returns full details including tasks, executionConditions, lastModifiedDateTime, and version. Use $expand=tasks to see all tasks in the workflow."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/taskDefinitions",
     "method": "get",
     "toolName": "list-lifecycle-task-definitions",
-    "appPermissions": [
-      "LifecycleWorkflows.Read.All"
-    ],
+    "appPermissions": ["LifecycleWorkflows.Read.All"],
     "llmTip": "Lists available task definitions for lifecycle workflows. Each has displayName, description, category (joiner, leaver), and parameters. Examples: Send welcome email, Add user to group, Remove user from group, Disable user account, Delete user."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/assignmentSchedules",
     "method": "get",
     "toolName": "list-pim-group-assignment-schedules",
-    "appPermissions": [
-      "PrivilegedAccess.Read.AzureADGroup"
-    ],
+    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
     "llmTip": "Lists PIM for Groups assignment schedules. Shows active role assignments on privileged groups (member or owner). Each has principalId, groupId, accessId (member, owner), status, scheduleInfo (startDateTime, expiration). Use to audit who has permanent access to privileged groups."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/eligibilitySchedules",
     "method": "get",
     "toolName": "list-pim-group-eligibility-schedules",
-    "appPermissions": [
-      "PrivilegedAccess.Read.AzureADGroup"
-    ],
+    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
     "llmTip": "Lists PIM for Groups eligibility schedules. Shows who is eligible (but not yet activated) for membership or ownership on privileged groups. Each has principalId, groupId, accessId (member, owner), status, scheduleInfo. Compare with assignment schedules to see eligible vs active."
   },
   {
     "pathPattern": "/identityGovernance/termsOfUse/agreements",
     "method": "get",
     "toolName": "list-terms-of-use-agreements",
-    "appPermissions": [
-      "Agreement.Read.All"
-    ],
+    "appPermissions": ["Agreement.Read.All"],
     "llmTip": "Lists terms of use agreements. Each agreement has displayName, isPerDeviceAcceptanceRequired, isViewingBeforeAcceptanceRequired, userReexpireFrequency, and termsExpiration. Useful for auditing compliance with organizational policies."
   },
   {
     "pathPattern": "/identityGovernance/termsOfUse/agreements/{agreement-id}",
     "method": "get",
     "toolName": "get-terms-of-use-agreement",
-    "appPermissions": [
-      "Agreement.Read.All"
-    ],
+    "appPermissions": ["Agreement.Read.All"],
     "llmTip": "Gets a specific terms of use agreement. Returns full details including acceptance status configuration and file content."
   },
   {
     "pathPattern": "/identityGovernance/termsOfUse/agreements/{agreement-id}/acceptances",
     "method": "get",
     "toolName": "list-terms-of-use-acceptances",
-    "appPermissions": [
-      "Agreement.Read.All"
-    ],
+    "appPermissions": ["Agreement.Read.All"],
     "llmTip": "Lists acceptances for a terms of use agreement. Each acceptance has userId, userDisplayName, userPrincipalName, state (accepted, declined), recordedDateTime, and expirationDateTime. Useful for compliance reporting on who has accepted terms."
   },
   {
     "pathPattern": "/identityGovernance/appConsent/appConsentRequests",
     "method": "get",
     "toolName": "list-app-consent-requests",
-    "appPermissions": [
-      "ConsentRequest.Read.All"
-    ],
+    "appPermissions": ["ConsentRequest.Read.All"],
     "llmTip": "Lists app consent requests. When users request access to apps that require admin consent, those requests appear here. Each has appId, appDisplayName, and pendingScopes. Use to review and manage pending consent requests."
   },
   {
     "pathPattern": "/identityGovernance/appConsent/appConsentRequests/{appConsentRequest-id}",
     "method": "get",
     "toolName": "get-app-consent-request",
-    "appPermissions": [
-      "ConsentRequest.Read.All"
-    ],
+    "appPermissions": ["ConsentRequest.Read.All"],
     "llmTip": "Gets a specific app consent request. Returns appId, appDisplayName, pendingScopes, and linked userConsentRequests showing which users requested access."
   },
   {
     "pathPattern": "/identityGovernance/appConsent/appConsentRequests/{appConsentRequest-id}/userConsentRequests",
     "method": "get",
     "toolName": "list-user-consent-requests",
-    "appPermissions": [
-      "ConsentRequest.Read.All"
-    ],
+    "appPermissions": ["ConsentRequest.Read.All"],
     "llmTip": "Lists user consent requests for a specific app consent request. Each has createdBy, status (Submitted, InProgress, Completed), and reason. Shows which individual users requested consent for the app."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices",
     "method": "get",
     "toolName": "list-managed-devices",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Lists all Intune-managed devices. Use $filter=operatingSystem eq 'Windows' to filter by OS. Use $filter=complianceState eq 'noncompliant' to find non-compliant devices. Use $select=deviceName,operatingSystem,osVersion,complianceState,isEncrypted,managementAgent,enrolledDateTime,lastSyncDateTime,userPrincipalName. Use $filter=lastSyncDateTime le 2024-01-01T00:00:00Z to find stale devices."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}",
     "method": "get",
     "toolName": "get-managed-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Gets a specific Intune-managed device by ID. Returns full details: deviceName, operatingSystem, osVersion, complianceState, isEncrypted, jailBroken, managementAgent, enrolledDateTime, lastSyncDateTime, userPrincipalName, azureADDeviceId, model, manufacturer, serialNumber, wiFiMacAddress."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/deviceCompliancePolicyStates",
     "method": "get",
     "toolName": "list-device-compliance-states",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Lists compliance policy states for a specific managed device. Shows which compliance policies apply and their state (compliant, nonCompliant, notApplicable, error). Each has displayName, state, settingCount, settingStates."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/deviceConfigurationStates",
     "method": "get",
     "toolName": "list-device-configuration-states",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Lists configuration profile states for a specific managed device. Shows which configuration profiles apply and their state (notApplicable, success, error, conflict). Each has displayName, state, settingCount."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies",
     "method": "get",
     "toolName": "list-compliance-policies",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Lists all Intune device compliance policies. Each has displayName, description, @odata.type (platform-specific: windows10, iOS, androidWorkProfile, macOS), createdDateTime, lastModifiedDateTime, and version. Use to audit what compliance rules are in place."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
     "method": "get",
     "toolName": "get-compliance-policy",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Gets a specific compliance policy. Returns full details including platform-specific settings (password requirements, encryption, OS version, etc.)."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}/deviceStatuses",
     "method": "get",
     "toolName": "list-compliance-policy-device-statuses",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Lists device statuses for a specific compliance policy. Each has deviceDisplayName, userName, status (compliant, nonCompliant, error, conflict, notApplicable), lastReportedDateTime, and complianceGracePeriodExpirationDateTime."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}/deviceStatusOverview",
     "method": "get",
     "toolName": "get-compliance-policy-status-overview",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Gets the device status overview for a compliance policy. Returns aggregate counts: pendingCount, notApplicableCount, successCount, errorCount, failedCount, conflictCount, lastUpdateDateTime."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicyDeviceStateSummary",
     "method": "get",
     "toolName": "get-compliance-state-summary",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Gets the tenant-wide device compliance state summary. Returns aggregate counts: inGracePeriodCount, compliantDeviceCount, nonCompliantDeviceCount, remediatedDeviceCount, errorDeviceCount, conflictDeviceCount, unknownDeviceCount, notApplicableDeviceCount."
   },
   {
     "pathPattern": "/deviceManagement/deviceConfigurations",
     "method": "get",
     "toolName": "list-device-configurations",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Lists all Intune device configuration profiles. Each has displayName, description, @odata.type (platform-specific), createdDateTime, lastModifiedDateTime, and version. Covers Wi-Fi, VPN, email, certificates, device restrictions, endpoint protection, etc."
   },
   {
     "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
     "method": "get",
     "toolName": "get-device-configuration",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Gets a specific device configuration profile. Returns full details including platform-specific settings (Wi-Fi SSID, VPN config, device restrictions, etc.)."
   },
   {
     "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}/deviceStatusOverview",
     "method": "get",
     "toolName": "get-device-configuration-status-overview",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Gets device status overview for a configuration profile. Returns aggregate counts: pendingCount, notApplicableCount, successCount, errorCount, failedCount, conflictCount, lastUpdateDateTime."
   },
   {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
     "method": "get",
     "toolName": "list-enrollment-configurations",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists device enrollment configurations. Includes Windows Autopilot deployment profiles, enrollment restrictions (platform, device limit), and enrollment status page settings. Each has displayName, @odata.type, priority, createdDateTime."
   },
   {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations/{deviceEnrollmentConfiguration-id}",
     "method": "get",
     "toolName": "get-enrollment-configuration",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Gets a specific enrollment configuration. Returns full details including platform restrictions, device limits, or Autopilot profile settings depending on the type."
   },
   {
     "pathPattern": "/deviceManagement/deviceCategories",
     "method": "get",
     "toolName": "list-device-categories",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Lists Intune device categories. Categories allow organizing devices for dynamic group targeting. Each has displayName and description."
   },
   {
     "pathPattern": "/deviceManagement/windowsAutopilotDeviceIdentities",
     "method": "get",
     "toolName": "list-autopilot-devices",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists Windows Autopilot device identities. Each has serialNumber, model, manufacturer, groupTag, purchaseOrderIdentifier, enrollmentState, deploymentProfileAssignmentStatus, lastContactedDateTime. Use to audit Autopilot-registered devices and their deployment status."
   },
   {
     "pathPattern": "/deviceManagement/windowsAutopilotDeviceIdentities/{windowsAutopilotDeviceIdentity-id}",
     "method": "get",
     "toolName": "get-autopilot-device",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Gets a specific Autopilot device identity. Returns serialNumber, model, manufacturer, groupTag, enrollmentState, deploymentProfileAssignmentStatus, and assignedDeploymentProfile."
   },
   {
     "pathPattern": "/deviceManagement/detectedApps",
     "method": "get",
     "toolName": "list-detected-apps",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists all applications detected on Intune-managed devices. Each has displayName, version, sizeInByte, deviceCount, and platform. Use to audit software inventory and find unauthorized applications. Use $orderby=deviceCount desc to see most-installed apps."
   },
   {
     "pathPattern": "/deviceManagement/detectedApps/{detectedApp-id}",
     "method": "get",
     "toolName": "get-detected-app",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Gets a specific detected application. Returns displayName, version, sizeInByte, deviceCount, and platform."
   },
   {
     "pathPattern": "/deviceManagement/detectedApps/{detectedApp-id}/managedDevices",
     "method": "get",
     "toolName": "list-detected-app-devices",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists managed devices that have a specific application installed. Useful for finding all devices with a particular app version (e.g., outdated or unauthorized software)."
   },
   {
     "pathPattern": "/deviceManagement/managedDeviceOverview",
     "method": "get",
     "toolName": "get-managed-device-overview",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Gets a high-level overview of all managed devices. Returns aggregate counts by enrolledDeviceCount, mdmEnrolledCount, dualEnrolledDeviceCount, deviceOperatingSystemSummary (android, iOS, macOS, windows, windowsMobile), and deviceExchangeAccessStateSummary."
   },
   {
     "pathPattern": "/deviceManagement/auditEvents",
     "method": "get",
     "toolName": "list-intune-audit-events",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists Intune audit events. Each has displayName, componentName, activity, activityDateTime, activityType, actor (userPrincipalName, applicationDisplayName), and resources (displayName, type). Use $filter=activityDateTime ge 2024-01-01T00:00:00Z to filter by date. Use to track who changed Intune policies."
   },
   {
     "pathPattern": "/deviceManagement/softwareUpdateStatusSummary",
     "method": "get",
     "toolName": "get-software-update-summary",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Gets a summary of Windows update statuses across managed devices. Returns counts by status: compliantDeviceCount, nonCompliantDeviceCount, remediatedDeviceCount, errorDeviceCount, conflictDeviceCount, unknownDeviceCount, notApplicableDeviceCount."
   },
   {
     "pathPattern": "/deviceManagement/applePushNotificationCertificate",
     "method": "get",
     "toolName": "get-apple-push-certificate",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Gets the Apple Push Notification certificate info. Returns appleIdentifier, topicIdentifier, lastModifiedDateTime, expirationDateTime, and certificateSerialNumber. CRITICAL: monitor expirationDateTime \u2014 if it expires, all iOS/macOS device management stops."
   },
   {
     "pathPattern": "/deviceManagement/roleDefinitions",
     "method": "get",
     "toolName": "list-intune-role-definitions",
-    "appPermissions": [
-      "DeviceManagementRBAC.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementRBAC.Read.All"],
     "llmTip": "Lists Intune RBAC role definitions. Each has displayName, description, isBuiltIn, permissions (actions), and roleAssignments. Built-in roles include Intune Administrator, Help Desk Operator, Read Only Operator, etc."
   },
   {
     "pathPattern": "/deviceManagement/roleAssignments",
     "method": "get",
     "toolName": "list-intune-role-assignments",
-    "appPermissions": [
-      "DeviceManagementRBAC.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementRBAC.Read.All"],
     "llmTip": "Lists Intune RBAC role assignments. Each has displayName, description, resourceScopes, and members. Shows who has been granted which Intune admin roles and over which scope."
   },
   {
     "pathPattern": "/deviceManagement/termsAndConditions",
     "method": "get",
     "toolName": "list-intune-terms-and-conditions",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists Intune terms and conditions. Each has displayName, description, title, bodyText, acceptanceStatement, version, createdDateTime, and modifiedDateTime."
   },
   {
     "pathPattern": "/deviceManagement/termsAndConditions/{termsAndConditions-id}/acceptanceStatuses",
     "method": "get",
     "toolName": "list-intune-terms-acceptances",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists acceptance statuses for Intune terms and conditions. Each has userDisplayName, userPrincipalName, acceptedVersion, acceptedDateTime. Useful for compliance reporting."
   },
   {
     "pathPattern": "/deviceManagement/conditionalAccessSettings",
     "method": "get",
     "toolName": "get-intune-conditional-access-settings",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Gets Intune on-premises conditional access settings. Returns enabled status and which devices are included/excluded from conditional access to on-premises Exchange."
   },
   {
     "pathPattern": "/deviceManagement/mobileThreatDefenseConnectors",
     "method": "get",
     "toolName": "list-mtd-connectors",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists Mobile Threat Defense (MTD) connectors. Shows which MTD partners are integrated (Microsoft Defender, Lookout, Zimperium, etc.), their state (enabled/disabled), and platform support. Each has partnerState, androidEnabled, iosEnabled, lastHeartbeatDateTime."
   },
   {
     "pathPattern": "/deviceManagement/iosUpdateStatuses",
     "method": "get",
     "toolName": "list-ios-update-statuses",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "llmTip": "Lists iOS update installation statuses across managed devices. Each has deviceDisplayName, userName, osVersion, installStatus (downloading, installing, idle, available, etc.), lastReportedDateTime, deviceModel, deviceId."
   },
   {
     "pathPattern": "/admin/exchange/tracing/messageTraces",
     "method": "get",
     "toolName": "list-message-traces",
-    "appPermissions": [
-      "MailboxSettings.Read"
-    ],
+    "appPermissions": ["MailboxSettings.Read"],
     "llmTip": "Lists Exchange message traces for auditing mail flow. Each trace has senderAddress, recipientAddress, subject, messageId, receivedDateTime, status (Delivered, Failed, Quarantined, FilteredAsSpam, Expanded, etc.), and size. Use $filter=receivedDateTime ge 2024-01-01T00:00:00Z to filter by date. Use $filter=senderAddress eq 'user@domain.com' to filter by sender."
   },
   {
     "pathPattern": "/admin/exchange/tracing/messageTraces/{exchangeMessageTrace-id}",
     "method": "get",
     "toolName": "get-message-trace",
-    "appPermissions": [
-      "MailboxSettings.Read"
-    ],
+    "appPermissions": ["MailboxSettings.Read"],
     "llmTip": "Gets a specific message trace by ID. Returns full details including senderAddress, recipientAddress, subject, messageId, receivedDateTime, status, size, and additional routing information."
   },
   {
     "pathPattern": "/admin/exchange/mailboxes",
     "method": "get",
     "toolName": "list-exchange-mailboxes",
-    "appPermissions": [
-      "Exchange.ManageAsApp"
-    ],
+    "appPermissions": ["Exchange.ManageAsApp"],
     "llmTip": "Lists Exchange mailboxes in the tenant via admin API. Each mailbox has displayName, primarySmtpAddress, recipientType (UserMailbox, SharedMailbox, RoomMailbox, EquipmentMailbox), and identity. Useful for auditing mailbox types and finding shared/resource mailboxes."
   },
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}",
     "method": "get",
     "toolName": "get-exchange-mailbox",
-    "appPermissions": [
-      "Exchange.ManageAsApp"
-    ],
+    "appPermissions": ["Exchange.ManageAsApp"],
     "llmTip": "Gets a specific Exchange mailbox. Returns full details including displayName, primarySmtpAddress, recipientType, and mailbox configuration."
   },
   {
     "pathPattern": "/security/threatIntelligence/hosts",
     "method": "get",
     "toolName": "list-threat-intel-hosts",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists hosts tracked by Microsoft threat intelligence. Use $filter=id eq 'example.com' to look up a specific host. Returns host details including firstSeenDateTime, lastSeenDateTime, and registrar info."
   },
   {
     "pathPattern": "/security/threatIntelligence/hosts/{host-id}",
     "method": "get",
     "toolName": "get-threat-intel-host",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Gets threat intelligence for a specific host (domain or IP). The host-id is the hostname or IP address. Returns firstSeenDateTime, lastSeenDateTime, registrar, registrant info, and reputation data."
   },
   {
     "pathPattern": "/security/threatIntelligence/hosts/{host-id}/whois",
     "method": "get",
     "toolName": "get-threat-intel-host-whois",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Gets WHOIS information for a host. Returns registrar, registrant (name, organization, email, phone), nameservers, registrationDateTime, expirationDateTime. Useful for investigating suspicious domains."
   },
   {
     "pathPattern": "/security/threatIntelligence/hosts/{host-id}/hostPairs",
     "method": "get",
     "toolName": "list-threat-intel-host-pairs",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists host pairs for a given host \u2014 relationships between parent and child hosts (redirects, iframes, scripts, etc.). Each has parentHost, childHost, linkKind (redirect, script, etc.), firstSeenDateTime, lastSeenDateTime. Useful for mapping infrastructure."
   },
   {
     "pathPattern": "/security/threatIntelligence/articles",
     "method": "get",
     "toolName": "list-threat-intel-articles",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists Microsoft threat intelligence articles. Each has title, body, createdDateTime, lastUpdatedDateTime, tags, and indicators. These are curated reports about threat actors, campaigns, and vulnerabilities."
   },
   {
     "pathPattern": "/security/threatIntelligence/articles/{article-id}",
     "method": "get",
     "toolName": "get-threat-intel-article",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Gets a specific threat intelligence article by ID. Returns title, body (HTML), summary, tags, indicators, and linked intelligence profiles."
   },
   {
     "pathPattern": "/security/threatIntelligence/articles/{article-id}/indicators",
     "method": "get",
     "toolName": "list-threat-intel-article-indicators",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists indicators of compromise (IOCs) associated with a threat intelligence article. Each indicator has artifact (hostname, IP, URL, file hash), source, and pattern details."
   },
   {
     "pathPattern": "/security/threatIntelligence/intelProfiles",
     "method": "get",
     "toolName": "list-threat-intel-profiles",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists threat actor intelligence profiles. Each has title, kind (actor, tool, vulnerability), aliases, countriesOrRegionsOfOrigin, targets (industries, countries), firstActiveDateTime, and description. Profiles represent tracked threat actors and their TTPs."
   },
   {
     "pathPattern": "/security/threatIntelligence/intelProfiles/{intelligenceProfile-id}",
     "method": "get",
     "toolName": "get-threat-intel-profile",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Gets a specific threat actor intelligence profile. Returns full details including title, kind, description, aliases, countriesOrRegionsOfOrigin, targets, tradecraft summary, and linked indicators."
   },
   {
     "pathPattern": "/security/threatIntelligence/intelProfiles/{intelligenceProfile-id}/indicators",
     "method": "get",
     "toolName": "list-threat-intel-profile-indicators",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists indicators of compromise associated with a threat actor profile. Each indicator has artifact (hostname, IP, URL, file hash), source, and firstSeenDateTime."
   },
   {
     "pathPattern": "/security/threatIntelligence/vulnerabilities",
     "method": "get",
     "toolName": "list-threat-intel-vulnerabilities",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists known vulnerabilities tracked by Microsoft threat intelligence. Each has id (CVE ID), description, severity, publishedDateTime, lastModifiedDateTime, hasChatter, exploitsAvailable, and cvss scores. Use to check if known CVEs are being actively exploited."
   },
   {
     "pathPattern": "/security/threatIntelligence/vulnerabilities/{vulnerability-id}",
     "method": "get",
     "toolName": "get-threat-intel-vulnerability",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Gets a specific vulnerability by CVE ID (e.g. CVE-2024-1234). Returns description, severity, cvss scores, publishedDateTime, exploitsAvailable, activeExploitsObserved, hasChatter, priorityScore, and remediation info."
   },
   {
     "pathPattern": "/security/threatIntelligence/whoisRecords",
     "method": "get",
     "toolName": "list-threat-intel-whois-records",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists WHOIS records from threat intelligence. Use to search WHOIS data across domains. Each record has host, registrar, registrant, nameservers, and dates."
   },
   {
     "pathPattern": "/security/threatIntelligence/whoisRecords/{whoisRecord-id}",
     "method": "get",
     "toolName": "get-threat-intel-whois-record",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Gets a specific WHOIS record by ID. Returns full registrant and registrar details, nameservers, registration and expiration dates."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostComponents",
     "method": "get",
     "toolName": "list-threat-intel-host-components",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists web components detected on hosts (web servers, frameworks, CMS, etc.). Each has host, name, version, category, firstSeenDateTime, lastSeenDateTime. Use to identify vulnerable software versions running on infrastructure."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostSslCertificates",
     "method": "get",
     "toolName": "list-threat-intel-ssl-certs",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists SSL certificates observed on hosts. Each has host, sslCertificate (issuer, subject, serialNumber, sha256, validityPeriod), firstSeenDateTime, lastSeenDateTime. Useful for tracking certificate changes and detecting suspicious certificates."
   },
   {
     "pathPattern": "/invitations",
     "method": "get",
     "toolName": "list-invitations",
-    "appPermissions": [
-      "User.Invite.All"
-    ],
+    "appPermissions": ["User.Invite.All"],
     "llmTip": "Lists guest user invitations. Each has invitedUserEmailAddress, invitedUserDisplayName, inviteRedeemUrl, status (PendingAcceptance, Completed, InProgress, Error), sendInvitationMessage, and invitedUserType (Guest, Member). Use to audit pending and completed B2B invitations."
   },
   {
     "pathPattern": "/invitations",
     "method": "post",
     "toolName": "create-invitation",
-    "appPermissions": [
-      "User.Invite.All"
-    ],
+    "appPermissions": ["User.Invite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a new guest user invitation. Body must include: invitedUserEmailAddress (required), inviteRedirectUrl (required, URL user lands on after redeeming). Optional: invitedUserDisplayName, sendInvitationMessage (true/false), invitedUserMessageInfo, invitedUserType ('Guest' or 'Member'). Returns inviteRedeemUrl and invitedUser object with the created user ID."
   },
@@ -1459,378 +1127,294 @@
     "pathPattern": "/identity/identityProviders",
     "method": "get",
     "toolName": "list-identity-providers",
-    "appPermissions": [
-      "IdentityProvider.Read.All"
-    ],
+    "appPermissions": ["IdentityProvider.Read.All"],
     "llmTip": "Lists identity providers configured for the tenant. Includes social providers (Google, Facebook, Apple), SAML/WS-Fed, and built-in providers (Azure AD, Microsoft Account). Each has displayName, @odata.type, clientId. Useful for auditing which external identity providers are trusted for B2B/B2C."
   },
   {
     "pathPattern": "/identity/identityProviders/{identityProviderBase-id}",
     "method": "get",
     "toolName": "get-identity-provider",
-    "appPermissions": [
-      "IdentityProvider.Read.All"
-    ],
+    "appPermissions": ["IdentityProvider.Read.All"],
     "llmTip": "Gets a specific identity provider. Returns displayName, @odata.type, clientId, and provider-specific configuration."
   },
   {
     "pathPattern": "/identity/b2xUserFlows",
     "method": "get",
     "toolName": "list-b2x-user-flows",
-    "appPermissions": [
-      "IdentityUserFlow.Read.All"
-    ],
+    "appPermissions": ["IdentityUserFlow.Read.All"],
     "llmTip": "Lists B2X (self-service sign-up) user flows. Each has id, userFlowType (signUpOrSignIn), userFlowTypeVersion, and apiConnectorConfiguration. B2X user flows control how external users can sign up as guests through self-service."
   },
   {
     "pathPattern": "/identity/b2xUserFlows/{b2xIdentityUserFlow-id}",
     "method": "get",
     "toolName": "get-b2x-user-flow",
-    "appPermissions": [
-      "IdentityUserFlow.Read.All"
-    ],
+    "appPermissions": ["IdentityUserFlow.Read.All"],
     "llmTip": "Gets a specific B2X user flow. Returns full configuration including apiConnectorConfiguration, identityProviders, userAttributeAssignments, and languages."
   },
   {
     "pathPattern": "/identity/apiConnectors",
     "method": "get",
     "toolName": "list-api-connectors",
-    "appPermissions": [
-      "APIConnectors.Read.All"
-    ],
+    "appPermissions": ["APIConnectors.Read.All"],
     "llmTip": "Lists API connectors used in self-service sign-up user flows. Each has displayName, targetUrl, and authenticationConfiguration. API connectors call external APIs during sign-up (e.g. for validation, enrichment, or approval). Audit these to ensure no unauthorized external endpoints are called."
   },
   {
     "pathPattern": "/identity/apiConnectors/{identityApiConnector-id}",
     "method": "get",
     "toolName": "get-api-connector",
-    "appPermissions": [
-      "APIConnectors.Read.All"
-    ],
+    "appPermissions": ["APIConnectors.Read.All"],
     "llmTip": "Gets a specific API connector. Returns displayName, targetUrl, and authenticationConfiguration (basic auth or client certificate)."
   },
   {
     "pathPattern": "/identity/customAuthenticationExtensions",
     "method": "get",
     "toolName": "list-custom-auth-extensions",
-    "appPermissions": [
-      "CustomAuthenticationExtension.Read.All"
-    ],
+    "appPermissions": ["CustomAuthenticationExtension.Read.All"],
     "llmTip": "Lists custom authentication extensions. These are webhook-based extensions that can be called during authentication flows (token issuance, attribute collection). Each has displayName, @odata.type, authenticationConfiguration, endpointConfiguration (targetUrl). Audit these to ensure no unauthorized custom logic in auth flows."
   },
   {
     "pathPattern": "/identity/customAuthenticationExtensions/{customAuthenticationExtension-id}",
     "method": "get",
     "toolName": "get-custom-auth-extension",
-    "appPermissions": [
-      "CustomAuthenticationExtension.Read.All"
-    ],
+    "appPermissions": ["CustomAuthenticationExtension.Read.All"],
     "llmTip": "Gets a specific custom authentication extension. Returns displayName, authenticationConfiguration, endpointConfiguration, and claimsForTokenConfiguration."
   },
   {
     "pathPattern": "/applications/{application-id}",
     "method": "get",
     "toolName": "get-application",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Gets a specific app registration by object ID. Use $select=displayName,appId,passwordCredentials,keyCredentials,signInAudience,requiredResourceAccess to audit credentials and permissions. passwordCredentials shows client secrets with displayName, endDateTime, and keyId. keyCredentials shows certificates. CRITICAL: check endDateTime on credentials to find expiring or expired secrets/certs."
   },
   {
     "pathPattern": "/applications/{application-id}/owners",
     "method": "get",
     "toolName": "list-application-owners",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Lists owners of an app registration. Owners can manage the app including adding credentials. Returns user objects. Audit this to ensure apps have appropriate owners and no orphaned apps exist."
   },
   {
     "pathPattern": "/applications/{application-id}/federatedIdentityCredentials",
     "method": "get",
     "toolName": "list-app-federated-credentials",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Lists federated identity credentials for an app (workload identity federation). Each has name, issuer, subject, audiences, and description. These allow external workloads (GitHub Actions, Kubernetes, etc.) to authenticate as the app without a secret. Audit to ensure only authorized external identities are trusted."
   },
   {
     "pathPattern": "/applications/{application-id}/federatedIdentityCredentials/{federatedIdentityCredential-id}",
     "method": "get",
     "toolName": "get-app-federated-credential",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Gets a specific federated identity credential. Returns name, issuer (e.g. https://token.actions.githubusercontent.com), subject (e.g. repo:org/repo:ref:refs/heads/main), audiences, and description."
   },
   {
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}",
     "method": "get",
     "toolName": "get-service-principal",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Gets a specific service principal (enterprise app) by ID. Use $select=displayName,appId,passwordCredentials,keyCredentials,servicePrincipalType,accountEnabled,appOwnerOrganizationId,loginUrl,notificationEmailAddresses. Check passwordCredentials and keyCredentials for credential audit."
   },
   {
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}/owners",
     "method": "get",
     "toolName": "list-service-principal-owners",
-    "appPermissions": [
-      "Application.Read.All"
-    ],
+    "appPermissions": ["Application.Read.All"],
     "llmTip": "Lists owners of a service principal. Returns user objects. Owners can manage the enterprise app configuration. Audit for orphaned service principals with no owners."
   },
   {
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}/oauth2PermissionGrants",
     "method": "get",
     "toolName": "list-sp-delegated-permissions",
-    "appPermissions": [
-      "Directory.Read.All"
-    ],
+    "appPermissions": ["Directory.Read.All"],
     "llmTip": "Lists delegated permission grants for a specific service principal. Shows which delegated permissions have been consented (admin or user). Each has consentType (AllPrincipals for admin consent, Principal for user consent), scope (space-separated permissions), and principalId."
   },
   {
     "pathPattern": "/policies/appManagementPolicies",
     "method": "get",
     "toolName": "list-app-management-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists app management policies. These policies restrict credential types and lifetimes for app registrations and service principals. Each has displayName, isEnabled, restrictions (passwordCredentials, keyCredentials with restrictForAppsCreatedAfterDateTime and maxLifetime). Useful for enforcing credential hygiene."
   },
   {
     "pathPattern": "/policies/appManagementPolicies/{appManagementPolicy-id}",
     "method": "get",
     "toolName": "get-app-management-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets a specific app management policy. Returns displayName, isEnabled, and detailed restrictions on password and key credentials including maxLifetime and restrictForAppsCreatedAfterDateTime."
   },
   {
     "pathPattern": "/security/cases/ediscoveryCases",
     "method": "get",
     "toolName": "list-ediscovery-cases",
-    "appPermissions": [
-      "eDiscovery.Read.All"
-    ],
+    "appPermissions": ["eDiscovery.Read.All"],
     "llmTip": "Lists eDiscovery cases in Microsoft Purview. Each case has displayName, description, status (active, closed, closedWithError), createdBy, createdDateTime, lastModifiedBy, lastModifiedDateTime, and externalId. Use $filter=status eq 'active' to see active cases. Use $top to limit results."
   },
   {
     "pathPattern": "/communications/callRecords",
     "method": "get",
     "toolName": "list-call-records",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Lists Teams call records. Each record has id, version, type (groupCall, peerToPeer), modalities (audio, video, videoBasedScreenSharing, data), startDateTime, endDateTime, organizer, and participants. Use $filter=startDateTime ge 2024-01-01T00:00:00Z to filter by date. Use $orderby=startDateTime desc. Use $top to limit."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/cloudPCs",
     "method": "get",
     "toolName": "list-cloud-pcs",
-    "appPermissions": [
-      "CloudPC.Read.All"
-    ],
+    "appPermissions": ["CloudPC.Read.All"],
     "llmTip": "Lists Cloud PCs (Windows 365) provisioned in the tenant. Each has displayName, managedDeviceName, userPrincipalName, status (provisioned, provisioning, failed, notProvisioned), provisioningPolicyId, imageDisplayName, lastModifiedDateTime, gracePeriodEndDateTime, and aadDeviceId. Use $filter=status eq 'provisioned' or status eq 'failed'. Use $top to limit."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/provisioningPolicies",
     "method": "get",
     "toolName": "list-cloud-pc-provisioning-policies",
-    "appPermissions": [
-      "CloudPC.Read.All"
-    ],
+    "appPermissions": ["CloudPC.Read.All"],
     "llmTip": "Lists Cloud PC provisioning policies. Each has displayName, description, imageId, imageDisplayName, imageType, onPremisesConnectionId, domainJoinConfigurations, windowsSetting, and provisioningType. These define how Cloud PCs are provisioned for users."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/deviceImages",
     "method": "get",
     "toolName": "list-cloud-pc-device-images",
-    "appPermissions": [
-      "CloudPC.Read.All"
-    ],
+    "appPermissions": ["CloudPC.Read.All"],
     "llmTip": "Lists custom OS images uploaded for Cloud PC provisioning. Each has displayName, version, operatingSystem, osBuildNumber, sourceImageResourceId, status (readyForUpload, pending, failed), statusDetails, and lastModifiedDateTime."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/galleryImages",
     "method": "get",
     "toolName": "list-cloud-pc-gallery-images",
-    "appPermissions": [
-      "CloudPC.Read.All"
-    ],
+    "appPermissions": ["CloudPC.Read.All"],
     "llmTip": "Lists gallery images available from Microsoft for Cloud PC provisioning. Each has displayName, offerDisplayName, publisherName, skuDisplayName, skuName, status, startDate, endDate, and expirationDate."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/onPremisesConnections",
     "method": "get",
     "toolName": "list-cloud-pc-on-premises-connections",
-    "appPermissions": [
-      "CloudPC.Read.All"
-    ],
+    "appPermissions": ["CloudPC.Read.All"],
     "llmTip": "Lists Azure network connections used by Cloud PCs. Each has displayName, type (azureADJoin, hybridAzureADJoin), subscriptionId, resourceGroupId, virtualNetworkId, subnetId, healthCheckStatus (passed, failed, running, warning), and healthCheckStatusDetail."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/userSettings",
     "method": "get",
     "toolName": "list-cloud-pc-user-settings",
-    "appPermissions": [
-      "CloudPC.Read.All"
-    ],
+    "appPermissions": ["CloudPC.Read.All"],
     "llmTip": "Lists Cloud PC user settings. Each has displayName, selfServiceEnabled, localAdminEnabled, restorePointSetting (frequencyType, userRestoreEnabled), and lastModifiedDateTime. User settings control end-user permissions on their Cloud PCs."
   },
   {
     "pathPattern": "/deviceManagement/virtualEndpoint/auditEvents",
     "method": "get",
     "toolName": "list-cloud-pc-audit-events",
-    "appPermissions": [
-      "CloudPC.Read.All"
-    ],
+    "appPermissions": ["CloudPC.Read.All"],
     "llmTip": "Lists Cloud PC audit events. Each has displayName, componentName, activity, activityDateTime, activityType (create, delete, patch), activityOperationType, activityResult (success, failure), actor, and resources. Use $filter=activityDateTime ge 2024-01-01T00:00:00Z. Use $orderby=activityDateTime desc."
   },
   {
     "pathPattern": "/print/printers",
     "method": "get",
     "toolName": "list-printers",
-    "appPermissions": [
-      "Printer.Read.All"
-    ],
+    "appPermissions": ["Printer.Read.All"],
     "llmTip": "Lists printers registered in Universal Print. Each has displayName, manufacturer, model, status (state: idle, processing, stopped, unknownFutureValue), isShared, isAcceptingJobs, location, defaults, and capabilities. Use $filter to narrow results."
   },
   {
     "pathPattern": "/print/shares",
     "method": "get",
     "toolName": "list-print-shares",
-    "appPermissions": [
-      "PrintJob.Read.All"
-    ],
+    "appPermissions": ["PrintJob.Read.All"],
     "llmTip": "Lists printer shares in Universal Print. Each has displayName, createdDateTime, isAcceptingJobs, status, printer, and allowedUsers/allowedGroups. Printer shares make printers discoverable to users."
   },
   {
     "pathPattern": "/print/connectors",
     "method": "get",
     "toolName": "list-print-connectors",
-    "appPermissions": [
-      "PrintConnector.Read.All"
-    ],
+    "appPermissions": ["PrintConnector.Read.All"],
     "llmTip": "Lists Universal Print connectors. Each has displayName, fullyQualifiedDomainName, operatingSystem, appVersion, deviceHealth (lastConnectionTime), location, and registeredDateTime. Connectors bridge on-premises printers to Universal Print."
   },
   {
     "pathPattern": "/print/services",
     "method": "get",
     "toolName": "list-print-services",
-    "appPermissions": [
-      "PrintJob.Read.All"
-    ],
+    "appPermissions": ["PrintJob.Read.All"],
     "llmTip": "Lists Universal Print service instances. Each has endpoints with displayName and uri. These represent the service endpoints used by Universal Print."
   },
   {
     "pathPattern": "/print/operations",
     "method": "get",
     "toolName": "list-print-operations",
-    "appPermissions": [
-      "PrintJob.Read.All"
-    ],
+    "appPermissions": ["PrintJob.Read.All"],
     "llmTip": "Lists long-running Universal Print operations. Each has status (state: notStarted, running, succeeded, failed), createdDateTime, and lastActionDateTime."
   },
   {
     "pathPattern": "/print/taskDefinitions",
     "method": "get",
     "toolName": "list-print-task-definitions",
-    "appPermissions": [
-      "PrintJob.Read.All"
-    ],
+    "appPermissions": ["PrintJob.Read.All"],
     "llmTip": "Lists Universal Print task definitions. Task definitions describe tasks that can be triggered on various print events (e.g., jobStarted)."
   },
   {
     "pathPattern": "/informationProtection/bitlocker/recoveryKeys",
     "method": "get",
     "toolName": "list-bitlocker-recovery-keys",
-    "appPermissions": [
-      "BitlockerKey.Read.All"
-    ],
+    "appPermissions": ["BitlockerKey.Read.All"],
     "llmTip": "Lists BitLocker recovery keys stored in Entra ID. Each has id, createdDateTime, deviceId, volumeType (operatingSystemVolume, fixedDataVolume, removableDataVolume). The actual key value is NOT returned by default for security; use $select=key to include it (requires BitlockerKey.ReadBasic.All or BitlockerKey.Read.All). Use $filter=deviceId eq 'xxx' to find keys for a specific device."
   },
   {
     "pathPattern": "/informationProtection/threatAssessmentRequests",
     "method": "get",
     "toolName": "list-threat-assessment-requests",
-    "appPermissions": [
-      "ThreatAssessment.Read.All"
-    ],
+    "appPermissions": ["ThreatAssessment.Read.All"],
     "llmTip": "Lists threat assessment requests. Each has id, createdDateTime, contentType (mail, url, file), expectedAssessment (block, unblock), category (spam, phishing, malware), status (pending, completed), requestSource, createdBy, and results (with resultType and message). Use $top to limit."
   },
   {
     "pathPattern": "/admin/sharepoint/settings",
     "method": "get",
     "toolName": "get-sharepoint-settings",
-    "appPermissions": [
-      "SharePointTenantSettings.Read.All"
-    ],
+    "appPermissions": ["SharePointTenantSettings.Read.All"],
     "llmTip": "Gets SharePoint tenant-level settings. Returns allowedDomainGuidsForSyncApp, availableManagedPathsForSiteCreation, deletedUserPersonalSiteRetentionPeriodInDays, excludedFileExtensionsForSyncApp, idleSessionSignOut, imageTaggingOption, isCommentingOnSitePagesEnabled, isFileActivityNotificationEnabled, isLoopEnabled, isMacSyncAppEnabled, isResharingByExternalUsersEnabled, isSharePointMobileNotificationEnabled, isSharePointNewsfeedEnabled, isSiteCreationEnabled, isSiteCreationUIEnabled, isSitePagesCreationEnabled, isSitesStorageLimitAutomatic, knowledgeIntelligenceEnabled, personalSiteDefaultStorageLimitInMB, sharingAllowedDomainList, sharingBlockedDomainList, sharingCapability, sharingDomainRestrictionMode, siteCreationDefaultManagedPath, siteCreationDefaultStorageLimitInMB, tenantDefaultTimezone."
   },
   {
     "pathPattern": "/security/labels/retentionLabels",
     "method": "get",
     "toolName": "list-retention-labels",
-    "appPermissions": [
-      "RecordsManagement.Read.All"
-    ],
+    "appPermissions": ["RecordsManagement.Read.All"],
     "llmTip": "Lists retention labels from Microsoft Purview Records Management. Each has displayName, descriptionForAdmins, descriptionForUsers, retentionDuration, retentionTrigger, behaviorDuringRetentionPeriod, actionAfterRetentionPeriod (none, delete, startDispositionReview), isInUse, createdDateTime, lastModifiedDateTime, and labelToBeApplied."
   },
   {
     "pathPattern": "/security/labels/authorities",
     "method": "get",
     "toolName": "list-file-plan-authorities",
-    "appPermissions": [
-      "RecordsManagement.Read.All"
-    ],
+    "appPermissions": ["RecordsManagement.Read.All"],
     "llmTip": "Lists file plan authorities used in retention labels. Each has displayName and id. Authorities represent the regulatory body or organizational authority behind a retention policy."
   },
   {
     "pathPattern": "/security/labels/categories",
     "method": "get",
     "toolName": "list-file-plan-categories",
-    "appPermissions": [
-      "RecordsManagement.Read.All"
-    ],
+    "appPermissions": ["RecordsManagement.Read.All"],
     "llmTip": "Lists file plan categories used in retention labels. Each has displayName and id. Categories classify the content type for records management."
   },
   {
     "pathPattern": "/security/labels/citations",
     "method": "get",
     "toolName": "list-file-plan-citations",
-    "appPermissions": [
-      "RecordsManagement.Read.All"
-    ],
+    "appPermissions": ["RecordsManagement.Read.All"],
     "llmTip": "Lists file plan citations used in retention labels. Each has displayName, citationUrl, citationJurisdiction, and id. Citations reference the regulation or law that requires the retention."
   },
   {
     "pathPattern": "/security/labels/departments",
     "method": "get",
     "toolName": "list-file-plan-departments",
-    "appPermissions": [
-      "RecordsManagement.Read.All"
-    ],
+    "appPermissions": ["RecordsManagement.Read.All"],
     "llmTip": "Lists file plan departments used in retention labels. Each has displayName and id. Departments identify which organizational unit owns the retention policy."
   },
   {
     "pathPattern": "/security/labels/filePlanReferences",
     "method": "get",
     "toolName": "list-file-plan-references",
-    "appPermissions": [
-      "RecordsManagement.Read.All"
-    ],
+    "appPermissions": ["RecordsManagement.Read.All"],
     "llmTip": "Lists file plan references used in retention labels. Each has displayName and id. File plan references provide a unique identifier or reference number for the retention policy within the organization's file plan."
   },
   {
     "pathPattern": "/deviceManagement/reports/getDeviceNonComplianceReport",
     "method": "post",
     "toolName": "intune-device-noncompliance-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates an Intune device non-compliance report. POST body: {\"name\":\"DeviceNonCompliance\",\"filter\":\"(PolicyId eq 'xxx')\",\"select\":[\"DeviceName\",\"UPN\",\"ComplianceState\"],\"top\":50}. Returns device-level compliance status."
   },
@@ -1838,9 +1422,7 @@
     "pathPattern": "/deviceManagement/reports/getCompliancePolicyNonComplianceReport",
     "method": "post",
     "toolName": "intune-compliance-policy-noncompliance-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a report of devices non-compliant with a specific compliance policy. POST body: {\"name\":\"CompliancePolicyNonCompliance\",\"filter\":\"(PolicyId eq 'xxx')\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\",\"State\"],\"top\":50}."
   },
@@ -1848,9 +1430,7 @@
     "pathPattern": "/deviceManagement/reports/getCompliancePolicyNonComplianceSummaryReport",
     "method": "post",
     "toolName": "intune-compliance-policy-noncompliance-summary",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a summary of non-compliance by compliance policy. POST body: {\"name\":\"CompliancePolicyNonComplianceSummary\",\"select\":[\"PolicyName\",\"NonCompliantDeviceCount\",\"ErrorDeviceCount\"],\"top\":50}."
   },
@@ -1858,9 +1438,7 @@
     "pathPattern": "/deviceManagement/reports/getComplianceSettingNonComplianceReport",
     "method": "post",
     "toolName": "intune-compliance-setting-noncompliance-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a report of devices non-compliant for a specific compliance setting. POST body: {\"name\":\"ComplianceSettingNonCompliance\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\",\"CurrentValue\"],\"top\":50}."
   },
@@ -1868,9 +1446,7 @@
     "pathPattern": "/deviceManagement/reports/getConfigurationPolicyNonComplianceReport",
     "method": "post",
     "toolName": "intune-config-policy-noncompliance-report",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a report of devices non-compliant with a device configuration policy. POST body: {\"name\":\"ConfigurationPolicyNonCompliance\",\"filter\":\"(PolicyId eq 'xxx')\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\",\"State\"],\"top\":50}."
   },
@@ -1878,9 +1454,7 @@
     "pathPattern": "/deviceManagement/reports/getConfigurationPolicyNonComplianceSummaryReport",
     "method": "post",
     "toolName": "intune-config-policy-noncompliance-summary",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a summary of non-compliance by device configuration policy. POST body: {\"name\":\"ConfigurationPolicyNonComplianceSummary\",\"select\":[\"PolicyName\",\"NonCompliantDeviceCount\"],\"top\":50}."
   },
@@ -1888,9 +1462,7 @@
     "pathPattern": "/deviceManagement/reports/getConfigurationSettingNonComplianceReport",
     "method": "post",
     "toolName": "intune-config-setting-noncompliance-report",
-    "appPermissions": [
-      "DeviceManagementConfiguration.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a report of devices non-compliant for a specific configuration setting. POST body: {\"name\":\"ConfigurationSettingNonCompliance\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\"],\"top\":50}."
   },
@@ -1898,9 +1470,7 @@
     "pathPattern": "/deviceManagement/reports/getDevicesWithoutCompliancePolicyReport",
     "method": "post",
     "toolName": "intune-devices-without-compliance-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a report of managed devices that have no compliance policy assigned. POST body: {\"name\":\"DevicesWithoutCompliancePolicy\",\"select\":[\"DeviceName\",\"UPN\",\"OS\"],\"top\":50}. Useful for identifying compliance coverage gaps."
   },
@@ -1908,9 +1478,7 @@
     "pathPattern": "/deviceManagement/reports/getNoncompliantDevicesAndSettingsReport",
     "method": "post",
     "toolName": "intune-noncompliant-devices-settings-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a combined report of non-compliant devices and the settings they violate. POST body: {\"name\":\"NoncompliantDevicesAndSettings\",\"select\":[\"DeviceName\",\"UPN\",\"Setting\",\"State\"],\"top\":50}."
   },
@@ -1918,9 +1486,7 @@
     "pathPattern": "/deviceManagement/reports/getPolicyNonComplianceReport",
     "method": "post",
     "toolName": "intune-policy-noncompliance-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a general policy non-compliance report. POST body: {\"name\":\"PolicyNonCompliance\",\"select\":[\"PolicyName\",\"DeviceName\",\"UPN\",\"ComplianceState\"],\"top\":50}."
   },
@@ -1928,9 +1494,7 @@
     "pathPattern": "/deviceManagement/reports/getPolicyNonComplianceSummaryReport",
     "method": "post",
     "toolName": "intune-policy-noncompliance-summary",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a summary of non-compliance across all policies. POST body: {\"name\":\"PolicyNonComplianceSummary\",\"select\":[\"PolicyName\",\"NonCompliantDeviceCount\",\"ErrorDeviceCount\"],\"top\":50}."
   },
@@ -1938,9 +1502,7 @@
     "pathPattern": "/deviceManagement/reports/getPolicyNonComplianceMetadata",
     "method": "post",
     "toolName": "intune-policy-noncompliance-metadata",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Gets metadata about policy non-compliance (available columns and filters). POST body: {\"name\":\"PolicyNonComplianceMetadata\"}. Useful before generating other reports to discover available fields."
   },
@@ -1948,9 +1510,7 @@
     "pathPattern": "/deviceManagement/reports/getSettingNonComplianceReport",
     "method": "post",
     "toolName": "intune-setting-noncompliance-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a report of non-compliance grouped by setting. POST body: {\"name\":\"SettingNonCompliance\",\"select\":[\"SettingName\",\"NonCompliantDeviceCount\"],\"top\":50}."
   },
@@ -1958,9 +1518,7 @@
     "pathPattern": "/deviceManagement/reports/getReportFilters",
     "method": "post",
     "toolName": "intune-report-filters",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Gets available report filters for Intune reports. POST body: {\"name\":\"ReportName\"}. Returns available filter values. Use before other report endpoints to discover filter options."
   },
@@ -1968,9 +1526,7 @@
     "pathPattern": "/deviceManagement/reports/getHistoricalReport",
     "method": "post",
     "toolName": "intune-historical-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a historical Intune report. POST body: {\"name\":\"ReportName\",\"filter\":\"...\",\"select\":[...],\"top\":50}. Provides point-in-time data for trend analysis."
   },
@@ -1978,9 +1534,7 @@
     "pathPattern": "/deviceManagement/reports/getCachedReport",
     "method": "post",
     "toolName": "intune-cached-report",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "riskLevel": "low",
     "llmTip": "Retrieves a previously generated cached Intune report by ID. POST body: {\"id\":\"report-id\",\"select\":[...],\"top\":50}. Faster than regenerating reports."
   },
@@ -1988,18 +1542,14 @@
     "pathPattern": "/deviceManagement/reports/exportJobs",
     "method": "get",
     "toolName": "list-intune-report-export-jobs",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Lists Intune report export jobs. Each has id, reportName, status (notStarted, inProgress, completed), requestDateTime, and url (download link when completed)."
   },
   {
     "pathPattern": "/deviceManagement/reports/retrieveDeviceAppInstallationStatusReport",
     "method": "post",
     "toolName": "intune-device-app-install-status-report",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "riskLevel": "low",
     "llmTip": "Generates a report of app installation status per device. POST body: {\"name\":\"DeviceAppInstallationStatus\",\"filter\":\"(AppId eq 'xxx')\",\"select\":[\"DeviceName\",\"UPN\",\"AppName\",\"InstallState\"],\"top\":50}."
   },
@@ -2007,486 +1557,378 @@
     "pathPattern": "/deviceManagement/complianceManagementPartners",
     "method": "get",
     "toolName": "list-compliance-management-partners",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Lists compliance management partners integrated with Intune. Each has displayName, partnerState, and supported platforms."
   },
   {
     "pathPattern": "/deviceManagement/deviceManagementPartners",
     "method": "get",
     "toolName": "list-device-management-partners",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Lists device management partners (DEP, Jamf, etc.) integrated with Intune. Each has displayName, partnerState, isConfigured, and partnerAppType."
   },
   {
     "pathPattern": "/deviceManagement/exchangeConnectors",
     "method": "get",
     "toolName": "list-exchange-connectors",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists Exchange connectors for Intune on-premises Exchange integration. Each has connectorName, status, serverName, exchangeConnectorType, and version."
   },
   {
     "pathPattern": "/deviceManagement/remoteAssistancePartners",
     "method": "get",
     "toolName": "list-remote-assistance-partners",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists remote assistance partners (TeamViewer, etc.) integrated with Intune. Each has displayName, onboardingStatus, and lastConnectionDateTime."
   },
   {
     "pathPattern": "/deviceManagement/notificationMessageTemplates",
     "method": "get",
     "toolName": "list-notification-message-templates",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists Intune notification message templates. These are compliance notification templates sent to users when their devices are non-compliant. Each has displayName, defaultLocale, brandingOptions, and roleScopeTagIds."
   },
   {
     "pathPattern": "/deviceManagement/resourceOperations",
     "method": "get",
     "toolName": "list-intune-resource-operations",
-    "appPermissions": [
-      "DeviceManagementRBAC.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementRBAC.Read.All"],
     "llmTip": "Lists Intune RBAC resource operations. Each has resourceName, actionName, and description. Shows all available operations that can be assigned to Intune roles."
   },
   {
     "pathPattern": "/deviceManagement/importedWindowsAutopilotDeviceIdentities",
     "method": "get",
     "toolName": "list-imported-autopilot-devices",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists imported Windows Autopilot device identities. Each has serialNumber, productKey, hardwareIdentifier, state (importState), and importedDateTime. Use to track Autopilot device import status."
   },
   {
     "pathPattern": "/deviceManagement/windowsMalwareInformation",
     "method": "get",
     "toolName": "list-windows-malware-info",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.Read.All"],
     "llmTip": "Lists Windows malware information detected across Intune-managed devices. Each has displayName, category, severity, additionalInformationUrl, and deviceMalwareStates. Use for threat landscape visibility."
   },
   {
     "pathPattern": "/deviceAppManagement/mobileApps",
     "method": "get",
     "toolName": "list-intune-mobile-apps",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists mobile apps managed by Intune. Each has displayName, publisher, createdDateTime, lastModifiedDateTime, isAssigned, isFeatured, publishingState. Includes Win32, iOS, Android, macOS, and web apps. Use $filter=isAssigned eq true to see assigned apps."
   },
   {
     "pathPattern": "/deviceAppManagement/mobileAppCategories",
     "method": "get",
     "toolName": "list-intune-app-categories",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists Intune mobile app categories. Each has displayName and id. Categories help organize apps in the Company Portal."
   },
   {
     "pathPattern": "/deviceAppManagement/mobileAppConfigurations",
     "method": "get",
     "toolName": "list-intune-app-configurations",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists Intune app configuration policies. Each has displayName, description, targetedMobileApps, settings, and createdDateTime. Used to push configuration to managed apps."
   },
   {
     "pathPattern": "/deviceAppManagement/managedAppPolicies",
     "method": "get",
     "toolName": "list-managed-app-policies",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists Intune managed app protection policies (MAM). Each has displayName, description, createdDateTime, version. Shows all app protection policies across platforms."
   },
   {
     "pathPattern": "/deviceAppManagement/managedAppRegistrations",
     "method": "get",
     "toolName": "list-managed-app-registrations",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists managed app registrations. Each registration represents a user+device+app combination where MAM policy applies. Has appIdentifier, createdDateTime, deviceName, managementSdkVersion, and userId."
   },
   {
     "pathPattern": "/deviceAppManagement/managedAppStatuses",
     "method": "get",
     "toolName": "list-managed-app-statuses",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists managed app status reports. Returns status summaries for Intune app protection policies including deployment and user status."
   },
   {
     "pathPattern": "/deviceAppManagement/androidManagedAppProtections",
     "method": "get",
     "toolName": "list-android-app-protections",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists Android managed app protection policies (MAM). Each has displayName, description, periodOfflineBeforeWipeIsEnforced, pinRequired, minimumPinLength, managedBrowser, allowedDataStorageLocations, and organizationalCredentialsRequired."
   },
   {
     "pathPattern": "/deviceAppManagement/iosManagedAppProtections",
     "method": "get",
     "toolName": "list-ios-app-protections",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists iOS managed app protection policies (MAM). Each has displayName, description, periodOfflineBeforeWipeIsEnforced, pinRequired, minimumPinLength, faceIdBlocked, and allowedDataStorageLocations."
   },
   {
     "pathPattern": "/deviceAppManagement/defaultManagedAppProtections",
     "method": "get",
     "toolName": "list-default-app-protections",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists default managed app protection policies. These are cross-platform MAM policies that apply when no platform-specific policy exists."
   },
   {
     "pathPattern": "/deviceAppManagement/targetedManagedAppConfigurations",
     "method": "get",
     "toolName": "list-targeted-app-configurations",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists targeted managed app configuration policies. Each has displayName, description, targetedMobileApps, customSettings, and isAssigned. These push configuration to specific groups of users."
   },
   {
     "pathPattern": "/deviceAppManagement/mdmWindowsInformationProtectionPolicies",
     "method": "get",
     "toolName": "list-mdm-wip-policies",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists MDM Windows Information Protection (WIP) policies. Each has displayName, enforcementLevel, protectedApps, exemptApps, enterpriseNetworkDomainNames, and enterpriseProtectedDomainNames."
   },
   {
     "pathPattern": "/deviceAppManagement/windowsInformationProtectionPolicies",
     "method": "get",
     "toolName": "list-mam-wip-policies",
-    "appPermissions": [
-      "DeviceManagementApps.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementApps.Read.All"],
     "llmTip": "Lists MAM Windows Information Protection (WIP) policies (without MDM enrollment). Each has displayName, enforcementLevel, protectedApps, exemptApps, and isAssigned."
   },
   {
     "pathPattern": "/deviceAppManagement/vppTokens",
     "method": "get",
     "toolName": "list-vpp-tokens",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.Read.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.Read.All"],
     "llmTip": "Lists Apple Volume Purchase Program (VPP) tokens. Each has organizationName, appleId, state (valid, expired, invalid), expirationDateTime, lastSyncDateTime, lastSyncStatus, and automaticallyUpdateApps."
   },
   {
     "pathPattern": "/policies/activityBasedTimeoutPolicies",
     "method": "get",
     "toolName": "list-activity-timeout-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists activity-based timeout policies. These enforce idle session timeout for web applications. Each has displayName, isOrganizationDefault, and definition (JSON with ActivityBasedTimeoutPolicy settings)."
   },
   {
     "pathPattern": "/policies/authorizationPolicy",
     "method": "get",
     "toolName": "get-authorization-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the tenant authorization policy. Returns allowedToSignUpEmailBasedSubscriptions, allowedToUseSSPR, allowEmailVerifiedUsersToJoinOrganization, allowInvitesFrom, blockMsolPowerShell, defaultUserRolePermissions (allowedToCreateApps, allowedToCreateSecurityGroups, allowedToReadBitlockerKeysForOwnedDevice, allowedToReadOtherUsers), and guestUserRoleId."
   },
   {
     "pathPattern": "/policies/authenticationFlowsPolicy",
     "method": "get",
     "toolName": "get-auth-flows-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the authentication flows policy. Returns selfServiceSignUp configuration (isEnabled) which controls whether external users can sign up via user flows."
   },
   {
     "pathPattern": "/policies/claimsMappingPolicies",
     "method": "get",
     "toolName": "list-claims-mapping-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists claims mapping policies. These customize token claims for specific applications. Each has displayName, isOrganizationDefault, and definition (JSON with ClaimsMappingPolicy including IncludeBasicClaimSet and ClaimsSchema)."
   },
   {
     "pathPattern": "/policies/conditionalAccessPolicies",
     "method": "get",
     "toolName": "list-conditional-access-policies-v2",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists all conditional access policies using the policies endpoint. Each has displayName, state (enabled, disabled, enabledForReportingButNotEnforced), conditions, grantControls, and sessionControls. Alternative to list-conditional-access-policies."
   },
   {
     "pathPattern": "/policies/defaultAppManagementPolicy",
     "method": "get",
     "toolName": "get-default-app-management-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the default app management policy for the tenant. Returns the default restrictions on password and key credentials for app registrations and service principals when no specific policy is assigned."
   },
   {
     "pathPattern": "/policies/deviceRegistrationPolicy",
     "method": "get",
     "toolName": "get-device-registration-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the device registration policy. Returns multiFactorAuthConfiguration, azureADRegistration (allowedToRegister, isAdminConfigurable), azureADJoin (allowedToJoin, isAdminConfigurable), and localAdminPassword settings. Critical for controlling which users can join/register devices."
   },
   {
     "pathPattern": "/policies/featureRolloutPolicies",
     "method": "get",
     "toolName": "list-feature-rollout-policies",
-    "appPermissions": [
-      "Directory.Read.All"
-    ],
+    "appPermissions": ["Directory.Read.All"],
     "llmTip": "Lists feature rollout policies. These enable staged rollout of Entra ID features (like passwordHashSync, seamlessSSO, passthroughAuthentication) to specific groups before tenant-wide enablement. Each has displayName, feature, isEnabled, and isAppliedToOrganization."
   },
   {
     "pathPattern": "/policies/homeRealmDiscoveryPolicies",
     "method": "get",
     "toolName": "list-home-realm-discovery-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists home realm discovery policies. These control authentication behavior for federated domains (auto-acceleration, preferred domain, etc.). Each has displayName, isOrganizationDefault, and definition (JSON with HomeRealmDiscoveryPolicy)."
   },
   {
     "pathPattern": "/policies/permissionGrantPolicies",
     "method": "get",
     "toolName": "list-permission-grant-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists permission grant policies. These control which permissions users/admins can consent to. Each has displayName, includes (conditions that match), and excludes (conditions that block). Critical for app consent security."
   },
   {
     "pathPattern": "/policies/roleManagementPolicies",
     "method": "get",
     "toolName": "list-role-management-policies",
-    "appPermissions": [
-      "RoleManagementPolicy.Read.Directory"
-    ],
+    "appPermissions": ["RoleManagementPolicy.Read.Directory"],
     "llmTip": "Lists PIM role management policies. Each policy defines activation rules (MFA, justification, approval, max duration), assignment rules (permanent eligible/active, expiration), and notification rules for a specific role. Use $expand=rules to see all settings."
   },
   {
     "pathPattern": "/policies/roleManagementPolicyAssignments",
     "method": "get",
     "toolName": "list-role-management-policy-assignments",
-    "appPermissions": [
-      "RoleManagementPolicy.Read.Directory"
-    ],
+    "appPermissions": ["RoleManagementPolicy.Read.Directory"],
     "llmTip": "Lists PIM role management policy assignments. Links policies to specific roles. Each has policyId, scopeId, scopeType, and roleDefinitionId. Use $expand=policy($expand=rules) to include the full policy details."
   },
   {
     "pathPattern": "/policies/tokenIssuancePolicies",
     "method": "get",
     "toolName": "list-token-issuance-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists token issuance policies. These control how SAML tokens are issued (token format, signing algorithm, etc.). Each has displayName, isOrganizationDefault, and definition."
   },
   {
     "pathPattern": "/policies/tokenLifetimePolicies",
     "method": "get",
     "toolName": "list-token-lifetime-policies",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists token lifetime policies. These override default token lifetimes for specific applications. Each has displayName, isOrganizationDefault, and definition (JSON with TokenLifetimePolicy including AccessTokenLifetime and MaxAgeSessionSingleFactor)."
   },
   {
     "pathPattern": "/policies/crossTenantAccessPolicy/default",
     "method": "get",
     "toolName": "get-cross-tenant-default-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Gets the default cross-tenant access policy. Returns the default inbound/outbound settings (b2bCollaboration, b2bDirectConnect, organizationDefault) that apply to all tenants not covered by a partner-specific policy. Critical for controlling external collaboration defaults."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/assignmentPolicies",
     "method": "get",
     "toolName": "list-entitlement-assignment-policies",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Lists entitlement management assignment policies. Each defines who can request an access package, approval requirements, and access review settings. Has displayName, accessPackageId, requestApprovalSettings, requestorSettings, and reviewSettings."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/resources",
     "method": "get",
     "toolName": "list-entitlement-resources",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Lists resources available in entitlement management catalogs. Resources are groups, apps, or SharePoint sites that can be included in access packages."
   },
   {
     "pathPattern": "/identityGovernance/entitlementManagement/resourceEnvironments",
     "method": "get",
     "toolName": "list-entitlement-resource-environments",
-    "appPermissions": [
-      "EntitlementManagement.Read.All"
-    ],
+    "appPermissions": ["EntitlementManagement.Read.All"],
     "llmTip": "Lists resource environments in entitlement management. Environments represent connected systems (like other tenants) that provide resources for access packages."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/workflowTemplates",
     "method": "get",
     "toolName": "list-lifecycle-workflow-templates",
-    "appPermissions": [
-      "LifecycleWorkflows.Read.All"
-    ],
+    "appPermissions": ["LifecycleWorkflows.Read.All"],
     "llmTip": "Lists available lifecycle workflow templates. Templates provide pre-built workflows for common scenarios (onboarding, offboarding, job change). Each has displayName, description, category (joiner, leaver, mover), and executionConditions."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/settings",
     "method": "get",
     "toolName": "get-lifecycle-workflow-settings",
-    "appPermissions": [
-      "LifecycleWorkflows.Read.All"
-    ],
+    "appPermissions": ["LifecycleWorkflows.Read.All"],
     "llmTip": "Gets lifecycle workflows global settings. Returns workflowScheduleIntervalInHours (how often workflows are evaluated) and emailSettings."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/customTaskExtensions",
     "method": "get",
     "toolName": "list-lifecycle-custom-task-extensions",
-    "appPermissions": [
-      "LifecycleWorkflows.Read.All"
-    ],
+    "appPermissions": ["LifecycleWorkflows.Read.All"],
     "llmTip": "Lists custom task extensions for lifecycle workflows. These are Logic App-based custom actions that can be added to workflow steps. Each has displayName, endpointConfiguration, callbackConfiguration, and createdDateTime."
   },
   {
     "pathPattern": "/identityGovernance/lifecycleWorkflows/deletedItems/workflows",
     "method": "get",
     "toolName": "list-deleted-lifecycle-workflows",
-    "appPermissions": [
-      "LifecycleWorkflows.Read.All"
-    ],
+    "appPermissions": ["LifecycleWorkflows.Read.All"],
     "llmTip": "Lists recently deleted lifecycle workflows. Deleted workflows can be restored within 30 days. Each has displayName, category, deletedDateTime."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/assignmentScheduleRequests",
     "method": "get",
     "toolName": "list-pim-group-assignment-requests",
-    "appPermissions": [
-      "PrivilegedAccess.Read.AzureADGroup"
-    ],
+    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
     "llmTip": "Lists PIM for Groups assignment schedule requests. Each request represents an activation or assignment operation. Has action (adminAssign, adminRemove, selfActivate, selfDeactivate), principalId, groupId, accessId (member, owner), scheduleInfo, and status."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/assignmentScheduleInstances",
     "method": "get",
     "toolName": "list-pim-group-assignment-instances",
-    "appPermissions": [
-      "PrivilegedAccess.Read.AzureADGroup"
-    ],
+    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
     "llmTip": "Lists active PIM for Groups assignment instances. Shows who currently has active (not just eligible) group membership/ownership via PIM. Has principalId, groupId, accessId, assignmentType (assigned, activated), startDateTime, endDateTime."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/eligibilityScheduleRequests",
     "method": "get",
     "toolName": "list-pim-group-eligibility-requests",
-    "appPermissions": [
-      "PrivilegedAccess.Read.AzureADGroup"
-    ],
+    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
     "llmTip": "Lists PIM for Groups eligibility schedule requests. Shows requests to make users eligible for group membership/ownership. Has action, principalId, groupId, accessId, scheduleInfo, and status."
   },
   {
     "pathPattern": "/identityGovernance/privilegedAccess/group/eligibilityScheduleInstances",
     "method": "get",
     "toolName": "list-pim-group-eligibility-instances",
-    "appPermissions": [
-      "PrivilegedAccess.Read.AzureADGroup"
-    ],
+    "appPermissions": ["PrivilegedAccess.Read.AzureADGroup"],
     "llmTip": "Lists active PIM for Groups eligibility instances. Shows who is currently eligible to activate group membership/ownership. Has principalId, groupId, accessId, startDateTime, endDateTime, and memberType."
   },
   {
     "pathPattern": "/identityGovernance/accessReviews/historyDefinitions",
     "method": "get",
     "toolName": "list-access-review-history",
-    "appPermissions": [
-      "AccessReview.Read.All"
-    ],
+    "appPermissions": ["AccessReview.Read.All"],
     "llmTip": "Lists access review history definitions. These are scheduled exports of access review decisions. Each has displayName, reviewHistoryPeriodStartDateTime, reviewHistoryPeriodEndDateTime, status, and decisions (approve, deny, dontKnow, notReviewed)."
   },
   {
     "pathPattern": "/roleManagement/directory/roleAssignmentScheduleRequests",
     "method": "get",
     "toolName": "list-pim-role-assignment-requests",
-    "appPermissions": [
-      "RoleAssignmentSchedule.Read.Directory"
-    ],
+    "appPermissions": ["RoleAssignmentSchedule.Read.Directory"],
     "llmTip": "Lists PIM role assignment schedule requests. Each request represents an activation or assignment of a directory role. Has action (adminAssign, adminRemove, selfActivate, selfDeactivate), principalId, roleDefinitionId, directoryScopeId, scheduleInfo, and status."
   },
   {
     "pathPattern": "/roleManagement/directory/roleAssignmentSchedules",
     "method": "get",
     "toolName": "list-pim-role-assignment-schedules",
-    "appPermissions": [
-      "RoleAssignmentSchedule.Read.Directory"
-    ],
+    "appPermissions": ["RoleAssignmentSchedule.Read.Directory"],
     "llmTip": "Lists PIM role assignment schedules. Shows the schedule (start/end dates) for active role assignments. Has principalId, roleDefinitionId, directoryScopeId, assignmentType (assigned, activated), scheduleInfo, and memberType."
   },
   {
     "pathPattern": "/roleManagement/directory/roleEligibilityScheduleRequests",
     "method": "get",
     "toolName": "list-pim-role-eligibility-requests",
-    "appPermissions": [
-      "RoleEligibilitySchedule.Read.Directory"
-    ],
+    "appPermissions": ["RoleEligibilitySchedule.Read.Directory"],
     "llmTip": "Lists PIM role eligibility schedule requests. Shows requests to make users eligible for directory roles. Has action, principalId, roleDefinitionId, directoryScopeId, scheduleInfo, and status."
   },
   {
     "pathPattern": "/roleManagement/directory/roleEligibilitySchedules",
     "method": "get",
     "toolName": "list-pim-role-eligibility-schedules",
-    "appPermissions": [
-      "RoleEligibilitySchedule.Read.Directory"
-    ],
+    "appPermissions": ["RoleEligibilitySchedule.Read.Directory"],
     "llmTip": "Lists PIM role eligibility schedules. Shows all users currently eligible to activate directory roles with their schedule details. Has principalId, roleDefinitionId, directoryScopeId, scheduleInfo, and memberType."
   },
   {
     "pathPattern": "/roleManagement/directory/resourceNamespaces",
     "method": "get",
     "toolName": "list-role-resource-namespaces",
-    "appPermissions": [
-      "RoleManagement.Read.Directory"
-    ],
+    "appPermissions": ["RoleManagement.Read.Directory"],
     "llmTip": "Lists RBAC resource namespaces for directory roles. Each namespace represents a resource provider (microsoft.directory, microsoft.aad.b2c, etc.) with resourceActions defining available permissions."
   },
   {
     "pathPattern": "/identityProtection/riskyServicePrincipals/confirmCompromised",
     "method": "post",
     "toolName": "confirm-compromised-service-principals",
-    "appPermissions": [
-      "IdentityRiskyServicePrincipal.ReadWrite.All"
-    ],
+    "appPermissions": ["IdentityRiskyServicePrincipal.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Confirms one or more service principals as compromised. Body: {\"servicePrincipalIds\":[\"sp-id-1\"]}. Sets riskState to confirmedCompromised. Use after investigating a risky service principal and confirming the threat is real."
   },
@@ -2494,9 +1936,7 @@
     "pathPattern": "/identityProtection/riskyServicePrincipals/dismiss",
     "method": "post",
     "toolName": "dismiss-risky-service-principals",
-    "appPermissions": [
-      "IdentityRiskyServicePrincipal.ReadWrite.All"
-    ],
+    "appPermissions": ["IdentityRiskyServicePrincipal.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Dismisses risk for one or more service principals. Body: {\"servicePrincipalIds\":[\"sp-id-1\"]}. Sets riskState to dismissed. Use after investigating and determining the risk is a false positive."
   },
@@ -2504,18 +1944,14 @@
     "pathPattern": "/identityProtection/servicePrincipalRiskDetections",
     "method": "get",
     "toolName": "list-service-principal-risk-detections",
-    "appPermissions": [
-      "IdentityRiskEvent.Read.All"
-    ],
+    "appPermissions": ["IdentityRiskEvent.Read.All"],
     "llmTip": "Lists risk detections for service principals. Each has riskEventType, riskLevel, riskState, riskDetail, detectedDateTime, activity, source, servicePrincipalId, and appId. Use $filter=riskState eq 'atRisk' to see active risks."
   },
   {
     "pathPattern": "/identityProtection/riskyUsers/confirmSafe",
     "method": "post",
     "toolName": "confirm-safe-users",
-    "appPermissions": [
-      "IdentityRiskyUser.ReadWrite.All"
-    ],
+    "appPermissions": ["IdentityRiskyUser.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Confirms one or more users as safe (not compromised). Body: {\"userIds\":[\"user-id-1\"]}. Sets riskState to remediated. Use after investigating a risky user and confirming the account is not compromised."
   },
@@ -2523,9 +1959,7 @@
     "pathPattern": "/security/microsoft.graph.security.runHuntingQuery",
     "method": "post",
     "toolName": "run-hunting-query",
-    "appPermissions": [
-      "ThreatHunting.Read.All"
-    ],
+    "appPermissions": ["ThreatHunting.Read.All"],
     "riskLevel": "low",
     "llmTip": "Runs an advanced hunting query using KQL (Kusto Query Language) against Microsoft 365 Defender data. Body: {\"query\":\"DeviceProcessEvents | where Timestamp > ago(1d) | take 10\"}. Tables include DeviceEvents, DeviceProcessEvents, DeviceNetworkEvents, DeviceFileEvents, EmailEvents, AlertEvidence, IdentityLogonEvents, CloudAppEvents. Powerful for threat investigation."
   },
@@ -2533,288 +1967,224 @@
     "pathPattern": "/security/identities/healthIssues",
     "method": "get",
     "toolName": "list-identity-health-issues",
-    "appPermissions": [
-      "SecurityIdentitiesHealth.Read.All"
-    ],
+    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
     "llmTip": "Lists Microsoft Defender for Identity health issues. Each has healthIssueType, severity (low, medium, high), displayName, description, recommendedActionCommands, status (open, closed, suppressed), domainName, sensorDNSName, and issueTypeId. Use to monitor Defender for Identity sensor health."
   },
   {
     "pathPattern": "/security/identities/sensors",
     "method": "get",
     "toolName": "list-identity-sensors",
-    "appPermissions": [
-      "SecurityIdentitiesHealth.Read.All"
-    ],
+    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
     "llmTip": "Lists Microsoft Defender for Identity sensors. Each has displayName, sensorType (adConnectIntegrated, adcsIntegrated, adfsIntegrated, domainControllerIntegrated), healthStatus (healthy, notHealthy, offline), openHealthIssuesCount, domainName, version, and deploymentStatus."
   },
   {
     "pathPattern": "/security/identities/settings",
     "method": "get",
     "toolName": "get-identity-security-settings",
-    "appPermissions": [
-      "SecurityIdentitiesHealth.Read.All"
-    ],
+    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
     "llmTip": "Gets Microsoft Defender for Identity global settings. Returns configuration for identity-based threat detection."
   },
   {
     "pathPattern": "/security/triggers/retentionEvents",
     "method": "get",
     "toolName": "list-retention-events",
-    "appPermissions": [
-      "RecordsManagement.Read.All"
-    ],
+    "appPermissions": ["RecordsManagement.Read.All"],
     "llmTip": "Lists retention events that trigger event-based retention labels. Each has displayName, description, eventTriggerDateTime, retentionEventType, createdDateTime, and status. These events start the retention period for event-based labels."
   },
   {
     "pathPattern": "/security/triggerTypes/retentionEventTypes",
     "method": "get",
     "toolName": "list-retention-event-types",
-    "appPermissions": [
-      "RecordsManagement.Read.All"
-    ],
+    "appPermissions": ["RecordsManagement.Read.All"],
     "llmTip": "Lists retention event types. Each has displayName, description, and createdDateTime. Event types categorize retention events (e.g., 'Employee Departure', 'Contract Expiration')."
   },
   {
     "pathPattern": "/security/subjectRightsRequests",
     "method": "get",
     "toolName": "list-subject-rights-requests",
-    "appPermissions": [
-      "SubjectRightsRequest.Read.All"
-    ],
+    "appPermissions": ["SubjectRightsRequest.Read.All"],
     "llmTip": "Lists data subject rights requests (DSAR) for privacy compliance. Each has displayName, type (access, delete, export, tagForAction), status (active, closed), dataSubjectType, createdDateTime, createdBy, stages, and regulation. Used for GDPR/privacy compliance."
   },
   {
     "pathPattern": "/security/attackSimulation/simulationAutomations",
     "method": "get",
     "toolName": "list-simulation-automations",
-    "appPermissions": [
-      "AttackSimulation.Read.All"
-    ],
+    "appPermissions": ["AttackSimulation.Read.All"],
     "llmTip": "Lists attack simulation automations. Each has displayName, description, status (enabled, disabled, notRunning), createdDateTime, lastRunDateTime, nextRunDateTime, and attackType. These automate recurring phishing simulations."
   },
   {
     "pathPattern": "/security/attackSimulation/trainings",
     "method": "get",
     "toolName": "list-simulation-trainings",
-    "appPermissions": [
-      "AttackSimulation.Read.All"
-    ],
+    "appPermissions": ["AttackSimulation.Read.All"],
     "llmTip": "Lists available training content for attack simulations. Each has displayName, description, source (microsoft, global, tenant), type (assigned, notAssigned, unknown), availabilityStatus, durationInMinutes, and supportedLocales."
   },
   {
     "pathPattern": "/security/attackSimulation/payloads",
     "method": "get",
     "toolName": "list-simulation-payloads",
-    "appPermissions": [
-      "AttackSimulation.Read.All"
-    ],
+    "appPermissions": ["AttackSimulation.Read.All"],
     "llmTip": "Lists attack simulation payloads. Each has displayName, description, source (microsoft, global, tenant), status, platform, simulationAttackType (social, credential), technique (phishing, malware), language, and complexity."
   },
   {
     "pathPattern": "/security/attackSimulation/endUserNotifications",
     "method": "get",
     "toolName": "list-simulation-end-user-notifications",
-    "appPermissions": [
-      "AttackSimulation.Read.All"
-    ],
+    "appPermissions": ["AttackSimulation.Read.All"],
     "llmTip": "Lists end-user notification templates for attack simulations. These are the emails sent to users during/after simulations."
   },
   {
     "pathPattern": "/security/attackSimulation/landingPages",
     "method": "get",
     "toolName": "list-simulation-landing-pages",
-    "appPermissions": [
-      "AttackSimulation.Read.All"
-    ],
+    "appPermissions": ["AttackSimulation.Read.All"],
     "llmTip": "Lists landing page templates for attack simulations. These are the phishing pages shown when a user clicks a simulation link."
   },
   {
     "pathPattern": "/security/attackSimulation/loginPages",
     "method": "get",
     "toolName": "list-simulation-login-pages",
-    "appPermissions": [
-      "AttackSimulation.Read.All"
-    ],
+    "appPermissions": ["AttackSimulation.Read.All"],
     "llmTip": "Lists login page templates for attack simulations. These are credential harvest pages used in phishing simulations."
   },
   {
     "pathPattern": "/security/threatIntelligence/passiveDnsRecords",
     "method": "get",
     "toolName": "list-passive-dns-records",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists passive DNS records from Microsoft Defender Threat Intelligence. Each has firstSeenDateTime, lastSeenDateTime, recordType, and associated host/parentHost. Use $filter=host/id eq 'example.com' to find DNS history for a domain."
   },
   {
     "pathPattern": "/security/threatIntelligence/sslCertificates",
     "method": "get",
     "toolName": "list-ssl-certificates",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists SSL certificates from Microsoft Defender Threat Intelligence. Each has sha1, issuer, subject, serialNumber, firstSeenDateTime, lastSeenDateTime, and relatedHosts. Useful for infrastructure attribution."
   },
   {
     "pathPattern": "/security/threatIntelligence/subdomains",
     "method": "get",
     "toolName": "list-threat-intel-subdomains",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists subdomains from Threat Intelligence. Each has value (the subdomain), firstSeenDateTime, and host. Use $filter=host/id eq 'example.com' to enumerate subdomains."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostPorts",
     "method": "get",
     "toolName": "list-threat-intel-host-ports",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists open ports observed on hosts from Threat Intelligence. Each has port, protocol, status, firstSeenDateTime, lastSeenDateTime, and associated host/service/banner. Use $filter=host/id eq 'x.x.x.x' for a specific host."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostTrackers",
     "method": "get",
     "toolName": "list-threat-intel-host-trackers",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists web trackers (analytics IDs, etc.) observed on hosts from Threat Intelligence. Each has kind (GoogleAnalyticsID, JarmHash, etc.), value, firstSeenDateTime, lastSeenDateTime, and host. Useful for infrastructure correlation."
   },
   {
     "pathPattern": "/security/threatIntelligence/hostCookies",
     "method": "get",
     "toolName": "list-threat-intel-host-cookies",
-    "appPermissions": [
-      "ThreatIntelligence.Read.All"
-    ],
+    "appPermissions": ["ThreatIntelligence.Read.All"],
     "llmTip": "Lists cookies observed on hosts from Threat Intelligence. Each has name, domain, firstSeenDateTime, lastSeenDateTime, and host."
   },
   {
     "pathPattern": "/reports/authenticationMethods/userRegistrationDetails",
     "method": "get",
     "toolName": "list-user-registration-details",
-    "appPermissions": [
-      "UserAuthenticationMethod.Read.All"
-    ],
+    "appPermissions": ["UserAuthenticationMethod.Read.All"],
     "llmTip": "Lists MFA/SSPR registration details for all users. Each has userPrincipalName, userDisplayName, isMfaRegistered, isMfaCapable, isSsprRegistered, isSsprEnabled, isSsprCapable, isPasswordlessCapable, methodsRegistered, and defaultMfaMethod. Powerful for MFA adoption reporting."
   },
   {
     "pathPattern": "/reports/dailyPrintUsageByPrinter",
     "method": "get",
     "toolName": "list-daily-print-usage-by-printer",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
+    "appPermissions": ["Reports.Read.All"],
     "llmTip": "Lists daily Universal Print usage summarized by printer. Each has printerName, printerId, usageDate, completedBlackAndWhiteJobCount, completedColorJobCount, incompleteJobCount, and pagesPrinted."
   },
   {
     "pathPattern": "/reports/dailyPrintUsageByUser",
     "method": "get",
     "toolName": "list-daily-print-usage-by-user",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
+    "appPermissions": ["Reports.Read.All"],
     "llmTip": "Lists daily Universal Print usage summarized by user. Each has userPrincipalName, usageDate, completedBlackAndWhiteJobCount, completedColorJobCount, incompleteJobCount, and pagesPrinted."
   },
   {
     "pathPattern": "/reports/monthlyPrintUsageByPrinter",
     "method": "get",
     "toolName": "list-monthly-print-usage-by-printer",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
+    "appPermissions": ["Reports.Read.All"],
     "llmTip": "Lists monthly Universal Print usage summarized by printer. Each has printerName, usageDate, completedBlackAndWhiteJobCount, completedColorJobCount, incompleteJobCount, and pagesPrinted."
   },
   {
     "pathPattern": "/reports/monthlyPrintUsageByUser",
     "method": "get",
     "toolName": "list-monthly-print-usage-by-user",
-    "appPermissions": [
-      "Reports.Read.All"
-    ],
+    "appPermissions": ["Reports.Read.All"],
     "llmTip": "Lists monthly Universal Print usage summarized by user. Each has userPrincipalName, usageDate, completedBlackAndWhiteJobCount, completedColorJobCount, incompleteJobCount, and pagesPrinted."
   },
   {
     "pathPattern": "/copilot/admin/settings",
     "method": "get",
     "toolName": "get-copilot-admin-settings",
-    "appPermissions": [
-      "CopilotSettings-Internal.ReadWrite.All"
-    ],
+    "appPermissions": ["CopilotSettings-Internal.ReadWrite.All"],
     "llmTip": "Gets Microsoft 365 Copilot admin settings for the tenant. Returns configuration controlling Copilot behavior and availability."
   },
   {
     "pathPattern": "/copilot/admin/settings/limitedMode",
     "method": "get",
     "toolName": "get-copilot-limited-mode",
-    "appPermissions": [
-      "CopilotSettings-Internal.ReadWrite.All"
-    ],
+    "appPermissions": ["CopilotSettings-Internal.ReadWrite.All"],
     "llmTip": "Gets Copilot limited mode configuration. Returns isEnabledForGroup, groupId, and whether Copilot features are restricted for specific user groups."
   },
   {
     "pathPattern": "/directory/attributeSets",
     "method": "get",
     "toolName": "list-attribute-sets",
-    "appPermissions": [
-      "CustomSecAttributeDefinition.Read.All"
-    ],
+    "appPermissions": ["CustomSecAttributeDefinition.Read.All"],
     "llmTip": "Lists custom security attribute sets. Each set is a container of custom security attributes. Has displayName, description, id, maxAttributesPerSet, and isLocked."
   },
   {
     "pathPattern": "/directory/customSecurityAttributeDefinitions",
     "method": "get",
     "toolName": "list-custom-security-attributes",
-    "appPermissions": [
-      "CustomSecAttributeDefinition.Read.All"
-    ],
+    "appPermissions": ["CustomSecAttributeDefinition.Read.All"],
     "llmTip": "Lists custom security attribute definitions. Each has attributeSet, name, type (String, Integer, Boolean), isSearchable, isCollection, usePreDefinedValuesOnly, status (Available, Deprecated), and description. Custom security attributes provide flexible tagging for Entra objects."
   },
   {
     "pathPattern": "/directory/deviceLocalCredentials",
     "method": "get",
     "toolName": "list-device-local-credentials",
-    "appPermissions": [
-      "DeviceLocalCredential.Read.All"
-    ],
+    "appPermissions": ["DeviceLocalCredential.Read.All"],
     "llmTip": "Lists device local admin credentials managed by Entra ID (LAPS - Local Admin Password Solution). Each has deviceName, lastBackupDateTime, and refreshDateTime. The actual password requires DeviceLocalCredential.Read.All and a separate GET by ID."
   },
   {
     "pathPattern": "/directory/federationConfigurations",
     "method": "get",
     "toolName": "list-federation-configurations",
-    "appPermissions": [
-      "Domain.Read.All"
-    ],
+    "appPermissions": ["Domain.Read.All"],
     "llmTip": "Lists federation configurations for the directory. Each has displayName, audiences, issuerUri, metadataExchangeUri, passiveSignInUri, signingCertificateUpdateStatus, and preferredAuthenticationProtocol."
   },
   {
     "pathPattern": "/directory/onPremisesSynchronization",
     "method": "get",
     "toolName": "list-on-premises-sync",
-    "appPermissions": [
-      "OnPremDirectorySynchronization.Read.All"
-    ],
+    "appPermissions": ["OnPremDirectorySynchronization.Read.All"],
     "llmTip": "Lists on-premises directory synchronization (Entra Connect) configurations. Returns features enabled (passwordHashSync, passwordWriteback, seamlessSSO, cloudSync), configuration details, and sync status."
   },
   {
     "pathPattern": "/teams",
     "method": "get",
     "toolName": "list-teams",
-    "appPermissions": [
-      "Team.ReadBasic.All"
-    ],
+    "appPermissions": ["Team.ReadBasic.All"],
     "llmTip": "Lists all teams in the tenant. Use $filter=displayName eq 'name' to find specific teams. Use $select=id,displayName,description to limit fields. Returns id, displayName, description, visibility, isArchived."
   },
   {
     "pathPattern": "/teams",
     "method": "post",
     "toolName": "create-team",
-    "appPermissions": [
-      "Team.Create"
-    ],
+    "appPermissions": ["Team.Create"],
     "riskLevel": "medium",
     "llmTip": "Creates a new team. Body requires template@odata.bind, displayName, description. Example: {\"template@odata.bind\":\"https://graph.microsoft.com/v1.0/teamsTemplates('standard')\",\"displayName\":\"My Team\",\"description\":\"desc\"}."
   },
@@ -2822,18 +2192,14 @@
     "pathPattern": "/teams/{team-id}",
     "method": "get",
     "toolName": "get-team",
-    "appPermissions": [
-      "Team.ReadBasic.All"
-    ],
+    "appPermissions": ["Team.ReadBasic.All"],
     "llmTip": "Gets a specific team by ID. Returns displayName, description, visibility (public/private), isArchived, memberSettings, guestSettings, messagingSettings, funSettings, discoverySettings."
   },
   {
     "pathPattern": "/teams/{team-id}",
     "method": "patch",
     "toolName": "update-team",
-    "appPermissions": [
-      "Team.ReadWrite.All"
-    ],
+    "appPermissions": ["Team.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates a team's settings. Body can include displayName, description, visibility, memberSettings, guestSettings, messagingSettings, funSettings."
   },
@@ -2841,9 +2207,7 @@
     "pathPattern": "/teams/{team-id}",
     "method": "delete",
     "toolName": "delete-team",
-    "appPermissions": [
-      "Group.ReadWrite.All"
-    ],
+    "appPermissions": ["Group.ReadWrite.All"],
     "riskLevel": "critical",
     "llmTip": "Deletes a team and its associated group. This is irreversible. The team and all its content (channels, messages, files) will be permanently deleted."
   },
@@ -2851,18 +2215,14 @@
     "pathPattern": "/teams/{team-id}/channels",
     "method": "get",
     "toolName": "list-team-admin-channels",
-    "appPermissions": [
-      "Channel.ReadBasic.All"
-    ],
+    "appPermissions": ["Channel.ReadBasic.All"],
     "llmTip": "Lists channels in a team. Returns id, displayName, description, membershipType (standard/private/shared), createdDateTime, email, webUrl."
   },
   {
     "pathPattern": "/teams/{team-id}/channels",
     "method": "post",
     "toolName": "create-team-admin-channel",
-    "appPermissions": [
-      "Channel.Create"
-    ],
+    "appPermissions": ["Channel.Create"],
     "riskLevel": "low",
     "llmTip": "Creates a new channel in a team. Body requires displayName. Optional: description, membershipType (standard/private/shared)."
   },
@@ -2870,18 +2230,14 @@
     "pathPattern": "/teams/{team-id}/channels/{channel-id}",
     "method": "get",
     "toolName": "get-team-admin-channel",
-    "appPermissions": [
-      "Channel.ReadBasic.All"
-    ],
+    "appPermissions": ["Channel.ReadBasic.All"],
     "llmTip": "Gets a specific channel by ID. Returns displayName, description, membershipType, createdDateTime, email, webUrl, tenantId."
   },
   {
     "pathPattern": "/teams/{team-id}/channels/{channel-id}",
     "method": "delete",
     "toolName": "delete-team-admin-channel",
-    "appPermissions": [
-      "Channel.Delete.All"
-    ],
+    "appPermissions": ["Channel.Delete.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a channel from a team. All messages and files in the channel will be deleted."
   },
@@ -2889,18 +2245,14 @@
     "pathPattern": "/teams/{team-id}/members",
     "method": "get",
     "toolName": "list-team-admin-members",
-    "appPermissions": [
-      "TeamMember.Read.All"
-    ],
+    "appPermissions": ["TeamMember.Read.All"],
     "llmTip": "Lists members of a team. Returns each member's id, displayName, roles (owner/member/guest), userId, email."
   },
   {
     "pathPattern": "/teams/{team-id}/members/add",
     "method": "post",
     "toolName": "add-team-admin-members",
-    "appPermissions": [
-      "TeamMember.ReadWrite.All"
-    ],
+    "appPermissions": ["TeamMember.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Adds members to a team in bulk. Body: {\"values\":[{\"@odata.type\":\"microsoft.graph.aadUserConversationMember\",\"roles\":[],\"user@odata.bind\":\"https://graph.microsoft.com/v1.0/users('userId')\"}]}."
   },
@@ -2908,9 +2260,7 @@
     "pathPattern": "/teams/{team-id}/members/remove",
     "method": "post",
     "toolName": "remove-team-admin-members",
-    "appPermissions": [
-      "TeamMember.ReadWrite.All"
-    ],
+    "appPermissions": ["TeamMember.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Removes members from a team in bulk. Body: {\"values\":[{\"id\":\"conversationMemberId\"}]}."
   },
@@ -2918,27 +2268,21 @@
     "pathPattern": "/teams/{team-id}/members/{conversationMember-id}",
     "method": "get",
     "toolName": "get-team-admin-member",
-    "appPermissions": [
-      "TeamMember.Read.All"
-    ],
+    "appPermissions": ["TeamMember.Read.All"],
     "llmTip": "Gets a specific member of a team. Returns displayName, roles, userId, email, visibleHistoryStartDateTime."
   },
   {
     "pathPattern": "/teams/{team-id}/installedApps",
     "method": "get",
     "toolName": "list-team-installed-apps",
-    "appPermissions": [
-      "TeamsAppInstallation.ReadForTeam.All"
-    ],
+    "appPermissions": ["TeamsAppInstallation.ReadForTeam.All"],
     "llmTip": "Lists apps installed in a team. Use $expand=teamsAppDefinition to get app details. Returns teamsApp, teamsAppDefinition with displayName, version, description."
   },
   {
     "pathPattern": "/teams/{team-id}/archive",
     "method": "post",
     "toolName": "archive-team",
-    "appPermissions": [
-      "Team.ReadWrite.All"
-    ],
+    "appPermissions": ["Team.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Archives a team. Archived teams become read-only. Optional body: {\"shouldSetSpoSiteReadOnlyForMembers\": true} to also make the SharePoint site read-only."
   },
@@ -2946,9 +2290,7 @@
     "pathPattern": "/teams/{team-id}/unarchive",
     "method": "post",
     "toolName": "unarchive-team",
-    "appPermissions": [
-      "Team.ReadWrite.All"
-    ],
+    "appPermissions": ["Team.ReadWrite.All"],
     "riskLevel": "low",
     "llmTip": "Unarchives a team, restoring it to active state and allowing users to send messages and edit the team again."
   },
@@ -2956,9 +2298,7 @@
     "pathPattern": "/teams/{team-id}/clone",
     "method": "post",
     "toolName": "clone-team",
-    "appPermissions": [
-      "Team.Create"
-    ],
+    "appPermissions": ["Team.Create"],
     "riskLevel": "medium",
     "llmTip": "Clones a team. Body requires displayName, description, mailNickname, partsToClone (apps,tabs,settings,channels,members). classification and visibility are optional."
   },
@@ -2966,36 +2306,28 @@
     "pathPattern": "/teams/{team-id}/operations",
     "method": "get",
     "toolName": "list-team-operations",
-    "appPermissions": [
-      "Team.ReadBasic.All"
-    ],
+    "appPermissions": ["Team.ReadBasic.All"],
     "llmTip": "Lists async operations on a team (archive, clone, etc.). Returns operationType, status (notStarted/running/succeeded/failed), createdDateTime, lastActionDateTime, error."
   },
   {
     "pathPattern": "/teams/{team-id}/permissionGrants",
     "method": "get",
     "toolName": "list-team-permission-grants",
-    "appPermissions": [
-      "TeamsAppInstallation.ReadForTeam.All"
-    ],
+    "appPermissions": ["TeamsAppInstallation.ReadForTeam.All"],
     "llmTip": "Lists resource-specific permission grants on a team. Shows which apps have been granted specific permissions (e.g., ChannelMessage.Read.Group)."
   },
   {
     "pathPattern": "/teamwork/teamsAppSettings",
     "method": "get",
     "toolName": "get-teams-app-settings",
-    "appPermissions": [
-      "TeamworkAppSettings.Read.All"
-    ],
+    "appPermissions": ["TeamworkAppSettings.Read.All"],
     "llmTip": "Gets tenant-wide Teams app settings. Returns allowUserRequestsForAppAccess (whether users can request admin approval for apps) and isUserPersonalScopeResourceSpecificConsentEnabled."
   },
   {
     "pathPattern": "/teamwork/teamsAppSettings",
     "method": "patch",
     "toolName": "update-teams-app-settings",
-    "appPermissions": [
-      "TeamworkAppSettings.ReadWrite.All"
-    ],
+    "appPermissions": ["TeamworkAppSettings.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Updates tenant-wide Teams app settings. Body can include allowUserRequestsForAppAccess and isUserPersonalScopeResourceSpecificConsentEnabled."
   },
@@ -3003,108 +2335,84 @@
     "pathPattern": "/teamwork/deletedTeams",
     "method": "get",
     "toolName": "list-deleted-teams",
-    "appPermissions": [
-      "Team.ReadBasic.All"
-    ],
+    "appPermissions": ["Team.ReadBasic.All"],
     "llmTip": "Lists recently deleted teams. Returns id and displayName. Deleted teams can be restored within 30 days."
   },
   {
     "pathPattern": "/appCatalogs/teamsApps",
     "method": "get",
     "toolName": "list-teams-catalog-apps",
-    "appPermissions": [
-      "AppCatalog.Read.All"
-    ],
+    "appPermissions": ["AppCatalog.Read.All"],
     "llmTip": "Lists apps in the Teams app catalog (tenant and store). Use $filter=distributionMethod eq 'organization' for tenant-only apps. Returns id, displayName, externalId, distributionMethod."
   },
   {
     "pathPattern": "/appCatalogs/teamsApps/{teamsApp-id}",
     "method": "get",
     "toolName": "get-teams-catalog-app",
-    "appPermissions": [
-      "AppCatalog.Read.All"
-    ],
+    "appPermissions": ["AppCatalog.Read.All"],
     "llmTip": "Gets a specific app from the Teams app catalog. Use $expand=appDefinitions to get version details."
   },
   {
     "pathPattern": "/appCatalogs/teamsApps/{teamsApp-id}/appDefinitions",
     "method": "get",
     "toolName": "list-teams-app-definitions",
-    "appPermissions": [
-      "AppCatalog.Read.All"
-    ],
+    "appPermissions": ["AppCatalog.Read.All"],
     "llmTip": "Lists all versions (definitions) of a Teams app. Each definition has displayName, description, version, publishingState, shortDescription, teamsAppId."
   },
   {
     "pathPattern": "/admin/teams",
     "method": "get",
     "toolName": "get-teams-admin-settings",
-    "appPermissions": [
-      "TeamworkDevice.Read.All"
-    ],
+    "appPermissions": ["TeamworkDevice.Read.All"],
     "llmTip": "Gets Teams admin settings for the tenant."
   },
   {
     "pathPattern": "/admin/teams/userConfigurations",
     "method": "get",
     "toolName": "list-teams-user-configurations",
-    "appPermissions": [
-      "TeamworkDevice.Read.All"
-    ],
+    "appPermissions": ["TeamworkDevice.Read.All"],
     "llmTip": "Lists Teams user configurations in the tenant."
   },
   {
     "pathPattern": "/admin/teams/policy",
     "method": "get",
     "toolName": "get-teams-admin-policy",
-    "appPermissions": [
-      "TeamworkDevice.Read.All"
-    ],
+    "appPermissions": ["TeamworkDevice.Read.All"],
     "llmTip": "Gets Teams admin policy settings."
   },
   {
     "pathPattern": "/admin/teams/policy/userAssignments",
     "method": "get",
     "toolName": "list-teams-policy-assignments",
-    "appPermissions": [
-      "TeamworkDevice.Read.All"
-    ],
+    "appPermissions": ["TeamworkDevice.Read.All"],
     "llmTip": "Lists Teams policy user assignments."
   },
   {
     "pathPattern": "/admin/teams/telephoneNumberManagement/numberAssignments",
     "method": "get",
     "toolName": "list-teams-phone-assignments",
-    "appPermissions": [
-      "TeamworkDevice.Read.All"
-    ],
+    "appPermissions": ["TeamworkDevice.Read.All"],
     "llmTip": "Lists telephone number assignments for Teams. Shows which phone numbers are assigned to which users or resources."
   },
   {
     "pathPattern": "/sites",
     "method": "get",
     "toolName": "list-sharepoint-sites",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Lists or searches SharePoint sites. Use $search='keyword' to search by site name/URL. Use $filter to filter. Use $select=id,displayName,webUrl to limit fields. Returns id, displayName, webUrl, createdDateTime, lastModifiedDateTime."
   },
   {
     "pathPattern": "/sites/{site-id}",
     "method": "get",
     "toolName": "get-sharepoint-site",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Gets a specific SharePoint site by ID. The site-id format is {hostname}:{server-relative-path} or a GUID. Returns displayName, webUrl, root, siteCollection, createdDateTime."
   },
   {
     "pathPattern": "/sites/{site-id}",
     "method": "patch",
     "toolName": "update-sharepoint-site",
-    "appPermissions": [
-      "Sites.ReadWrite.All"
-    ],
+    "appPermissions": ["Sites.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates a SharePoint site's properties. Body can include displayName and description."
   },
@@ -3112,180 +2420,140 @@
     "pathPattern": "/sites/{site-id}/drives",
     "method": "get",
     "toolName": "list-site-drives",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Lists document libraries (drives) in a SharePoint site. Returns id, name, driveType, webUrl, quota, owner for each drive."
   },
   {
     "pathPattern": "/sites/{site-id}/drive",
     "method": "get",
     "toolName": "get-site-default-drive",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Gets the default document library (drive) for a SharePoint site. Returns id, name, driveType, webUrl, quota."
   },
   {
     "pathPattern": "/sites/{site-id}/lists",
     "method": "get",
     "toolName": "list-site-lists",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Lists SharePoint lists in a site. Returns id, displayName, list (template, contentTypesEnabled, hidden), createdDateTime, webUrl for each list."
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}",
     "method": "get",
     "toolName": "get-site-list",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Gets a specific SharePoint list by ID. Returns displayName, list settings, columns, contentTypes, webUrl."
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
     "method": "get",
     "toolName": "list-site-list-items",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Lists items in a SharePoint list. Use $expand=fields to get column values. Use $filter on fields/ColumnName for filtering."
   },
   {
     "pathPattern": "/sites/{site-id}/lists/{list-id}/columns",
     "method": "get",
     "toolName": "list-site-list-columns",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Lists column definitions for a SharePoint list. Returns each column's name, displayName, type (text, number, choice, etc.), description."
   },
   {
     "pathPattern": "/sites/{site-id}/columns",
     "method": "get",
     "toolName": "list-site-columns",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Lists site-level column definitions. Returns each column's name, displayName, type, description."
   },
   {
     "pathPattern": "/sites/{site-id}/contentTypes",
     "method": "get",
     "toolName": "list-site-content-types",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Lists content types defined in a SharePoint site. Returns id, name, description, group, isBuiltIn, parentId."
   },
   {
     "pathPattern": "/sites/{site-id}/permissions",
     "method": "get",
     "toolName": "list-site-permissions",
-    "appPermissions": [
-      "Sites.FullControl.All"
-    ],
+    "appPermissions": ["Sites.FullControl.All"],
     "llmTip": "Lists permissions granted on a SharePoint site. Returns each permission's id, roles, grantedToIdentities (application or user)."
   },
   {
     "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
     "method": "get",
     "toolName": "get-site-permission",
-    "appPermissions": [
-      "Sites.FullControl.All"
-    ],
+    "appPermissions": ["Sites.FullControl.All"],
     "llmTip": "Gets a specific permission on a SharePoint site by ID. Returns id, roles, grantedToIdentities."
   },
   {
     "pathPattern": "/sites/{site-id}/analytics",
     "method": "get",
     "toolName": "get-site-analytics",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Gets analytics for a SharePoint site. Returns allTime and lastSevenDays access counts."
   },
   {
     "pathPattern": "/sites/{site-id}/sites",
     "method": "get",
     "toolName": "list-site-subsites",
-    "appPermissions": [
-      "Sites.Read.All"
-    ],
+    "appPermissions": ["Sites.Read.All"],
     "llmTip": "Lists subsites of a SharePoint site. Returns displayName, webUrl, createdDateTime for each subsite."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels",
     "method": "get",
     "toolName": "list-sensitivity-labels",
-    "appPermissions": [
-      "InformationProtectionPolicy.Read.All"
-    ],
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
     "llmTip": "Lists sensitivity labels defined in the tenant. Returns id, name, description, tooltip, color, isActive, priority, parent. Labels are used for data classification and protection."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}",
     "method": "get",
     "toolName": "get-sensitivity-label",
-    "appPermissions": [
-      "InformationProtectionPolicy.Read.All"
-    ],
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
     "llmTip": "Gets a specific sensitivity label by ID. Returns name, description, tooltip, color, isActive, priority, parent, contentFormats, autoLabeling settings."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}/sublabels",
     "method": "get",
     "toolName": "list-sensitivity-sublabels",
-    "appPermissions": [
-      "InformationProtectionPolicy.Read.All"
-    ],
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
     "llmTip": "Lists sublabels under a parent sensitivity label. Returns id, name, description, tooltip, color, isActive, priority."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/sensitivityLabels/{sensitivityLabel-id}/rights",
     "method": "get",
     "toolName": "get-sensitivity-label-rights",
-    "appPermissions": [
-      "InformationProtectionPolicy.Read.All"
-    ],
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
     "llmTip": "Gets the rights associated with a sensitivity label, including encryption settings and usage rights."
   },
   {
     "pathPattern": "/security/dataSecurityAndGovernance/protectionScopes",
     "method": "get",
     "toolName": "get-protection-scopes",
-    "appPermissions": [
-      "InformationProtectionPolicy.Read.All"
-    ],
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
     "llmTip": "Gets the data security and governance protection scopes configured for the tenant."
   },
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/folders",
     "method": "get",
     "toolName": "list-exchange-mailbox-folders",
-    "appPermissions": [
-      "Exchange.ManageAsApp"
-    ],
+    "appPermissions": ["Exchange.ManageAsApp"],
     "llmTip": "Lists mailbox folders for an Exchange mailbox (admin). Returns id, displayName, totalItemCount, unreadItemCount, childFolderCount, parentFolderId."
   },
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/folders/{mailboxFolder-id}",
     "method": "get",
     "toolName": "get-exchange-mailbox-folder",
-    "appPermissions": [
-      "Exchange.ManageAsApp"
-    ],
+    "appPermissions": ["Exchange.ManageAsApp"],
     "llmTip": "Gets a specific mailbox folder by ID (admin). Returns displayName, totalItemCount, unreadItemCount, childFolderCount."
   },
   {
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}/exportItems",
     "method": "post",
     "toolName": "export-exchange-mailbox-items",
-    "appPermissions": [
-      "Exchange.ManageAsApp"
-    ],
+    "appPermissions": ["Exchange.ManageAsApp"],
     "riskLevel": "medium",
     "llmTip": "Exports items from an Exchange mailbox. Body: {\"itemIds\":[\"itemId1\",\"itemId2\"]}. Returns exportedItems with data (base64)."
   },
@@ -3293,107 +2561,79 @@
     "pathPattern": "/communications/callRecords/{callRecord-id}",
     "method": "get",
     "toolName": "get-call-record",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Gets a specific call record by ID. Returns type (groupCall/peerToPeer), modalities (audio/video/screenSharing), startDateTime, endDateTime, organizer, participants, version."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/sessions",
     "method": "get",
     "toolName": "list-call-record-sessions",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Lists sessions within a call record. Each session represents a participant's connection. Returns caller, callee, startDateTime, endDateTime, modalities, failureInfo."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}",
     "method": "get",
     "toolName": "get-call-record-session",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Gets a specific session within a call record. Returns detailed caller/callee info, modalities, startDateTime, endDateTime, failureInfo, isTest."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}/segments",
     "method": "get",
     "toolName": "list-call-session-segments",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Lists segments within a call session. Each segment has media streams with detailed quality metrics: jitter, packetLoss, roundTripTime, averageAudioDegradation, etc."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/sessions/{session-id}/segments/{segment-id}",
     "method": "get",
     "toolName": "get-call-session-segment",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Gets a specific segment of a call session. Returns detailed media stream quality metrics including jitter, packetLoss, roundTripTime for audio/video/screenSharing."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/participants_v2",
     "method": "get",
     "toolName": "list-call-record-participants",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Lists participants in a call record (v2 API). Returns each participant's identity (user, phone, application), and participant details."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/participants_v2/{participant-id}",
     "method": "get",
     "toolName": "get-call-record-participant",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Gets a specific participant in a call record (v2 API). Returns participant identity and details."
   },
   {
     "pathPattern": "/communications/callRecords/{callRecord-id}/organizer_v2",
     "method": "get",
     "toolName": "get-call-record-organizer",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
     "llmTip": "Gets the organizer of a call record (v2 API). Returns the organizer's identity (user or application)."
   },
   {
     "pathPattern": "/communications/callRecords/microsoft.graph.callRecords.getPstnCalls(fromDateTime={fromDateTime},toDateTime={toDateTime})",
     "method": "get",
     "toolName": "get-pstn-calls",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
-    "skipEncoding": [
-      "fromDateTime",
-      "toDateTime"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
+    "skipEncoding": ["fromDateTime", "toDateTime"],
     "llmTip": "Gets PSTN (Public Switched Telephone Network) call records for a date range. Parameters are ISO 8601 dates. Returns callId, userId, userPrincipalName, callerNumber, calleeNumber, duration, charge, callType, currency."
   },
   {
     "pathPattern": "/communications/callRecords/microsoft.graph.callRecords.getDirectRoutingCalls(fromDateTime={fromDateTime},toDateTime={toDateTime})",
     "method": "get",
     "toolName": "get-direct-routing-calls",
-    "appPermissions": [
-      "CallRecords.Read.All"
-    ],
-    "skipEncoding": [
-      "fromDateTime",
-      "toDateTime"
-    ],
+    "appPermissions": ["CallRecords.Read.All"],
+    "skipEncoding": ["fromDateTime", "toDateTime"],
     "llmTip": "Gets Direct Routing call records for a date range. Parameters are ISO 8601 dates. Returns callId, correlationId, userId, callerNumber, calleeNumber, duration, startDateTime, failureDateTime, finalSipCode, mediaPathLocation."
   },
   {
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/wipe",
     "method": "post",
     "toolName": "wipe-managed-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "critical",
     "llmTip": "Wipes a managed device (factory reset). IRREVERSIBLE \u2014 all data on the device will be erased. Optional body: {\"keepEnrollmentData\":false,\"keepUserData\":false,\"macOsUnlockCode\":\"pin\"}. Always confirm with operator before executing."
   },
@@ -3401,9 +2641,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/retire",
     "method": "post",
     "toolName": "retire-managed-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "high",
     "llmTip": "Retires a managed device. Removes company data (apps, email, Wi-Fi, VPN profiles) but keeps personal data. The device is unenrolled from Intune management."
   },
@@ -3411,9 +2649,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/syncDevice",
     "method": "post",
     "toolName": "sync-managed-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "low",
     "llmTip": "Triggers an immediate sync of the managed device with Intune. Forces the device to check in and apply any pending policies, apps, or configurations."
   },
@@ -3421,9 +2657,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/rebootNow",
     "method": "post",
     "toolName": "reboot-managed-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "high",
     "llmTip": "Reboots a managed device immediately. The user will lose unsaved work. Windows devices only."
   },
@@ -3431,9 +2665,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/remoteLock",
     "method": "post",
     "toolName": "remote-lock-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "medium",
     "llmTip": "Remotely locks a managed device. The device owner must use their passcode/PIN to unlock. Useful for lost/stolen devices."
   },
@@ -3441,9 +2673,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/resetPasscode",
     "method": "post",
     "toolName": "reset-device-passcode",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "high",
     "llmTip": "Resets the passcode on a managed device. Behavior varies by platform: Android generates a new passcode, iOS removes the passcode."
   },
@@ -3451,9 +2681,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/shutDown",
     "method": "post",
     "toolName": "shutdown-managed-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "high",
     "llmTip": "Shuts down a managed device. The user will lose unsaved work."
   },
@@ -3461,9 +2689,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/disableLostMode",
     "method": "post",
     "toolName": "disable-lost-mode",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "low",
     "llmTip": "Disables Lost Mode on a supervised iOS device. The device returns to normal operation."
   },
@@ -3471,9 +2697,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/locateDevice",
     "method": "post",
     "toolName": "locate-managed-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "low",
     "llmTip": "Locates a managed device (iOS supervised). Returns the device's GPS coordinates. Use get-managed-device after to read deviceActionResults for the location."
   },
@@ -3481,9 +2705,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/bypassActivationLock",
     "method": "post",
     "toolName": "bypass-activation-lock",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "high",
     "llmTip": "Bypasses the Activation Lock on a supervised iOS device. Used when a device needs to be reactivated without the original Apple ID credentials."
   },
@@ -3491,9 +2713,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/windowsDefenderScan",
     "method": "post",
     "toolName": "trigger-defender-scan",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "low",
     "llmTip": "Triggers a Windows Defender antivirus scan on the device. Body: {\"quickScan\": true} for quick scan, or {\"quickScan\": false} for full scan."
   },
@@ -3501,9 +2721,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/windowsDefenderUpdateSignatures",
     "method": "post",
     "toolName": "update-defender-signatures",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "low",
     "llmTip": "Forces a Windows Defender signature update on the device. Ensures the latest antivirus definitions are installed."
   },
@@ -3511,9 +2729,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/cleanWindowsDevice",
     "method": "post",
     "toolName": "clean-windows-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "critical",
     "llmTip": "Cleans a Windows device (fresh start). Body: {\"keepUserData\": false}. Removes all installed apps and resets to default Windows. IRREVERSIBLE."
   },
@@ -3521,9 +2737,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/logoutSharedAppleDeviceActiveUser",
     "method": "post",
     "toolName": "logout-shared-apple-user",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "medium",
     "llmTip": "Logs out the active user from a shared Apple device (iPad). The device returns to the login screen."
   },
@@ -3531,9 +2745,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/deleteUserFromSharedAppleDevice",
     "method": "post",
     "toolName": "delete-shared-apple-user",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a user and their data from a shared Apple device. Body: {\"userPrincipalName\": \"user@contoso.com\"}."
   },
@@ -3541,9 +2753,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/updateWindowsDeviceAccount",
     "method": "post",
     "toolName": "update-windows-device-account",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.PrivilegedOperations.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
     "riskLevel": "medium",
     "llmTip": "Updates the account on a Windows device (Surface Hub). Body: {\"updateWindowsDeviceAccountActionParameter\": {\"deviceAccount\": {\"email\": \"room@contoso.com\"}, \"passwordRotationEnabled\": true}}."
   },
@@ -3551,9 +2761,7 @@
     "pathPattern": "/identity/conditionalAccess/policies",
     "method": "post",
     "toolName": "create-conditional-access-policy",
-    "appPermissions": [
-      "Policy.ReadWrite.ConditionalAccess"
-    ],
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
     "riskLevel": "high",
     "llmTip": "Creates a new Conditional Access policy. Body requires displayName, state (enabled/disabled/enabledForReportingButNotEnforced), conditions (users, applications, locations, platforms, signInRiskLevels), grantControls or sessionControls. Start with state='disabled' or 'enabledForReportingButNotEnforced' for safety."
   },
@@ -3561,9 +2769,7 @@
     "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
     "method": "patch",
     "toolName": "update-conditional-access-policy",
-    "appPermissions": [
-      "Policy.ReadWrite.ConditionalAccess"
-    ],
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
     "riskLevel": "high",
     "llmTip": "Updates a Conditional Access policy. Body can include displayName, state, conditions, grantControls, sessionControls. Changing state to 'enabled' activates enforcement \u2014 verify conditions before enabling."
   },
@@ -3571,9 +2777,7 @@
     "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
     "method": "delete",
     "toolName": "delete-conditional-access-policy",
-    "appPermissions": [
-      "Policy.ReadWrite.ConditionalAccess"
-    ],
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
     "riskLevel": "critical",
     "llmTip": "Deletes a Conditional Access policy. IRREVERSIBLE. Consider disabling (state='disabled') instead of deleting."
   },
@@ -3581,9 +2785,7 @@
     "pathPattern": "/identity/conditionalAccess/namedLocations",
     "method": "post",
     "toolName": "create-named-location",
-    "appPermissions": [
-      "Policy.ReadWrite.ConditionalAccess"
-    ],
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
     "riskLevel": "medium",
     "llmTip": "Creates a named location for Conditional Access. For IP ranges: {\"@odata.type\":\"#microsoft.graph.ipNamedLocation\",\"displayName\":\"Corp IPs\",\"isTrusted\":true,\"ipRanges\":[{\"@odata.type\":\"#microsoft.graph.iPv4CidrRange\",\"cidrAddress\":\"10.0.0.0/8\"}]}."
   },
@@ -3591,9 +2793,7 @@
     "pathPattern": "/identity/conditionalAccess/namedLocations/{namedLocation-id}",
     "method": "patch",
     "toolName": "update-named-location",
-    "appPermissions": [
-      "Policy.ReadWrite.ConditionalAccess"
-    ],
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
     "riskLevel": "medium",
     "llmTip": "Updates a named location. Body can include displayName, isTrusted, ipRanges (for IP locations) or countriesAndRegions, includeUnknownCountriesAndRegions (for country locations)."
   },
@@ -3601,9 +2801,7 @@
     "pathPattern": "/identity/conditionalAccess/namedLocations/{namedLocation-id}",
     "method": "delete",
     "toolName": "delete-named-location",
-    "appPermissions": [
-      "Policy.ReadWrite.ConditionalAccess"
-    ],
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
     "riskLevel": "high",
     "llmTip": "Deletes a named location. If in use by a Conditional Access policy, the location reference must be removed from the policy first."
   },
@@ -3611,18 +2809,14 @@
     "pathPattern": "/identity/conditionalAccess/templates",
     "method": "get",
     "toolName": "list-conditional-access-templates",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "llmTip": "Lists Conditional Access policy templates provided by Microsoft. Templates can be used as starting points for new policies. Returns id, name, description, scenarios, details."
   },
   {
     "pathPattern": "/deviceManagement/deviceCompliancePolicies",
     "method": "post",
     "toolName": "create-compliance-policy",
-    "appPermissions": [
-      "DeviceManagementConfiguration.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a new device compliance policy. Body varies by platform. Example for Windows: {\"@odata.type\":\"#microsoft.graph.windows10CompliancePolicy\",\"displayName\":\"Win10 Compliance\",\"passwordRequired\":true,\"bitLockerEnabled\":true}."
   },
@@ -3630,9 +2824,7 @@
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
     "method": "patch",
     "toolName": "update-compliance-policy",
-    "appPermissions": [
-      "DeviceManagementConfiguration.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates an existing device compliance policy. Body can include any compliance settings for the platform type."
   },
@@ -3640,9 +2832,7 @@
     "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
     "method": "delete",
     "toolName": "delete-compliance-policy",
-    "appPermissions": [
-      "DeviceManagementConfiguration.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a device compliance policy. Devices assigned to this policy will no longer be evaluated for compliance."
   },
@@ -3650,9 +2840,7 @@
     "pathPattern": "/deviceManagement/deviceConfigurations",
     "method": "post",
     "toolName": "create-device-configuration",
-    "appPermissions": [
-      "DeviceManagementConfiguration.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a new device configuration profile. Body varies by platform and profile type. Example: {\"@odata.type\":\"#microsoft.graph.windows10GeneralConfiguration\",\"displayName\":\"Win10 Config\",\"passwordBlockSimple\":true}."
   },
@@ -3660,9 +2848,7 @@
     "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
     "method": "patch",
     "toolName": "update-device-configuration",
-    "appPermissions": [
-      "DeviceManagementConfiguration.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates an existing device configuration profile. Body can include any configuration settings for the profile type."
   },
@@ -3670,9 +2856,7 @@
     "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
     "method": "delete",
     "toolName": "delete-device-configuration",
-    "appPermissions": [
-      "DeviceManagementConfiguration.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a device configuration profile. Devices assigned to this profile will no longer receive these settings."
   },
@@ -3680,9 +2864,7 @@
     "pathPattern": "/sites/{site-id}/permissions",
     "method": "post",
     "toolName": "create-site-permission",
-    "appPermissions": [
-      "Sites.FullControl.All"
-    ],
+    "appPermissions": ["Sites.FullControl.All"],
     "riskLevel": "medium",
     "llmTip": "Grants a permission on a SharePoint site. Body: {\"roles\":[\"write\"],\"grantedToIdentities\":[{\"application\":{\"id\":\"app-id\",\"displayName\":\"App Name\"}}]}. Roles: read, write, owner."
   },
@@ -3690,9 +2872,7 @@
     "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
     "method": "patch",
     "toolName": "update-site-permission",
-    "appPermissions": [
-      "Sites.FullControl.All"
-    ],
+    "appPermissions": ["Sites.FullControl.All"],
     "riskLevel": "medium",
     "llmTip": "Updates a permission on a SharePoint site. Body: {\"roles\":[\"read\"]} to change the role."
   },
@@ -3700,9 +2880,7 @@
     "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
     "method": "delete",
     "toolName": "delete-site-permission",
-    "appPermissions": [
-      "Sites.FullControl.All"
-    ],
+    "appPermissions": ["Sites.FullControl.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a permission from a SharePoint site. The app or user will lose access to the site."
   },
@@ -3710,9 +2888,7 @@
     "pathPattern": "/sites/{site-id}/lists",
     "method": "post",
     "toolName": "create-site-list",
-    "appPermissions": [
-      "Sites.ReadWrite.All"
-    ],
+    "appPermissions": ["Sites.ReadWrite.All"],
     "riskLevel": "low",
     "llmTip": "Creates a new SharePoint list. Body: {\"displayName\":\"My List\",\"list\":{\"template\":\"genericList\"}}. Templates: genericList, documentLibrary, events, tasks, contacts, etc."
   },
@@ -3720,9 +2896,7 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}",
     "method": "patch",
     "toolName": "update-site-list",
-    "appPermissions": [
-      "Sites.ReadWrite.All"
-    ],
+    "appPermissions": ["Sites.ReadWrite.All"],
     "riskLevel": "low",
     "llmTip": "Updates a SharePoint list. Body can include displayName and description."
   },
@@ -3730,9 +2904,7 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}",
     "method": "delete",
     "toolName": "delete-site-list",
-    "appPermissions": [
-      "Sites.ReadWrite.All"
-    ],
+    "appPermissions": ["Sites.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a SharePoint list and all its items."
   },
@@ -3740,9 +2912,7 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
     "method": "post",
     "toolName": "create-site-list-item",
-    "appPermissions": [
-      "Sites.ReadWrite.All"
-    ],
+    "appPermissions": ["Sites.ReadWrite.All"],
     "riskLevel": "low",
     "llmTip": "Creates a new item in a SharePoint list. Body: {\"fields\":{\"Title\":\"Item title\",\"ColumnName\":\"value\"}}."
   },
@@ -3750,9 +2920,7 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
     "method": "patch",
     "toolName": "update-site-list-item",
-    "appPermissions": [
-      "Sites.ReadWrite.All"
-    ],
+    "appPermissions": ["Sites.ReadWrite.All"],
     "riskLevel": "low",
     "llmTip": "Updates a SharePoint list item. Body: {\"fields\":{\"ColumnName\":\"new value\"}}."
   },
@@ -3760,9 +2928,7 @@
     "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
     "method": "delete",
     "toolName": "delete-site-list-item",
-    "appPermissions": [
-      "Sites.ReadWrite.All"
-    ],
+    "appPermissions": ["Sites.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Deletes a SharePoint list item."
   },
@@ -3770,9 +2936,7 @@
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}",
     "method": "patch",
     "toolName": "update-exchange-mailbox",
-    "appPermissions": [
-      "Exchange.ManageAsApp"
-    ],
+    "appPermissions": ["Exchange.ManageAsApp"],
     "riskLevel": "medium",
     "llmTip": "Updates an Exchange mailbox configuration (admin). Body can include settings like archiveEnabled."
   },
@@ -3780,9 +2944,7 @@
     "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}",
     "method": "delete",
     "toolName": "delete-exchange-mailbox",
-    "appPermissions": [
-      "Exchange.ManageAsApp"
-    ],
+    "appPermissions": ["Exchange.ManageAsApp"],
     "riskLevel": "critical",
     "llmTip": "Deletes an Exchange mailbox (admin). IRREVERSIBLE \u2014 all mailbox data will be permanently removed. Always confirm with operator before executing."
   },
@@ -3790,9 +2952,7 @@
     "pathPattern": "/users",
     "method": "post",
     "toolName": "create-user",
-    "appPermissions": [
-      "User.ReadWrite.All"
-    ],
+    "appPermissions": ["User.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Creates a new user in the directory. Body requires displayName, mailNickname, userPrincipalName, accountEnabled, and passwordProfile."
   },
@@ -3800,9 +2960,7 @@
     "pathPattern": "/users/{user-id}",
     "method": "delete",
     "toolName": "delete-user",
-    "appPermissions": [
-      "User.ReadWrite.All"
-    ],
+    "appPermissions": ["User.ReadWrite.All"],
     "riskLevel": "critical",
     "llmTip": "Deletes a user from the directory. The user is moved to deletedItems and can be restored within 30 days. Always confirm with operator before executing."
   },
@@ -3810,9 +2968,7 @@
     "pathPattern": "/users/{user-id}/assignLicense",
     "method": "post",
     "toolName": "assign-user-license",
-    "appPermissions": [
-      "User.ReadWrite.All"
-    ],
+    "appPermissions": ["User.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Assigns or removes licenses for a user. Body requires addLicenses (array of {disabledPlans, skuId}) and removeLicenses (array of skuId GUIDs)."
   },
@@ -3820,9 +2976,7 @@
     "pathPattern": "/users/{user-id}/reprocessLicenseAssignment",
     "method": "post",
     "toolName": "reprocess-user-license",
-    "appPermissions": [
-      "User.ReadWrite.All"
-    ],
+    "appPermissions": ["User.ReadWrite.All"],
     "riskLevel": "low",
     "llmTip": "Reprocesses all group-based license assignments for a user. Useful when license assignment is in an error state."
   },
@@ -3830,9 +2984,7 @@
     "pathPattern": "/users/{user-id}/changePassword",
     "method": "post",
     "toolName": "change-user-password",
-    "appPermissions": [
-      "Directory.AccessAsUser.All"
-    ],
+    "appPermissions": ["Directory.AccessAsUser.All"],
     "riskLevel": "high",
     "llmTip": "Changes the signed-in user's password. Body requires currentPassword and newPassword. This is a delegated-only operation."
   },
@@ -3840,9 +2992,7 @@
     "pathPattern": "/groups",
     "method": "post",
     "toolName": "create-group",
-    "appPermissions": [
-      "Group.ReadWrite.All"
-    ],
+    "appPermissions": ["Group.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a new group. Body requires displayName, mailEnabled, mailNickname, securityEnabled. Set groupTypes=['Unified'] for Microsoft 365 group."
   },
@@ -3850,9 +3000,7 @@
     "pathPattern": "/groups/{group-id}",
     "method": "patch",
     "toolName": "update-group",
-    "appPermissions": [
-      "Group.ReadWrite.All"
-    ],
+    "appPermissions": ["Group.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates group properties (displayName, description, visibility, etc.)."
   },
@@ -3860,9 +3008,7 @@
     "pathPattern": "/groups/{group-id}",
     "method": "delete",
     "toolName": "delete-group",
-    "appPermissions": [
-      "Group.ReadWrite.All"
-    ],
+    "appPermissions": ["Group.ReadWrite.All"],
     "riskLevel": "critical",
     "llmTip": "Deletes a group. For Microsoft 365 groups, can be restored within 30 days. Security groups are permanently deleted. Always confirm with operator."
   },
@@ -3870,9 +3016,7 @@
     "pathPattern": "/groups/{group-id}/members/$ref",
     "method": "post",
     "toolName": "add-group-member",
-    "appPermissions": [
-      "GroupMember.ReadWrite.All"
-    ],
+    "appPermissions": ["GroupMember.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Adds a member to a group. Body requires @odata.id pointing to the directoryObject (e.g., https://graph.microsoft.com/v1.0/users/{id})."
   },
@@ -3880,9 +3024,7 @@
     "pathPattern": "/applications/{application-id}",
     "method": "patch",
     "toolName": "update-application",
-    "appPermissions": [
-      "Application.ReadWrite.All"
-    ],
+    "appPermissions": ["Application.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Updates an application registration (displayName, identifierUris, web redirect URIs, requiredResourceAccess, etc.)."
   },
@@ -3890,9 +3032,7 @@
     "pathPattern": "/applications/{application-id}",
     "method": "delete",
     "toolName": "delete-application",
-    "appPermissions": [
-      "Application.ReadWrite.All"
-    ],
+    "appPermissions": ["Application.ReadWrite.All"],
     "riskLevel": "critical",
     "llmTip": "Deletes an application registration. Can be restored from deletedItems within 30 days. Always confirm with operator."
   },
@@ -3900,9 +3040,7 @@
     "pathPattern": "/servicePrincipals/{servicePrincipal-id}",
     "method": "patch",
     "toolName": "update-service-principal",
-    "appPermissions": [
-      "Application.ReadWrite.All"
-    ],
+    "appPermissions": ["Application.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Updates a service principal (displayName, appRoleAssignmentRequired, notes, tags, etc.)."
   },
@@ -3910,9 +3048,7 @@
     "pathPattern": "/directoryRoles/{directoryRole-id}/members/$ref",
     "method": "post",
     "toolName": "add-directory-role-member",
-    "appPermissions": [
-      "RoleManagement.ReadWrite.Directory"
-    ],
+    "appPermissions": ["RoleManagement.ReadWrite.Directory"],
     "riskLevel": "critical",
     "llmTip": "Adds a member to a directory role. Body requires @odata.id pointing to the user or service principal. CRITICAL: grants admin privileges."
   },
@@ -3920,9 +3056,7 @@
     "pathPattern": "/domains",
     "method": "post",
     "toolName": "create-domain",
-    "appPermissions": [
-      "Domain.ReadWrite.All"
-    ],
+    "appPermissions": ["Domain.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Adds a new domain to the tenant. Body requires id (the domain name, e.g., 'contoso.com'). Domain must be verified after creation."
   },
@@ -3930,9 +3064,7 @@
     "pathPattern": "/domains/{domain-id}/verify",
     "method": "post",
     "toolName": "verify-domain",
-    "appPermissions": [
-      "Domain.ReadWrite.All"
-    ],
+    "appPermissions": ["Domain.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Verifies domain ownership. DNS records (TXT or MX) must be configured before calling. Returns the verified domain object."
   },
@@ -3940,9 +3072,7 @@
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
     "method": "post",
     "toolName": "create-enrollment-configuration",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a new device enrollment configuration (enrollment restrictions, ESP profile, etc.)."
   },
@@ -3950,9 +3080,7 @@
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations/{deviceEnrollmentConfiguration-id}",
     "method": "patch",
     "toolName": "update-enrollment-configuration",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates a device enrollment configuration (displayName, description, priority, etc.)."
   },
@@ -3960,9 +3088,7 @@
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations/{deviceEnrollmentConfiguration-id}",
     "method": "delete",
     "toolName": "delete-enrollment-configuration",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a device enrollment configuration. Cannot delete default configurations."
   },
@@ -3970,9 +3096,7 @@
     "pathPattern": "/deviceManagement/windowsAutopilotDeviceIdentities/{windowsAutopilotDeviceIdentity-id}",
     "method": "patch",
     "toolName": "update-autopilot-device",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates properties of an Autopilot device identity (groupTag, displayName, etc.)."
   },
@@ -3980,9 +3104,7 @@
     "pathPattern": "/deviceManagement/windowsAutopilotDeviceIdentities/{windowsAutopilotDeviceIdentity-id}",
     "method": "delete",
     "toolName": "delete-autopilot-device",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes an Autopilot device identity from Intune. The physical device is not affected."
   },
@@ -3990,9 +3112,7 @@
     "pathPattern": "/deviceManagement/importedWindowsAutopilotDeviceIdentities",
     "method": "post",
     "toolName": "import-autopilot-device",
-    "appPermissions": [
-      "DeviceManagementServiceConfig.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementServiceConfig.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Imports a new Autopilot device identity. Body requires serialNumber and hardwareIdentifier (base64-encoded hardware hash)."
   },
@@ -4000,9 +3120,7 @@
     "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}",
     "method": "delete",
     "toolName": "delete-managed-device",
-    "appPermissions": [
-      "DeviceManagementManagedDevices.ReadWrite.All"
-    ],
+    "appPermissions": ["DeviceManagementManagedDevices.ReadWrite.All"],
     "riskLevel": "critical",
     "llmTip": "Deletes a managed device record from Intune. Does NOT wipe the physical device. Use wipe-managed-device for factory reset."
   },
@@ -4010,9 +3128,7 @@
     "pathPattern": "/directory/administrativeUnits",
     "method": "post",
     "toolName": "create-administrative-unit",
-    "appPermissions": [
-      "AdministrativeUnit.ReadWrite.All"
-    ],
+    "appPermissions": ["AdministrativeUnit.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a new administrative unit. Body requires displayName. Optional: description, visibility ('HiddenMembership' or null)."
   },
@@ -4020,9 +3136,7 @@
     "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}",
     "method": "patch",
     "toolName": "update-administrative-unit",
-    "appPermissions": [
-      "AdministrativeUnit.ReadWrite.All"
-    ],
+    "appPermissions": ["AdministrativeUnit.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates an administrative unit (displayName, description, visibility)."
   },
@@ -4030,9 +3144,7 @@
     "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}",
     "method": "delete",
     "toolName": "delete-administrative-unit",
-    "appPermissions": [
-      "AdministrativeUnit.ReadWrite.All"
-    ],
+    "appPermissions": ["AdministrativeUnit.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes an administrative unit. All scoped role assignments are also removed."
   },
@@ -4040,9 +3152,7 @@
     "pathPattern": "/directory/administrativeUnits/{administrativeUnit-id}/members/$ref",
     "method": "post",
     "toolName": "add-administrative-unit-member",
-    "appPermissions": [
-      "AdministrativeUnit.ReadWrite.All"
-    ],
+    "appPermissions": ["AdministrativeUnit.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Adds a member (user or group) to an administrative unit. Body requires @odata.id pointing to the directory object."
   },
@@ -4050,9 +3160,7 @@
     "pathPattern": "/identity/conditionalAccess/authenticationStrength/policies",
     "method": "post",
     "toolName": "create-auth-strength-policy",
-    "appPermissions": [
-      "Policy.ReadWrite.AuthenticationMethod"
-    ],
+    "appPermissions": ["Policy.ReadWrite.AuthenticationMethod"],
     "riskLevel": "high",
     "llmTip": "Creates a custom authentication strength policy. Body requires displayName and allowedCombinations (array of auth method combos like 'password,microsoftAuthenticatorPush')."
   },
@@ -4060,9 +3168,7 @@
     "pathPattern": "/identity/conditionalAccess/authenticationStrength/policies/{authenticationStrengthPolicy-id}",
     "method": "get",
     "toolName": "get-auth-strength-policy",
-    "appPermissions": [
-      "Policy.Read.All"
-    ],
+    "appPermissions": ["Policy.Read.All"],
     "riskLevel": "low",
     "llmTip": "Gets a specific authentication strength policy by ID."
   },
@@ -4070,9 +3176,7 @@
     "pathPattern": "/identity/conditionalAccess/authenticationStrength/policies/{authenticationStrengthPolicy-id}",
     "method": "patch",
     "toolName": "update-auth-strength-policy",
-    "appPermissions": [
-      "Policy.ReadWrite.AuthenticationMethod"
-    ],
+    "appPermissions": ["Policy.ReadWrite.AuthenticationMethod"],
     "riskLevel": "high",
     "llmTip": "Updates a custom authentication strength policy (displayName, description, allowedCombinations). Built-in policies cannot be modified."
   },
@@ -4080,9 +3184,7 @@
     "pathPattern": "/identity/conditionalAccess/authenticationStrength/policies/{authenticationStrengthPolicy-id}",
     "method": "delete",
     "toolName": "delete-auth-strength-policy",
-    "appPermissions": [
-      "Policy.ReadWrite.AuthenticationMethod"
-    ],
+    "appPermissions": ["Policy.ReadWrite.AuthenticationMethod"],
     "riskLevel": "high",
     "llmTip": "Deletes a custom authentication strength policy. Built-in policies cannot be deleted. Fails if policy is referenced by a Conditional Access policy."
   },
@@ -4090,9 +3192,7 @@
     "pathPattern": "/security/attackSimulation/simulations",
     "method": "post",
     "toolName": "create-attack-simulation",
-    "appPermissions": [
-      "AttackSimulation.ReadWrite.All"
-    ],
+    "appPermissions": ["AttackSimulation.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Creates a new attack simulation campaign. Body requires displayName, attackTechnique, status, and payload configuration."
   },
@@ -4100,9 +3200,7 @@
     "pathPattern": "/security/attackSimulation/simulations/{simulation-id}",
     "method": "patch",
     "toolName": "update-attack-simulation",
-    "appPermissions": [
-      "AttackSimulation.ReadWrite.All"
-    ],
+    "appPermissions": ["AttackSimulation.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates an attack simulation (displayName, status, etc.). Can be used to launch or cancel a simulation."
   },
@@ -4110,9 +3208,7 @@
     "pathPattern": "/security/attackSimulation/simulations/{simulation-id}",
     "method": "delete",
     "toolName": "delete-attack-simulation",
-    "appPermissions": [
-      "AttackSimulation.ReadWrite.All"
-    ],
+    "appPermissions": ["AttackSimulation.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Deletes an attack simulation campaign."
   },
@@ -4120,9 +3216,7 @@
     "pathPattern": "/deviceManagement/virtualEndpoint/provisioningPolicies",
     "method": "post",
     "toolName": "create-cloud-pc-provisioning-policy",
-    "appPermissions": [
-      "CloudPC.ReadWrite.All"
-    ],
+    "appPermissions": ["CloudPC.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a new Cloud PC provisioning policy. Body requires displayName, imageId or imageDisplayName, imageType, and onPremisesConnectionId."
   },
@@ -4130,9 +3224,7 @@
     "pathPattern": "/deviceManagement/virtualEndpoint/provisioningPolicies/{cloudPcProvisioningPolicy-id}",
     "method": "patch",
     "toolName": "update-cloud-pc-provisioning-policy",
-    "appPermissions": [
-      "CloudPC.ReadWrite.All"
-    ],
+    "appPermissions": ["CloudPC.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates a Cloud PC provisioning policy (displayName, description, imageId, onPremisesConnectionId, etc.)."
   },
@@ -4140,9 +3232,7 @@
     "pathPattern": "/deviceManagement/virtualEndpoint/provisioningPolicies/{cloudPcProvisioningPolicy-id}",
     "method": "delete",
     "toolName": "delete-cloud-pc-provisioning-policy",
-    "appPermissions": [
-      "CloudPC.ReadWrite.All"
-    ],
+    "appPermissions": ["CloudPC.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a Cloud PC provisioning policy. Existing Cloud PCs provisioned with this policy are not affected."
   }

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2716,5 +2716,336 @@
     "appPermissions": ["CallRecords.Read.All"],
     "skipEncoding": ["fromDateTime", "toDateTime"],
     "llmTip": "Gets Direct Routing call records for a date range. Parameters are ISO 8601 dates. Returns callId, correlationId, userId, callerNumber, calleeNumber, duration, startDateTime, failureDateTime, finalSipCode, mediaPathLocation."
+  },
+
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/wipe",
+    "method": "post",
+    "toolName": "wipe-managed-device",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "critical",
+    "llmTip": "Wipes a managed device (factory reset). IRREVERSIBLE — all data on the device will be erased. Optional body: {\"keepEnrollmentData\":false,\"keepUserData\":false,\"macOsUnlockCode\":\"pin\"}. Always confirm with operator before executing."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/retire",
+    "method": "post",
+    "toolName": "retire-managed-device",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "high",
+    "llmTip": "Retires a managed device. Removes company data (apps, email, Wi-Fi, VPN profiles) but keeps personal data. The device is unenrolled from Intune management."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/syncDevice",
+    "method": "post",
+    "toolName": "sync-managed-device",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "low",
+    "llmTip": "Triggers an immediate sync of the managed device with Intune. Forces the device to check in and apply any pending policies, apps, or configurations."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/rebootNow",
+    "method": "post",
+    "toolName": "reboot-managed-device",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "high",
+    "llmTip": "Reboots a managed device immediately. The user will lose unsaved work. Windows devices only."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/remoteLock",
+    "method": "post",
+    "toolName": "remote-lock-device",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "medium",
+    "llmTip": "Remotely locks a managed device. The device owner must use their passcode/PIN to unlock. Useful for lost/stolen devices."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/resetPasscode",
+    "method": "post",
+    "toolName": "reset-device-passcode",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "high",
+    "llmTip": "Resets the passcode on a managed device. Behavior varies by platform: Android generates a new passcode, iOS removes the passcode."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/shutDown",
+    "method": "post",
+    "toolName": "shutdown-managed-device",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "high",
+    "llmTip": "Shuts down a managed device. The user will lose unsaved work."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/disableLostMode",
+    "method": "post",
+    "toolName": "disable-lost-mode",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "low",
+    "llmTip": "Disables Lost Mode on a supervised iOS device. The device returns to normal operation."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/locateDevice",
+    "method": "post",
+    "toolName": "locate-managed-device",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "low",
+    "llmTip": "Locates a managed device (iOS supervised). Returns the device's GPS coordinates. Use get-managed-device after to read deviceActionResults for the location."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/bypassActivationLock",
+    "method": "post",
+    "toolName": "bypass-activation-lock",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "high",
+    "llmTip": "Bypasses the Activation Lock on a supervised iOS device. Used when a device needs to be reactivated without the original Apple ID credentials."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/windowsDefenderScan",
+    "method": "post",
+    "toolName": "trigger-defender-scan",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "low",
+    "llmTip": "Triggers a Windows Defender antivirus scan on the device. Body: {\"quickScan\": true} for quick scan, or {\"quickScan\": false} for full scan."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/windowsDefenderUpdateSignatures",
+    "method": "post",
+    "toolName": "update-defender-signatures",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "low",
+    "llmTip": "Forces a Windows Defender signature update on the device. Ensures the latest antivirus definitions are installed."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/cleanWindowsDevice",
+    "method": "post",
+    "toolName": "clean-windows-device",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "critical",
+    "llmTip": "Cleans a Windows device (fresh start). Body: {\"keepUserData\": false}. Removes all installed apps and resets to default Windows. IRREVERSIBLE."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/logoutSharedAppleDeviceActiveUser",
+    "method": "post",
+    "toolName": "logout-shared-apple-user",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "medium",
+    "llmTip": "Logs out the active user from a shared Apple device (iPad). The device returns to the login screen."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/deleteUserFromSharedAppleDevice",
+    "method": "post",
+    "toolName": "delete-shared-apple-user",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "high",
+    "llmTip": "Deletes a user and their data from a shared Apple device. Body: {\"userPrincipalName\": \"user@contoso.com\"}."
+  },
+  {
+    "pathPattern": "/deviceManagement/managedDevices/{managedDevice-id}/updateWindowsDeviceAccount",
+    "method": "post",
+    "toolName": "update-windows-device-account",
+    "appPermissions": ["DeviceManagementManagedDevices.PrivilegedOperations.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates the account on a Windows device (Surface Hub). Body: {\"updateWindowsDeviceAccountActionParameter\": {\"deviceAccount\": {\"email\": \"room@contoso.com\"}, \"passwordRotationEnabled\": true}}."
+  },
+
+  {
+    "pathPattern": "/identity/conditionalAccess/policies",
+    "method": "post",
+    "toolName": "create-conditional-access-policy",
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "riskLevel": "high",
+    "llmTip": "Creates a new Conditional Access policy. Body requires displayName, state (enabled/disabled/enabledForReportingButNotEnforced), conditions (users, applications, locations, platforms, signInRiskLevels), grantControls or sessionControls. Start with state='disabled' or 'enabledForReportingButNotEnforced' for safety."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
+    "method": "get",
+    "toolName": "get-conditional-access-policy",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Gets a specific Conditional Access policy by ID. Returns displayName, state, conditions (users, applications, locations, platforms, signInRiskLevels, clientAppTypes), grantControls, sessionControls, createdDateTime, modifiedDateTime."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
+    "method": "patch",
+    "toolName": "update-conditional-access-policy",
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "riskLevel": "high",
+    "llmTip": "Updates a Conditional Access policy. Body can include displayName, state, conditions, grantControls, sessionControls. Changing state to 'enabled' activates enforcement — verify conditions before enabling."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/policies/{conditionalAccessPolicy-id}",
+    "method": "delete",
+    "toolName": "delete-conditional-access-policy",
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "riskLevel": "critical",
+    "llmTip": "Deletes a Conditional Access policy. IRREVERSIBLE. Consider disabling (state='disabled') instead of deleting."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/namedLocations",
+    "method": "post",
+    "toolName": "create-named-location",
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "riskLevel": "medium",
+    "llmTip": "Creates a named location for Conditional Access. For IP ranges: {\"@odata.type\":\"#microsoft.graph.ipNamedLocation\",\"displayName\":\"Corp IPs\",\"isTrusted\":true,\"ipRanges\":[{\"@odata.type\":\"#microsoft.graph.iPv4CidrRange\",\"cidrAddress\":\"10.0.0.0/8\"}]}."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/namedLocations/{namedLocation-id}",
+    "method": "patch",
+    "toolName": "update-named-location",
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "riskLevel": "medium",
+    "llmTip": "Updates a named location. Body can include displayName, isTrusted, ipRanges (for IP locations) or countriesAndRegions, includeUnknownCountriesAndRegions (for country locations)."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/namedLocations/{namedLocation-id}",
+    "method": "delete",
+    "toolName": "delete-named-location",
+    "appPermissions": ["Policy.ReadWrite.ConditionalAccess"],
+    "riskLevel": "high",
+    "llmTip": "Deletes a named location. If in use by a Conditional Access policy, the location reference must be removed from the policy first."
+  },
+  {
+    "pathPattern": "/identity/conditionalAccess/templates",
+    "method": "get",
+    "toolName": "list-conditional-access-templates",
+    "appPermissions": ["Policy.Read.All"],
+    "llmTip": "Lists Conditional Access policy templates provided by Microsoft. Templates can be used as starting points for new policies. Returns id, name, description, scenarios, details."
+  },
+
+  {
+    "pathPattern": "/deviceManagement/deviceCompliancePolicies",
+    "method": "post",
+    "toolName": "create-compliance-policy",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Creates a new device compliance policy. Body varies by platform. Example for Windows: {\"@odata.type\":\"#microsoft.graph.windows10CompliancePolicy\",\"displayName\":\"Win10 Compliance\",\"passwordRequired\":true,\"bitLockerEnabled\":true}."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
+    "method": "patch",
+    "toolName": "update-compliance-policy",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates an existing device compliance policy. Body can include any compliance settings for the platform type."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCompliancePolicies/{deviceCompliancePolicy-id}",
+    "method": "delete",
+    "toolName": "delete-compliance-policy",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Deletes a device compliance policy. Devices assigned to this policy will no longer be evaluated for compliance."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceConfigurations",
+    "method": "post",
+    "toolName": "create-device-configuration",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Creates a new device configuration profile. Body varies by platform and profile type. Example: {\"@odata.type\":\"#microsoft.graph.windows10GeneralConfiguration\",\"displayName\":\"Win10 Config\",\"passwordBlockSimple\":true}."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
+    "method": "patch",
+    "toolName": "update-device-configuration",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates an existing device configuration profile. Body can include any configuration settings for the profile type."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceConfigurations/{deviceConfiguration-id}",
+    "method": "delete",
+    "toolName": "delete-device-configuration",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Deletes a device configuration profile. Devices assigned to this profile will no longer receive these settings."
+  },
+
+  {
+    "pathPattern": "/sites/{site-id}/permissions",
+    "method": "post",
+    "toolName": "create-site-permission",
+    "appPermissions": ["Sites.FullControl.All"],
+    "riskLevel": "medium",
+    "llmTip": "Grants a permission on a SharePoint site. Body: {\"roles\":[\"write\"],\"grantedToIdentities\":[{\"application\":{\"id\":\"app-id\",\"displayName\":\"App Name\"}}]}. Roles: read, write, owner."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
+    "method": "patch",
+    "toolName": "update-site-permission",
+    "appPermissions": ["Sites.FullControl.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates a permission on a SharePoint site. Body: {\"roles\":[\"read\"]} to change the role."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/permissions/{permission-id}",
+    "method": "delete",
+    "toolName": "delete-site-permission",
+    "appPermissions": ["Sites.FullControl.All"],
+    "riskLevel": "high",
+    "llmTip": "Deletes a permission from a SharePoint site. The app or user will lose access to the site."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists",
+    "method": "post",
+    "toolName": "create-site-list",
+    "appPermissions": ["Sites.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Creates a new SharePoint list. Body: {\"displayName\":\"My List\",\"list\":{\"template\":\"genericList\"}}. Templates: genericList, documentLibrary, events, tasks, contacts, etc."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}",
+    "method": "patch",
+    "toolName": "update-site-list",
+    "appPermissions": ["Sites.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Updates a SharePoint list. Body can include displayName and description."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}",
+    "method": "delete",
+    "toolName": "delete-site-list",
+    "appPermissions": ["Sites.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Deletes a SharePoint list and all its items."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}/items",
+    "method": "post",
+    "toolName": "create-site-list-item",
+    "appPermissions": ["Sites.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Creates a new item in a SharePoint list. Body: {\"fields\":{\"Title\":\"Item title\",\"ColumnName\":\"value\"}}."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
+    "method": "patch",
+    "toolName": "update-site-list-item",
+    "appPermissions": ["Sites.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Updates a SharePoint list item. Body: {\"fields\":{\"ColumnName\":\"new value\"}}."
+  },
+  {
+    "pathPattern": "/sites/{site-id}/lists/{list-id}/items/{listItem-id}",
+    "method": "delete",
+    "toolName": "delete-site-list-item",
+    "appPermissions": ["Sites.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Deletes a SharePoint list item."
+  },
+
+  {
+    "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}",
+    "method": "patch",
+    "toolName": "update-exchange-mailbox",
+    "appPermissions": ["Exchange.ManageAsApp"],
+    "riskLevel": "medium",
+    "llmTip": "Updates an Exchange mailbox configuration (admin). Body can include settings like archiveEnabled."
+  },
+  {
+    "pathPattern": "/admin/exchange/mailboxes/{mailbox-id}",
+    "method": "delete",
+    "toolName": "delete-exchange-mailbox",
+    "appPermissions": ["Exchange.ManageAsApp"],
+    "riskLevel": "critical",
+    "llmTip": "Deletes an Exchange mailbox (admin). IRREVERSIBLE — all mailbox data will be permanently removed. Always confirm with operator before executing."
   }
 ]

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -49,7 +49,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   intune: {
     name: 'intune',
     pattern:
-      /managed-device|compliance-policy|compliance-state|device-configuration|enrollment|autopilot|detected-app|device-overview|intune|software-update|apple-push|mtd-connector|ios-update|device-categor|compliance-management|device-management-partner|exchange-connector|remote-assistance|notification-message|resource-operation|imported-autopilot|malware|mobile-app|app-categor|app-configuration|managed-app|app-protection|wip-polic|vpp-token|targeted-app/i,
+      /managed-device|compliance-policy|compliance-state|device-configuration|enrollment|autopilot|detected-app|device-overview|intune|software-update|apple-push|mtd-connector|ios-update|device-categor|compliance-management|device-management-partner|exchange-connector|remote-assistance|notification-message|resource-operation|imported-autopilot|malware|mobile-app|app-categor|app-configuration|managed-app|app-protection|wip-polic|vpp-token|targeted-app|wipe-managed|retire-managed|sync-managed|reboot-managed|remote-lock|reset-device|shutdown-managed|lost-mode|locate-managed|bypass-activation|defender-scan|defender-signature|clean-windows|shared-apple|windows-device-account/i,
     description:
       'Intune device management (managed devices, compliance, configurations, Autopilot, apps, MAM, RBAC, reports)',
   },
@@ -63,7 +63,7 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   response: {
     name: 'response',
     pattern:
-      /disable-user|revoke|block|reset|isolate|update-security|delete-user-auth|delete-user-phone|update-device|update-user-auth|confirm-compromised|dismiss-risky|confirm-safe|hunting-query/i,
+      /disable-user|revoke|block|reset|isolate|update-security|delete-user-auth|delete-user-phone|update-device|update-user-auth|confirm-compromised|dismiss-risky|confirm-safe|hunting-query|wipe-managed|retire-managed|remote-lock|locate-managed|bypass-activation/i,
     description:
       'Incident response operations (disable user, revoke sessions, confirm compromised/safe, dismiss risk, hunting queries)',
   },


### PR DESCRIPTION
## Summary
- Add **75 new admin write endpoints**, bringing total from 369 to 444 tools
- Fix 3 pre-existing duplicate toolNames

### Batch 1 (41 endpoints)
- **Intune device remote actions (16)**: wipe, retire, sync, reboot, remote lock, reset passcode, shutdown, locate device, bypass activation lock, Defender scan/signatures update, clean Windows device, shared Apple device management
- **Conditional Access CRUD (8)**: create/update/delete policies, create/update/delete named locations, list templates, get individual policy
- **Intune policies CRUD (6)**: create/update/delete compliance policies and device configuration profiles
- **SharePoint writes (9)**: lists, list items, and permissions CRUD
- **Exchange writes (2)**: update/delete mailbox

### Batch 2 (34 endpoints)
- **User management (5)**: create/delete user, assign/reprocess license, change password
- **Group management (4)**: create/update/delete group, add member
- **App management (3)**: update/delete application, update service principal
- **Directory roles (1)**: add role member
- **Domains (2)**: create/verify domain
- **Enrollment & Autopilot (6)**: CRUD enrollment config, update/delete/import Autopilot device
- **Managed device (1)**: delete managed device record
- **Administrative units (4)**: CRUD + add member
- **Auth strength policies (5)**: list/get/create/update/delete
- **Attack simulations (3)**: create/update/delete
- **Cloud PC provisioning (3)**: create/update/delete provisioning policy

## Test plan
- [x] `npm run generate` succeeds
- [x] `npm run build` succeeds
- [x] `npm test` — all 3 tests pass (no duplicate toolNames, valid JSON, risk levels present)
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)