### PR TITLE
sec: sanitize query strings and testLogin error leaks

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -131,11 +131,18 @@ class AuthManager {
       });
 
       if (!response.ok) {
+        // SEC-B: log full error for diagnostics, return sanitized message to caller
         const errorText = await response.text();
-        return {
-          success: false,
-          message: `Graph API error: ${response.status} ${response.statusText} - ${errorText}`,
-        };
+        logger.error(`testLogin Graph error ${response.status}: ${errorText}`);
+        let clientMessage = `Graph API error: ${response.status} ${response.statusText}`;
+        try {
+          const parsed = JSON.parse(errorText) as { error?: { message?: string; code?: string } };
+          if (parsed.error?.code) clientMessage += ` (${parsed.error.code})`;
+          if (parsed.error?.message) clientMessage += ` - ${parsed.error.message}`;
+        } catch {
+          // Non-JSON error body — don't leak raw text
+        }
+        return { success: false, message: clientMessage };
       }
 
       const data = (await response.json()) as {

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -51,7 +51,8 @@ class GraphClient {
     const cloudEndpoints = getCloudEndpoints(this.secrets.cloudType);
     const url = `${cloudEndpoints.graphApi}/v1.0${endpoint}`;
 
-    logger.debug(`[GRAPH CLIENT] Final URL: ${url}`);
+    // SEC: strip query string — can contain PII/UPN/secret IDs via $filter, etc.
+    logger.debug(`[GRAPH CLIENT] Final URL: ${url.split('?')[0]}`);
 
     const headers: Record<string, string> = {
       Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
## Summary

Two log-hygiene fixes surfaced by the post-merge security review:

- **graph-client.ts**: the debug log at line 54 was printing the full URL (query string included). `\$filter`, `\$search` and path-embedded IDs can carry PII/UPN/recovery-key IDs. Stripped the query string to match the info-level log at line 37.
- **auth.ts `testLogin`**: was returning the raw Graph error body to the caller, inconsistent with the SEC-B pattern used everywhere else (`graph-client.ts:70-83`). Now logs raw text for diagnostics and returns a sanitized message.

Both are low/medium severity hygiene fixes, not active exploits.

## Test plan

- [x] `npm run verify` — generate + lint + format + build + test all pass
- [ ] Manual: run `--verify-login` against a failing tenant and confirm the returned message no longer contains raw HTML/JSON bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)