### PR TITLE
chore: bump verified-publisher risk and remove dead dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^3.8.0",
-        "@modelcontextprotocol/express": "^2.0.0-alpha.2",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^11.1.0",
         "dotenv": "^17.0.1",
@@ -1237,19 +1236,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@modelcontextprotocol/express": {
-      "version": "2.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/express/-/express-2.0.0-alpha.2.tgz",
-      "integrity": "sha512-TlTUFnpUCH3dqegSnAZpCe+pn4fM43tow0KLRa3QTTWaC/jctsl51QQykqXHse5UhBpqGw+QF1rLfWOwEI9PPw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/server": "^2.0.0-alpha.2",
-        "express": "^5.2.1"
-      }
-    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
@@ -1288,37 +1274,6 @@
         "zod": {
           "optional": false
         }
-      }
-    },
-    "node_modules/@modelcontextprotocol/server": {
-      "version": "2.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/server/-/server-2.0.0-alpha.2.tgz",
-      "integrity": "sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "zod": "^4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@cfworker/json-schema": "^4.1.1"
-      },
-      "peerDependenciesMeta": {
-        "@cfworker/json-schema": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@modelcontextprotocol/server/node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "license": "MIT",
   "dependencies": {
     "@azure/msal-node": "^3.8.0",
-    "@modelcontextprotocol/express": "^2.0.0-alpha.2",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "commander": "^11.1.0",
     "dotenv": "^17.0.1",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -3322,8 +3322,8 @@
     "method": "post",
     "toolName": "set-application-verified-publisher",
     "appPermissions": ["Application.ReadWrite.All"],
-    "riskLevel": "medium",
-    "llmTip": "Sets the verified publisher MPN ID on an application. Body: {\"verifiedPublisherId\":\"<mpn-id>\"}. Requires a verified MPN account in Partner Center."
+    "riskLevel": "high",
+    "llmTip": "Sets the verified publisher MPN ID on an application. Body: {\"verifiedPublisherId\":\"<mpn-id>\"}. Requires a verified MPN account in Partner Center. Impacts the consent UX for every user across every tenant that sees the app."
   },
 
   {


### PR DESCRIPTION
## Summary

Two quality fixes from the post-merge security review:

- **Risk level bump**: `set-application-verified-publisher` promoted from `medium` to `high`. Verified-publisher status surfaces on the consent prompt across every tenant that encounters the app, so the blast radius extends well beyond the owning tenant. Updated the `llmTip` to make that explicit.
- **Dead dependency**: drop `@modelcontextprotocol/express`. Not imported anywhere in `src/`; the HTTP transport uses `StreamableHTTPServerTransport` from `@modelcontextprotocol/sdk` plus plain `express`.

## Test plan

- [x] `npm run verify` — generate + lint + format + build + test all pass
- [x] `grep -r '@modelcontextprotocol/express' src/` returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)