### PR TITLE
docs: add LICENSE, SECURITY, CONTRIBUTING, CHANGELOG, and docs/ guides

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -40,6 +40,7 @@ node dist/index.js ...
 <!-- Run with `-v` and paste sanitized output. Redact tokens, client secrets, and tenant IDs. -->
 
 ```
+
 ```
 
 ## Additional context

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Report a reproducible problem
+title: '[bug] '
+labels: bug
+---
+
+## Description
+
+<!-- Clear, concise description of what's wrong. -->
+
+## Reproduction
+
+1.
+2.
+3.
+
+**Command used:**
+
+```
+node dist/index.js ...
+```
+
+**Expected behavior:**
+
+**Actual behavior:**
+
+## Environment
+
+- Version / commit SHA:
+- Node version: `node --version`
+- OS:
+- Transport: stdio / HTTP
+- Cloud: global / china
+- Presets enabled:
+- `--allow-writes`: yes / no
+
+## Logs
+
+<!-- Run with `-v` and paste sanitized output. Redact tokens, client secrets, and tenant IDs. -->
+
+```
+```
+
+## Additional context
+
+<!-- Related issues, workarounds you tried, etc. -->
+
+---
+
+**Security note.** If this is a security vulnerability, do **not** file a public issue. See [SECURITY.md](../../SECURITY.md) for private reporting.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/okapi-ca/ms-365-admin-mcp-server/security/advisories/new
+    about: Report a vulnerability privately (do not file a public issue).
+  - name: Discussions
+    url: https://github.com/okapi-ca/ms-365-admin-mcp-server/discussions
+    about: Ask a question or discuss an idea.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,41 @@
+---
+name: Feature request
+about: Propose a new tool, preset, or capability
+title: '[feature] '
+labels: enhancement
+---
+
+## Use case
+
+<!-- What admin scenario does this enable? Who benefits? -->
+
+## Proposal
+
+<!-- Concrete description of what you'd like added. -->
+
+### If this is a new tool
+
+- **Graph API endpoint:** `/path/to/endpoint`
+- **HTTP method:** `GET` / `POST` / `PATCH` / `DELETE`
+- **Graph API permissions required:**
+- **Suggested toolName:**
+- **Suggested riskLevel** (if non-GET, see [RISK_MODEL.md](../../docs/RISK_MODEL.md)):
+- **Matching preset:** `security` / `identity` / ... / new preset
+
+### If this is a new preset
+
+- **Preset name:**
+- **Regex matching:** (list expected toolNames)
+- **Description:**
+
+### If this is another enhancement
+
+<!-- Describe the behavior you want. -->
+
+## Alternatives considered
+
+<!-- Other approaches you thought about, and why this is better. -->
+
+## Additional context
+
+<!-- Screenshots, Graph API docs links, related tickets, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,69 @@
+<!-- Thanks for contributing to ms-365-admin-mcp-server. Please fill in the sections below. -->
+
+## Summary
+
+<!-- 1-3 bullet points: what changed and why. -->
+
+## Type of change
+
+<!-- Check one. -->
+
+- [ ] `feat` — new tool, preset, or feature
+- [ ] `fix` — bug fix
+- [ ] `sec` — security fix
+- [ ] `docs` — documentation only
+- [ ] `chore` — tooling, deps, non-functional
+- [ ] `refactor` — no behavior change
+- [ ] `test` — tests only
+
+## Tool inventory impact (if applicable)
+
+<!-- If this PR adds or removes tools, fill this in. -->
+
+- Tool count before: `___` → after: `___`
+- New tools: <!-- list names -->
+- Removed / renamed tools: <!-- list names and reason -->
+- New preset(s): <!-- if any -->
+
+## Risk assessment (required for new write tools)
+
+<!-- See docs/RISK_MODEL.md. -->
+
+| Tool | riskLevel | Reversibility | Blast radius | Justification |
+| ---- | --------- | ------------- | ------------ | ------------- |
+|      |           |               |              |               |
+
+## Graph API permissions
+
+<!-- List any new application permissions required. Prefer least privilege. -->
+
+- [ ] No new permissions required
+- New permissions:
+  - `...`
+
+## Testing
+
+<!-- How did you verify this works? -->
+
+- [ ] `npm run verify` passes locally
+- [ ] Manual test against a real tenant (describe briefly)
+- [ ] New unit tests added
+- [ ] Not applicable (docs-only, etc.)
+
+## Documentation
+
+- [ ] `README.md` tool tables updated (if tool count changed)
+- [ ] `CHANGELOG.md` updated under `[Unreleased]`
+- [ ] `docs/USE_CASES.md` updated (if a new typical scenario emerges)
+- [ ] Not applicable
+
+## Security checklist
+
+- [ ] No secrets, tokens, or tenant IDs committed
+- [ ] New write tools carry a `riskLevel` in `endpoints.json`
+- [ ] New permissions are the minimum required (no `.ReadWrite.All` when `.Read.All` suffices)
+- [ ] No bypass of existing `SEC-*` defenses in `src/`
+
+## Additional context
+
+<!-- Anything a reviewer should know: related issues, rollout plan, follow-ups. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to `ms-365-admin-mcp-server` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Tool counts in parentheses indicate the cumulative total after the change.
+
+## [Unreleased]
+
+### Added
+
+- `docs/USE_CASES.md` — 15 typical admin scenarios (security monitoring, incident response, PIM hygiene, Intune, eDiscovery, Conditional Access, etc.)
+- `docs/APP_REGISTRATION.md` — step-by-step Azure AD app registration guide
+- `docs/HTTP_DEPLOYMENT.md` — HTTP transport and Azure Container Apps deployment
+- `docs/TROUBLESHOOTING.md` — common errors and diagnosis
+- `docs/ARCHITECTURE.md` — internal architecture and code generation flow
+- `docs/RISK_MODEL.md` — risk classification methodology
+- `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` (MIT), `CHANGELOG.md`
+- `.github/PULL_REQUEST_TEMPLATE.md` and issue templates
+
+## [0.1.0] — 515 tools
+
+### Added
+
+- 71 admin write endpoints, bringing the total to **515 tools** (#26)
+- eDiscovery hold actions exposed via the `response` preset
+
+### Security
+
+- `set-application-verified-publisher` risk level bumped (#28)
+- Query strings and `testLogin` error messages sanitized to avoid leaking secrets (#27)
+- Removed dead dependency
+
+## 444 tools
+
+### Added
+
+- 75 admin write operations (#25)
+- 3 duplicate tool entries fixed during write expansion
+
+## 369 tools
+
+### Added
+
+- 5 new endpoint categories (#24): Cloud PC, Teams call records, Universal Print, Information Protection, SharePoint admin
+- Records Management
+
+## 306 tools
+
+### Added
+
+- 107 high-value admin endpoints (#23): eDiscovery, Cloud PC, call records, print, info protection, SharePoint admin, records management, app credentials, guest users, external identity, Exchange, threat intelligence, Intune, Identity Governance
+
+## 199 tools
+
+### Security
+
+- `dismiss-risky-users` elevated from `medium` to `high` risk (#22)
+- Over-privileged permission scopes reduced to least-privilege
+
+## Prior — 175 tools and earlier
+
+### Added
+
+- 117 endpoints restored after squash-merge loss (#21)
+- Full security review with fixes (#20)
+- 25 endpoints for devices, PIM, risk detections, administrative units (#19)
+- 9 app credentials and management policy endpoints
+- 10 guest users and external identity endpoints
+- 20 Exchange and threat intelligence endpoints
+- 31 Intune/device management endpoints
+- 23 Identity Governance endpoints
+
+### Infrastructure
+
+- MCP server scaffolding with stdio and HTTP (StreamableHTTP) transports
+- Azure AD client credentials flow via `@azure/msal-node`
+- JWT validation via Microsoft JWKS in HTTP mode
+- Preset-based tool filtering (`--preset`, `--enabled-tools`)
+- Key Vault secret provider (`MS365_ADMIN_MCP_KEYVAULT_URL`)
+- Multi-cloud support (global and China / 21Vianet)
+- Azure Container Apps Bicep template
+- Docker image with non-root user
+
+---
+
+[Unreleased]: https://github.com/okapi-ca/ms-365-admin-mcp-server/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/okapi-ca/ms-365-admin-mcp-server/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,169 @@
+# Contributing
+
+Thanks for your interest in contributing to `ms-365-admin-mcp-server`.
+
+## Ground rules
+
+- **No breaking changes** to tool names, parameter shapes, or preset categories without discussion. MCP clients rely on stable tool identifiers.
+- **Security-first mindset.** Every new write operation must be classified with a risk level (`low`/`medium`/`high`/`critical`) and require `--allow-writes`.
+- **Least privilege.** New tools must declare the minimum Graph API permissions (`appPermissions` in `endpoints.json`). Never request `.ReadWrite.All` when `.Read.All` suffices.
+- **Tests and lint must pass** before PR merge (`npm run verify`).
+
+## Development setup
+
+```bash
+git clone https://github.com/okapi-ca/ms-365-admin-mcp-server.git
+cd ms-365-admin-mcp-server
+npm install
+npm run generate    # Download Graph OpenAPI spec and generate client
+npm run build
+npm test
+```
+
+Create a local `.env` with your Azure AD app registration credentials:
+
+```
+MS365_ADMIN_MCP_CLIENT_ID=...
+MS365_ADMIN_MCP_CLIENT_SECRET=...
+MS365_ADMIN_MCP_TENANT_ID=...
+```
+
+Run the server interactively with the MCP Inspector:
+
+```bash
+npm run inspector
+```
+
+## Project layout
+
+```
+bin/                  Code-generation scripts (OpenAPI -> zod client)
+src/
+  auth.ts             MSAL client credentials flow
+  cli.ts              Commander argv parsing
+  cloud-config.ts     Global vs China (21Vianet) endpoints
+  endpoints.json      Source of truth for tool definitions
+  generated/          Auto-generated zod client (do not edit)
+  graph-client.ts     Graph API fetch wrapper
+  graph-tools.ts      MCP tool registration
+  http-server.ts      Express + StreamableHTTP transport
+  index.ts            Entry point
+  logger.ts           Winston logger
+  secrets.ts          env / Key Vault secret providers
+  server.ts           Stdio server and tool wiring
+  token-validator.ts  JWT validation for HTTP mode
+  tool-categories.ts  Preset definitions
+infra/
+  main.bicep          Azure Container Apps deployment
+test/                 Vitest specs
+```
+
+## Adding a new tool
+
+1. **Find the Graph API endpoint** in the [Microsoft Graph OpenAPI spec](https://github.com/microsoftgraph/msgraph-metadata).
+2. **Add an entry** to `src/endpoints.json`:
+
+   ```jsonc
+   {
+     "toolName": "list-something",
+     "pathPattern": "/something",
+     "method": "GET",
+     "appPermissions": ["Something.Read.All"],
+     "llmTip": "Optional hint shown to the LLM in the tool description",
+     "riskLevel": "low" // only for non-GET
+   }
+   ```
+
+3. **Regenerate the client**:
+
+   ```bash
+   npm run generate
+   ```
+
+4. **Verify** the tool is registered and permissions are correct:
+
+   ```bash
+   node dist/index.js --list-tools | grep list-something
+   node dist/index.js --list-permissions | grep Something
+   ```
+
+5. **Add a test** if the tool has non-trivial parameter handling or skipEncoding rules.
+
+6. **Update `README.md`** tool tables to reflect the new count and category.
+
+### Risk classification rubric
+
+Use this rubric for non-GET operations:
+
+| Level      | Criteria                                                                  | Examples                                                              |
+| ---------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `low`      | Read-only in effect (POST-only queries, reports) or trivial annotations   | `run-hunting-query`, `add-security-alert-comment`, Intune reports     |
+| `medium`   | Reversible mutation affecting a single entity                             | `update-user`, `add-group-member`, `create-invitation`                |
+| `high`     | Significant impact: broad scope, credential change, or destructive+       | `revoke-user-sessions`, `update-conditional-access-policy`            |
+| `critical` | Irreversible or tenant-wide impact                                        | `delete-user`, `wipe-managed-device`, `delete-conditional-access-policy` |
+
+When in doubt, pick the higher level.
+
+## Adding a new preset
+
+Edit `src/tool-categories.ts`:
+
+```ts
+export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
+  mypreset: {
+    name: 'mypreset',
+    pattern: /pattern-matching-tool-names/i,
+    description: 'Short human-readable description',
+  },
+  // ...
+};
+```
+
+Regex must match `toolName`s in `endpoints.json`. Validate with:
+
+```bash
+node dist/index.js --preset mypreset --list-tools
+```
+
+## Coding style
+
+- **TypeScript strict mode.** No `any` without justification.
+- **No new runtime dependencies** without discussion. Prefer standard library.
+- **Prettier + ESLint** must pass (`npm run format:check` and `npm run lint`).
+- **Comments explain why, not what.** Name things well instead.
+
+## Commit and PR conventions
+
+Commit prefixes:
+
+- `feat:` new tool, preset, or feature
+- `fix:` bug fix
+- `sec:` security fix (document in `SECURITY.md` if externally reported)
+- `docs:` documentation only
+- `chore:` tooling, deps, non-functional
+- `refactor:` no behavior change
+- `test:` tests only
+- `build(deps):` / `build(deps-dev):` dependency bumps (Dependabot format)
+
+Examples from the project history:
+
+```
+feat: add 71 admin write endpoints (444->515 tools)
+sec: sanitize query strings and testLogin error leaks
+chore: bump verified-publisher risk and remove dead dep
+```
+
+### Pull requests
+
+- Keep PRs focused. One feature or fix per PR.
+- Include a summary of what changed, why, and how it was tested.
+- For new tools, attach a sample prompt demonstrating usage.
+- For write operations, document the expected rollback procedure.
+
+## Generated code
+
+Do not hand-edit anything under `src/generated/`. Those files are regenerated from the Graph OpenAPI spec via `npm run generate`. Edit `src/endpoints.json` and regenerate instead.
+
+## Questions
+
+Open a [GitHub discussion](https://github.com/okapi-ca/ms-365-admin-mcp-server/discussions) or a non-security issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ test/                 Vitest specs
      "method": "GET",
      "appPermissions": ["Something.Read.All"],
      "llmTip": "Optional hint shown to the LLM in the tool description",
-     "riskLevel": "low" // only for non-GET
+     "riskLevel": "low", // only for non-GET
    }
    ```
 
@@ -95,12 +95,12 @@ test/                 Vitest specs
 
 Use this rubric for non-GET operations:
 
-| Level      | Criteria                                                                  | Examples                                                              |
-| ---------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `low`      | Read-only in effect (POST-only queries, reports) or trivial annotations   | `run-hunting-query`, `add-security-alert-comment`, Intune reports     |
-| `medium`   | Reversible mutation affecting a single entity                             | `update-user`, `add-group-member`, `create-invitation`                |
-| `high`     | Significant impact: broad scope, credential change, or destructive+       | `revoke-user-sessions`, `update-conditional-access-policy`            |
-| `critical` | Irreversible or tenant-wide impact                                        | `delete-user`, `wipe-managed-device`, `delete-conditional-access-policy` |
+| Level      | Criteria                                                                | Examples                                                                 |
+| ---------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `low`      | Read-only in effect (POST-only queries, reports) or trivial annotations | `run-hunting-query`, `add-security-alert-comment`, Intune reports        |
+| `medium`   | Reversible mutation affecting a single entity                           | `update-user`, `add-group-member`, `create-invitation`                   |
+| `high`     | Significant impact: broad scope, credential change, or destructive+     | `revoke-user-sessions`, `update-conditional-access-policy`               |
+| `critical` | Irreversible or tenant-wide impact                                      | `delete-user`, `wipe-managed-device`, `delete-conditional-access-policy` |
 
 When in doubt, pick the higher level.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 okapi-ca
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 - **Multi-cloud**: Microsoft global and China (21Vianet)
 - **Key Vault** support for secrets management
 
+## Documentation
+
+| Document                                           | Purpose                                                         |
+| -------------------------------------------------- | --------------------------------------------------------------- |
+| [docs/USE_CASES.md](docs/USE_CASES.md)             | 15 typical admin scenarios with sample prompts and tool lists   |
+| [docs/APP_REGISTRATION.md](docs/APP_REGISTRATION.md) | Step-by-step Azure AD app registration and permission consent |
+| [docs/HTTP_DEPLOYMENT.md](docs/HTTP_DEPLOYMENT.md) | HTTP transport, JWT validation, Docker, Azure Container Apps    |
+| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Common errors and how to diagnose them                          |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)       | Internal architecture and code generation pipeline              |
+| [docs/RISK_MODEL.md](docs/RISK_MODEL.md)           | Risk classification rubric for write tools                      |
+| [CONTRIBUTING.md](CONTRIBUTING.md)                 | How to contribute new tools, presets, and fixes                 |
+| [SECURITY.md](SECURITY.md)                         | Vulnerability reporting and operator hardening checklist        |
+| [CHANGELOG.md](CHANGELOG.md)                       | Release history                                                 |
+
 ## Prerequisites
 
 - Node.js >= 18
@@ -1210,4 +1224,4 @@ npm run inspector        # MCP Inspector for interactive testing
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 
 ## Documentation
 
-| Document                                           | Purpose                                                         |
-| -------------------------------------------------- | --------------------------------------------------------------- |
-| [docs/USE_CASES.md](docs/USE_CASES.md)             | 15 typical admin scenarios with sample prompts and tool lists   |
+| Document                                             | Purpose                                                       |
+| ---------------------------------------------------- | ------------------------------------------------------------- |
+| [docs/USE_CASES.md](docs/USE_CASES.md)               | 15 typical admin scenarios with sample prompts and tool lists |
 | [docs/APP_REGISTRATION.md](docs/APP_REGISTRATION.md) | Step-by-step Azure AD app registration and permission consent |
-| [docs/HTTP_DEPLOYMENT.md](docs/HTTP_DEPLOYMENT.md) | HTTP transport, JWT validation, Docker, Azure Container Apps    |
-| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Common errors and how to diagnose them                          |
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)       | Internal architecture and code generation pipeline              |
-| [docs/RISK_MODEL.md](docs/RISK_MODEL.md)           | Risk classification rubric for write tools                      |
-| [CONTRIBUTING.md](CONTRIBUTING.md)                 | How to contribute new tools, presets, and fixes                 |
-| [SECURITY.md](SECURITY.md)                         | Vulnerability reporting and operator hardening checklist        |
-| [CHANGELOG.md](CHANGELOG.md)                       | Release history                                                 |
+| [docs/HTTP_DEPLOYMENT.md](docs/HTTP_DEPLOYMENT.md)   | HTTP transport, JWT validation, Docker, Azure Container Apps  |
+| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)   | Common errors and how to diagnose them                        |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)         | Internal architecture and code generation pipeline            |
+| [docs/RISK_MODEL.md](docs/RISK_MODEL.md)             | Risk classification rubric for write tools                    |
+| [CONTRIBUTING.md](CONTRIBUTING.md)                   | How to contribute new tools, presets, and fixes               |
+| [SECURITY.md](SECURITY.md)                           | Vulnerability reporting and operator hardening checklist      |
+| [CHANGELOG.md](CHANGELOG.md)                         | Release history                                               |
 
 ## Prerequisites
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest release of `ms-365-admin-mcp-server` receives security updates. Older versions may contain vulnerabilities that have been fixed upstream.
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | Yes       |
+| < main  | No        |
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, report privately via one of these channels:
+
+- GitHub's [private vulnerability reporting](https://github.com/okapi-ca/ms-365-admin-mcp-server/security/advisories/new) (preferred)
+- Email the maintainer listed in the GitHub organization profile
+
+Include in your report:
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce (proof-of-concept if possible)
+- Affected version (commit SHA or release tag)
+- Suggested remediation, if any
+
+## Response process
+
+- **Acknowledgment** — within 5 business days
+- **Initial assessment** — within 10 business days
+- **Fix and disclosure** — coordinated with the reporter; typically within 90 days depending on severity
+
+## Scope
+
+The following are in scope for security reports:
+
+- Authentication and authorization bypass (stdio and HTTP transports)
+- JWT validation flaws in HTTP mode (issuer, audience, signature, tenant, client ID)
+- Token leakage in logs, error responses, or traces
+- Path traversal, SSRF, or command injection via tool parameters
+- Privilege escalation via unexpected Graph API calls
+- Risk-level misclassification of write tools (e.g. `critical` operation marked as `low`)
+- Supply chain issues in direct dependencies
+
+Out of scope:
+
+- Issues requiring physical access to the MCP host
+- Social engineering of MCP operators
+- Denial-of-service via resource exhaustion on the local process (the server is expected to be run with OS-level limits)
+- Vulnerabilities in Microsoft Graph API itself (report those to Microsoft MSRC)
+
+## Hardening checklist for operators
+
+If you run this server, we recommend:
+
+1. **Least-privilege credentials.** Grant only the Graph API application permissions you actually need. Use `--preset` and `--enabled-tools` to scope the tool surface.
+2. **Read-only by default.** Do not pass `--allow-writes` unless a scenario requires mutations.
+3. **Secret management.** Store `MS365_ADMIN_MCP_CLIENT_SECRET` in Azure Key Vault (`MS365_ADMIN_MCP_KEYVAULT_URL`), never in plain environment files committed to source control.
+4. **Certificate authentication.** Prefer certificates over client secrets where possible (planned; see `CHANGELOG.md`).
+5. **Secret rotation.** Rotate client secrets every 90 days; federated credentials and managed identity remove this burden.
+6. **HTTP mode exposure.** Never expose the HTTP transport on `0.0.0.0` without a reverse proxy enforcing TLS and additional authentication. Always pass `--allowed-clients` with the minimum set of Entra app IDs.
+7. **Audit trail.** Enable verbose logging (`-v`) and forward logs to a SIEM. All Graph mutations are also auditable via `list-directory-audits` and `list-intune-audit-events`.
+8. **Network segmentation.** Run the server in a network segment that only permits egress to `login.microsoftonline.com` and `graph.microsoft.com` (or sovereign equivalents).
+
+## Known hardening in this codebase
+
+The following defenses are already implemented (see inline `SEC-*` comments in `src/`):
+
+- JWT signature verification via Microsoft JWKS (RS256), issuer, audience, tenant, and client ID checks (`src/token-validator.ts`)
+- Rate limiting: 100 req/min on `/mcp` (`src/http-server.ts`)
+- Security headers: `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Cache-Control: no-store`, CSP `default-src 'none'`
+- Body size limit: 100 KB
+- Path parameter validation against traversal (`../`, `/`, `\`, `?`, `#`, `&`) for `skipEncoding` params
+- ReDoS protection: `--enabled-tools` regex capped at 500 chars
+- Sensitive data redacted from logs
+- Tenant `common` rejected (single-tenant required for client credentials)
+- Non-root Docker user
+- Sanitized query strings in error messages (no secret leakage)

--- a/docs/APP_REGISTRATION.md
+++ b/docs/APP_REGISTRATION.md
@@ -1,0 +1,151 @@
+# Azure AD App Registration Guide
+
+This guide walks through creating an Entra ID (Azure AD) app registration with the **application permissions** required by `ms-365-admin-mcp-server`.
+
+> This server uses the **client credentials flow** (no user sign-in). It requires a single-tenant registration and admin consent for every permission it uses.
+
+## Prerequisites
+
+- A Microsoft 365 tenant you administer
+- **Global Administrator** or **Cloud Application Administrator** role (to create the app)
+- **Global Administrator** or **Privileged Role Administrator** (to grant admin consent for privileged scopes like `RoleManagement.ReadWrite.Directory`)
+
+## Step 1. Create the app registration
+
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com).
+2. Navigate to **Identity** → **Applications** → **App registrations** → **New registration**.
+3. Fill in:
+   - **Name.** `ms-365-admin-mcp-server` (or any descriptive name)
+   - **Supported account types.** `Accounts in this organizational directory only (single tenant)`
+   - **Redirect URI.** Leave blank — this flow does not use redirects.
+4. Click **Register**.
+5. Note the **Application (client) ID** and **Directory (tenant) ID** from the Overview blade.
+
+## Step 2. Create a client secret (or certificate)
+
+### Option A — Client secret (simplest, 2-year max lifetime)
+
+1. In the app blade, go to **Certificates & secrets** → **Client secrets** → **New client secret**.
+2. Description: `mcp-server`. Expires: **6 months** or **12 months** (shorter is safer; plan rotation).
+3. Click **Add**. **Copy the `Value` immediately** — it is shown only once.
+
+### Option B — Certificate (recommended for production)
+
+1. Generate a self-signed certificate:
+
+   ```bash
+   openssl req -x509 -newkey rsa:2048 -keyout mcp-key.pem -out mcp-cert.pem \
+     -days 365 -nodes -subj "/CN=ms-365-admin-mcp-server"
+   ```
+
+2. Upload `mcp-cert.pem` in **Certificates & secrets** → **Certificates** → **Upload certificate**.
+3. Note the thumbprint.
+
+> Certificate-based auth is planned for a future release of this server. For now, use a client secret stored in Azure Key Vault.
+
+### Option C — Managed Identity (Azure-hosted only)
+
+When running in Azure Container Apps, Container Instances, or VMs, use a system-assigned managed identity and grant it Graph permissions directly. No secret to rotate. See [docs/HTTP_DEPLOYMENT.md](HTTP_DEPLOYMENT.md).
+
+## Step 3. Add Graph API application permissions
+
+1. In the app blade, go to **API permissions** → **Add a permission** → **Microsoft Graph** → **Application permissions**.
+2. Select each permission required by the tools you intend to use.
+
+To list exactly what's needed for your configuration:
+
+```bash
+# All read-only permissions (default mode)
+node dist/index.js --list-permissions
+
+# Only what a specific preset requires
+node dist/index.js --preset identity,security --list-permissions
+
+# Read + write for a preset
+node dist/index.js --preset response --allow-writes --list-permissions
+```
+
+The full read-only and write permission lists are also documented in [README.md](../README.md#azure-ad-permissions).
+
+3. Click **Add permissions**.
+4. Click **Grant admin consent for <tenant>** and confirm. **This step is mandatory** — until admin consent is granted, Graph API calls will fail with `AADSTS65001` (no consent).
+
+## Step 4. Verify
+
+Set the environment variables locally and run the verify command:
+
+```bash
+export MS365_ADMIN_MCP_CLIENT_ID=<application-client-id>
+export MS365_ADMIN_MCP_CLIENT_SECRET=<secret-value-from-step-2>
+export MS365_ADMIN_MCP_TENANT_ID=<directory-tenant-id>
+
+node dist/index.js --verify-login
+```
+
+Expected output:
+
+```json
+{
+  "success": true,
+  "message": "Connected to tenant: Contoso",
+  "tenantInfo": { "displayName": "Contoso", "id": "..." }
+}
+```
+
+If `success: false`, see [docs/TROUBLESHOOTING.md](TROUBLESHOOTING.md#authentication).
+
+## Step 5. Narrow the permission scope (optional but recommended)
+
+The default set includes every permission across all 515 tools. For a specific use case, grant only what's needed:
+
+1. Decide on the preset(s) you'll use (e.g., `identity,security`).
+2. Run `--list-permissions --preset identity,security` and grant only those.
+3. Start the server with matching `--preset identity,security`.
+4. If you later need more, add permissions incrementally and re-consent.
+
+This keeps the blast radius of a leaked secret bounded.
+
+## Step 6. Protect the app
+
+- **Owner assignment.** Add at least two named owners to the app (not just the service account that created it).
+- **Authentication → Allow public client flows.** Keep this **disabled**. Client credentials do not need it.
+- **Token configuration.** No optional claims are required.
+- **Expose an API.** Not needed for this server (it consumes Graph, does not expose its own API) — unless you are the one using HTTP mode with `--allowed-clients`; see below.
+- **App roles.** Not needed.
+- **App manifest.** Set `"signInAudience": "AzureADMyOrg"` if not already.
+
+## App registration for HTTP transport clients
+
+If you run the server with `--transport http`, **callers** (MCP clients connecting to the server) must also have their own app registration. The server's `--allowed-clients` flag lists the Entra app IDs of authorized callers.
+
+1. Create a separate app registration per caller (e.g., one per agent host).
+2. Under **Expose an API** or **API permissions** of the caller app, configure whatever is needed to obtain a token with audience matching your server's Application ID URI.
+3. Start the server with `--allowed-clients client-id-1,client-id-2`.
+4. The caller obtains a token via client credentials (or another flow), then sends it as `Authorization: Bearer <token>` on `/mcp` requests.
+
+Token validation verifies:
+
+- RS256 signature via Microsoft JWKS (`https://login.microsoftonline.com/<tenant>/discovery/v2.0/keys`)
+- `iss` = `https://login.microsoftonline.com/<tenant>/v2.0`
+- `tid` = the server's configured tenant
+- `appid` or `azp` ∈ `--allowed-clients`
+- `aud` = server's expected audience (if configured)
+
+## Rotation and hygiene
+
+- **Client secrets.** Rotate every 90 days at most. Set calendar reminders 30 days before expiry.
+- **Certificates.** Renew 30 days before expiry.
+- **Orphaned credentials.** Review `list-app-federated-credentials` and `add-application-password` usage quarterly. Delete unused credentials.
+- **Ownership.** Audit app owners in your access reviews (use this server to do so).
+
+## Appendix — permission reference
+
+The full list of application permissions this server can use is in [README.md](../README.md#azure-ad-permissions). Short summary:
+
+- **Read-only base (~70 permissions).** Required for any read operation.
+- **Write base (~40 additional).** Required only if you pass `--allow-writes`.
+- **Exchange.ManageAsApp.** Required specifically for Exchange admin calls.
+- **PIM and RoleManagement scopes.** Required for role assignment tools.
+- **eDiscovery.ReadWrite.All.** Privileged — use access reviews.
+
+Grant the minimum intersection of (your enabled tools × the permissions each tool declares).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -156,11 +156,11 @@ Single source of truth for tool definitions. Each entry:
   "method": "GET",
   "appPermissions": ["User.Read.All"],
   "llmTip": "Use $filter='userType eq ''Guest''' to list guests",
-  "riskLevel": "medium",         // only for non-GET
-  "skipEncoding": ["userId"],    // optional: path params that should not be URL-encoded
+  "riskLevel": "medium", // only for non-GET
+  "skipEncoding": ["userId"], // optional: path params that should not be URL-encoded
   "contentType": "application/json",
   "acceptType": "application/json",
-  "returnDownloadUrl": false
+  "returnDownloadUrl": false,
 }
 ```
 
@@ -182,9 +182,9 @@ This means tool parameter validation is derived automatically from Graph's own s
 
 The runtime tool registration in `graph-tools.ts` then combines:
 
-- Generated schema (from OpenAPI)  →  parameter validation
-- `endpoints.json` metadata         →  risk level, llmTip, skipEncoding, content type
-- `tool-categories.ts` regexes      →  preset filtering
+- Generated schema (from OpenAPI) → parameter validation
+- `endpoints.json` metadata → risk level, llmTip, skipEncoding, content type
+- `tool-categories.ts` regexes → preset filtering
 
 ## Risk classification
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,245 @@
+# Architecture
+
+This document describes the internal design of `ms-365-admin-mcp-server`.
+
+## High-level flow
+
+```
+          +-----------------+
+          |   MCP client    |  (Claude Desktop, Claude Code, custom agent)
+          +--------+--------+
+                   |
+   stdio or HTTP   |  MCP protocol (JSON-RPC over streams)
+                   v
+          +--------+--------+
+          |   This server   |
+          |                 |
+          |  CLI parse      |
+          |  Secrets load   |
+          |  Auth (MSAL)    |
+          |  Tool register  |
+          +--------+--------+
+                   |
+     HTTPS Graph   |
+                   v
+          +--------+--------+
+          |  Microsoft      |
+          |  Graph API      |
+          +-----------------+
+```
+
+## Components
+
+### Entry point — `src/index.ts`
+
+1. Parses CLI args (`parseArgs`).
+2. Handles meta-commands first (`--list-tools`, `--list-permissions`, `--list-presets`) and exits.
+3. Loads secrets from env or Key Vault (`getSecrets`).
+4. Creates the `AuthManager` (MSAL confidential client).
+5. If `--verify-login`, tests credentials and exits.
+6. Otherwise creates `AdminGraphServer`, initializes, and starts.
+
+### CLI — `src/cli.ts`
+
+Thin wrapper over [commander](https://github.com/tj/commander.js). Adds:
+
+- Preset expansion (`--preset identity,security` becomes a regex via `getCombinedPresetPattern`)
+- Read-only default (only `--allow-writes` enables mutations)
+- Regex length cap (500 chars, ReDoS prevention)
+- `MS365_ADMIN_MCP_CLOUD_TYPE` propagation via env
+
+### Secrets — `src/secrets.ts`
+
+Two providers:
+
+- `EnvironmentSecretsProvider` — reads `MS365_ADMIN_MCP_*` env vars. Default.
+- `KeyVaultSecretsProvider` — fetches from Azure Key Vault if `MS365_ADMIN_MCP_KEYVAULT_URL` is set. Uses `DefaultAzureCredential` (local CLI login, managed identity, workload identity, etc.).
+
+Secrets are cached in-process after first retrieval. `clearSecretsCache()` exists for tests.
+
+### Auth — `src/auth.ts`
+
+Wraps `@azure/msal-node`'s `ConfidentialClientApplication`. Responsibilities:
+
+- Validate inputs early (`clientId`, `clientSecret`, specific tenant — rejects `common`).
+- Acquire tokens via `acquireTokenByClientCredential` with scope `https://graph.microsoft.com/.default`.
+- Cache the token until 60 seconds before expiry.
+- `testLogin()` hits `/v1.0/organization` to validate end-to-end.
+
+Also exports `buildPermissionsFromEndpoints(enabledToolsPattern, readOnly)` — collects the unique set of `appPermissions` from `endpoints.json` based on filters, used by `--list-permissions`.
+
+### Graph client — `src/graph-client.ts`
+
+Thin `fetch` wrapper that:
+
+- Adds the bearer token from `AuthManager`
+- Applies the cloud-specific base URL (`getCloudEndpoints`)
+- Normalizes errors into MCP-friendly `CallToolResult` shapes
+
+### Tool registration — `src/graph-tools.ts`
+
+The core of the server. For each endpoint definition:
+
+1. Build a Zod schema from the generated client's parameter metadata (path, query, header, body, plus OData-friendly descriptions for `$filter`, `$select`, `$top`).
+2. Compose a tool description, optionally augmented with `llmTip` and a `RISK LEVEL` warning for non-GET operations (`graph-tools.ts:290-303`).
+3. Register via `server.tool(alias, description, paramSchema, hints, handler)`.
+4. The handler (`executeGraphTool`) stitches params into the path, query string, and body, then calls `graphClient.graphRequest`.
+
+Skipping logic:
+
+- `readOnly` mode skips any non-GET.
+- `enabledToolsRegex` (from `--preset` / `--enabled-tools` / `ENABLED_TOOLS`) filters by tool name.
+
+Security hardening inside the handler (grep for `SEC-` comments):
+
+- `SEC-A` — path-param skip-encoding validated against traversal
+- `SEC-D` — query-string encoding via `encodeURIComponent`
+- `excludeResponse: true` opt-in to drop the body for operations where the LLM only needs success/failure
+
+### Presets — `src/tool-categories.ts`
+
+A static record mapping preset names to `{ pattern: RegExp, description }`. `getCombinedPresetPattern(names)` unions their regex. Matching happens at tool-registration time against the `toolName` string.
+
+### Stdio server — `src/server.ts`
+
+`AdminGraphServer` wires up:
+
+- `McpServer` from the MCP SDK
+- `GraphClient` instance
+- Tool registration via `registerGraphTools`
+- Transport selection based on `--transport`
+
+For stdio it connects `StdioServerTransport`. For HTTP it delegates to `src/http-server.ts`.
+
+### HTTP server — `src/http-server.ts`
+
+Express app with:
+
+- Security headers
+- 100 KB body limit
+- 100 req/min rate limit on `/mcp`
+- JWT validation middleware on `/mcp` (see `token-validator.ts`)
+- `GET /health` unauthenticated
+- Stateless MCP transport (`StreamableHTTPServerTransport`) — one fresh transport per request
+
+### Token validation — `src/token-validator.ts`
+
+Per-tenant `jwks-rsa` client with caching (10 min). Verifies:
+
+- RS256 signature
+- `iss` = tenant v2 endpoint
+- `tid` matches configured tenant
+- `appid` / `azp` in `allowedClientIds`
+- `aud` matches expected (if provided)
+- 30 s clock tolerance
+
+Failures are logged at `warn` with a short reason (no token echoing).
+
+### Cloud config — `src/cloud-config.ts`
+
+Maps `CloudType` (`global` / `china`) to `{ authority, graphApi }` endpoints. Validates the input and defaults to `global`.
+
+### Logger — `src/logger.ts`
+
+Winston logger. Default level depends on `-v` flag. Redacts sensitive fields.
+
+## Data sources
+
+### `src/endpoints.json`
+
+Single source of truth for tool definitions. Each entry:
+
+```jsonc
+{
+  "toolName": "list-users",
+  "pathPattern": "/users",
+  "method": "GET",
+  "appPermissions": ["User.Read.All"],
+  "llmTip": "Use $filter='userType eq ''Guest''' to list guests",
+  "riskLevel": "medium",         // only for non-GET
+  "skipEncoding": ["userId"],    // optional: path params that should not be URL-encoded
+  "contentType": "application/json",
+  "acceptType": "application/json",
+  "returnDownloadUrl": false
+}
+```
+
+`endpoints.json` is **hand-curated** (~515 entries). It is the thing a contributor edits.
+
+### `src/generated/`
+
+Auto-generated by `bin/generate-graph-client.mjs` from the Microsoft Graph OpenAPI spec. Contains the typed zod client. **Never hand-edit.**
+
+## Code generation pipeline
+
+`npm run generate` runs `bin/generate-graph-client.mjs`:
+
+1. **Download** the latest Graph OpenAPI spec (`openapi/openapi.yaml`).
+2. **Trim** it to only the paths listed in `src/endpoints.json` (`openapi-trimmed.yaml`).
+3. **Generate** a zod-typed client via `openapi-zod-client` into `src/generated/`.
+
+This means tool parameter validation is derived automatically from Graph's own schema — you get accurate types for body schemas, path params, query params, enums, etc., without writing them by hand.
+
+The runtime tool registration in `graph-tools.ts` then combines:
+
+- Generated schema (from OpenAPI)  →  parameter validation
+- `endpoints.json` metadata         →  risk level, llmTip, skipEncoding, content type
+- `tool-categories.ts` regexes      →  preset filtering
+
+## Risk classification
+
+Every non-GET tool carries a `riskLevel`. See [RISK_MODEL.md](RISK_MODEL.md) for the rubric. Risk levels are surfaced to the LLM through the tool description (`graph-tools.ts:295-302`) and serve as machine-readable guardrails for policy enforcement (e.g., an operator wrapper can require explicit human confirmation for `critical`).
+
+## Write protection
+
+Two layers:
+
+1. **Registration-time.** If the server is started without `--allow-writes`, non-GET tools are skipped entirely during registration (`graph-tools.ts:232-235`). They are not exposed to the MCP client.
+2. **Permission-time.** `--list-permissions` only emits write scopes when `--allow-writes` is set, so the operator granting admin consent naturally follows least privilege.
+
+## Extensibility points
+
+- **New tools** — add entries to `endpoints.json`, regenerate, done (see [CONTRIBUTING.md](../CONTRIBUTING.md#adding-a-new-tool)).
+- **New presets** — add regex to `tool-categories.ts`.
+- **New secret backend** — implement `SecretsProvider` in `secrets.ts`.
+- **New transport** — follow the `http-server.ts` pattern and wire it in `server.ts`.
+- **New cloud** — add endpoints to `cloud-config.ts` and extend `parseCloudType`.
+
+## Testing
+
+- **Vitest** (`test/`). Unit tests focus on auth validation, tool parameter parsing, preset regex combinations, token validation, risk-level serialization.
+- **MCP Inspector** for interactive E2E testing (`npm run inspector`).
+- **`--verify-login`** as a smoke test against a real tenant.
+
+## What's intentionally absent
+
+- **No caching of Graph responses.** Freshness matters for admin data.
+- **No automatic retry on 429.** Callers / proxies should handle throttling.
+- **No tool result summarization.** The raw Graph response is returned; the LLM decides what to do with it.
+- **No audit log of tool invocations by this server.** Graph itself logs every mutation (directory audits, Intune audit, Cloud PC audit); use those for traceability.
+- **No per-user authorization.** With application permissions, all calls run as the app. User-scoped authorization belongs in a delegated-permissions server (see [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365-mcp-server)).
+
+## Dependencies
+
+Runtime:
+
+- `@azure/msal-node` — MSAL for client credentials
+- `@modelcontextprotocol/sdk` — MCP protocol
+- `commander` — CLI parsing
+- `dotenv` — local `.env` loading
+- `express`, `express-rate-limit` — HTTP transport
+- `js-yaml` — OpenAPI parsing
+- `jsonwebtoken`, `jwks-rsa` — JWT validation (HTTP mode)
+- `winston` — logging
+- `zod` — schema validation (via generated client)
+
+Optional:
+
+- `@azure/identity`, `@azure/keyvault-secrets` — Key Vault secret provider
+
+Dev:
+
+- `tsup` — build
+- `vitest` — tests
+- `eslint`, `prettier` — linting and formatting
+- `tsx` — dev runner

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -1,0 +1,186 @@
+# HTTP Transport and Remote Deployment
+
+The server supports two transports:
+
+- **stdio** (default) — the MCP client spawns the server as a subprocess over stdin/stdout. Best for Claude Desktop, Claude Code, and local agents.
+- **HTTP (StreamableHTTP)** — the server listens on a TCP port and accepts requests from remote MCP clients authenticated with an Entra bearer token. Best for shared deployments (multi-user, Azure-hosted, behind a reverse proxy).
+
+This guide focuses on HTTP mode.
+
+## When to use HTTP mode
+
+Use HTTP when:
+
+- Multiple users or agents share one server instance
+- You want to host the server in Azure (Container Apps, AKS, VMs) rather than on each user's laptop
+- You need centralized logging, rate limiting, or network-level access control
+- Your MCP client lives on a different machine from the server (a common case for agent automation)
+
+Do **not** use HTTP when stdio is sufficient — it's simpler and has a smaller attack surface.
+
+## Quick start
+
+```bash
+node dist/index.js \
+  --transport http \
+  --port 8080 \
+  --host 127.0.0.1 \
+  --allowed-clients "caller-app-id-1,caller-app-id-2"
+```
+
+`--allowed-clients` is **mandatory** in HTTP mode. There is no anonymous access.
+
+Endpoints:
+
+- `GET /health` — unauthenticated liveness probe. Returns `{ status: "ok", transport: "http", timestamp: "..." }`.
+- `POST /mcp`, `DELETE /mcp`, `GET /mcp` — MCP protocol endpoints. Require `Authorization: Bearer <token>`.
+
+## Authentication model
+
+The server validates the incoming JWT against Microsoft JWKS:
+
+| Check              | Value                                                      |
+| ------------------ | ---------------------------------------------------------- |
+| Algorithm          | `RS256` (only)                                             |
+| Issuer (`iss`)     | `https://login.microsoftonline.com/<tenant>/v2.0`          |
+| Tenant (`tid`)     | Must match `MS365_ADMIN_MCP_TENANT_ID`                     |
+| Client (`appid`/`azp`) | Must be in `--allowed-clients`                         |
+| Audience (`aud`)   | Matches `--expected-audience` (if configured)              |
+| Signature          | Verified via `https://login.microsoftonline.com/<tenant>/discovery/v2.0/keys` |
+| Clock tolerance    | 30 seconds                                                 |
+
+Failure modes:
+
+- Missing/malformed `Authorization` header → `401`
+- Signature invalid, issuer/tenant/client mismatch → `403`
+- Token expired → `403`
+
+## Caller token acquisition
+
+A caller obtains its token via any standard Entra flow. Typical client-credentials example:
+
+```bash
+CALLER_CLIENT_ID=... # must be listed in --allowed-clients
+CALLER_CLIENT_SECRET=...
+TENANT_ID=...
+SERVER_AUDIENCE="api://ms-365-admin-mcp-server"  # or the server's Application ID URI
+
+TOKEN=$(curl -s -X POST \
+  "https://login.microsoftonline.com/$TENANT_ID/oauth2/v2.0/token" \
+  -d "client_id=$CALLER_CLIENT_ID" \
+  -d "client_secret=$CALLER_CLIENT_SECRET" \
+  -d "grant_type=client_credentials" \
+  -d "scope=$SERVER_AUDIENCE/.default" | jq -r .access_token)
+
+curl -X POST http://localhost:8080/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+## Hardening defenses (already implemented)
+
+The server ships with these defenses enabled by default (see `src/http-server.ts`):
+
+| Defense            | Detail                                                             |
+| ------------------ | ------------------------------------------------------------------ |
+| Rate limit         | 100 req/min per source IP on `/mcp`                                |
+| Body size limit    | 100 KB                                                             |
+| Security headers   | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store`, CSP `default-src 'none'`, `Referrer-Policy: no-referrer` |
+| Default bind       | `127.0.0.1` (loopback)                                             |
+| Stateless sessions | Each request creates a fresh transport; no server-side session state |
+| Stack trace suppression | Errors return `500` with generic message; details in logs only |
+
+## Operator-provided hardening (you must do this)
+
+The server does not terminate TLS or add caller allowlisting beyond JWT. You must:
+
+1. **Terminate TLS** at a reverse proxy (Azure Front Door, Application Gateway, nginx, Caddy, Cloudflare Tunnel, etc.).
+2. **Restrict network exposure** — bind the server to loopback or a private network, front it with the proxy.
+3. **Forward `X-Forwarded-For`** so rate limits attribute correctly.
+4. **Monitor logs** — all auth failures are logged at `warn`/`error` levels.
+
+## Docker
+
+```bash
+docker build -t ms365-admin-mcp .
+docker run --rm -p 8080:8080 \
+  -e MS365_ADMIN_MCP_CLIENT_ID=... \
+  -e MS365_ADMIN_MCP_CLIENT_SECRET=... \
+  -e MS365_ADMIN_MCP_TENANT_ID=... \
+  ms365-admin-mcp \
+  --transport http \
+  --port 8080 \
+  --host 0.0.0.0 \
+  --allowed-clients "caller-app-id"
+```
+
+The Docker image runs as a non-root user. Do not mount writable volumes unless needed.
+
+## Azure Container Apps
+
+A reference Bicep template lives at [infra/main.bicep](../infra/main.bicep). It deploys:
+
+- Log Analytics workspace (retention 30 days)
+- Application Insights (linked to the workspace)
+- Container App Environment
+- Container App with system-assigned managed identity
+
+### Deploy
+
+```bash
+# Build and push the image to your ACR
+az acr build --registry <your-acr> --image ms365-admin-mcp:latest .
+
+# Deploy
+az deployment group create \
+  --resource-group rg-mcp-admin \
+  --template-file infra/main.bicep \
+  --parameters \
+    containerImage=<your-acr>.azurecr.io/ms365-admin-mcp:latest \
+    tenantId=$TENANT_ID \
+    clientId=$CLIENT_ID \
+    clientSecret=$CLIENT_SECRET
+```
+
+### Post-deploy recommendations
+
+1. **Front with Application Gateway or Front Door** for WAF and TLS termination.
+2. **Switch to managed identity** — remove the client-secret parameter, assign the Container App's managed identity the Graph permissions directly, and use `DefaultAzureCredential` (requires a code change to swap MSAL client-credentials for managed-identity token acquisition, planned).
+3. **Use Key Vault for the secret** — set `MS365_ADMIN_MCP_KEYVAULT_URL` and store the client secret as `ms365-admin-mcp-client-secret`. Grant the Container App's managed identity `get` access on the vault secrets.
+4. **Log forwarding.** Container App stdout is ingested into Log Analytics. Configure a diagnostic setting to stream to your SIEM.
+5. **Autoscale.** The server is stateless; scale horizontally on request volume or CPU.
+
+## Observability
+
+The server logs via Winston in JSON format. Key events:
+
+| Event                           | Level | Sample                                                          |
+| ------------------------------- | ----- | --------------------------------------------------------------- |
+| Tool invocation                 | info  | `Tool list-users called with params: [top, filter]`              |
+| Token acquisition (server-side) | info  | `Acquiring token via client credentials flow...`                |
+| Token validation failure        | warn  | `Token client ID not in allowed list`                           |
+| Graph API error                 | error | `testLogin Graph error 403: Forbidden`                          |
+| Tool registration summary       | info  | `Tool registration complete: 515 registered, 0 skipped, 0 failed` |
+| Rate limit hit                  | (express-rate-limit default) |                                                |
+
+Enable verbose Graph request logging with `-v`.
+
+## Scaling and limits
+
+- **Concurrency.** Node event loop handles concurrent Graph requests. MSAL caches the token for ~1 hour.
+- **Rate limits.** Graph API applies tenant-wide throttling (HTTP 429). The server does not currently retry — implement retry at the caller or behind a proxy with queueing.
+- **Memory.** Single instance is typically <200 MB. Increase only if you see OOM during large list operations.
+- **Paging.** Set `MS365_ADMIN_MCP_MAX_TOP=50` to cap page size and avoid long-running requests on large tenants.
+
+## Health checks
+
+- **Liveness.** `GET /health` returns 200 as long as the process is up.
+- **Readiness.** Combine `/health` with a background `--verify-login` in a sidecar if you want to fail readiness when Graph credentials are invalid.
+
+## Migration from stdio to HTTP
+
+1. Deploy the server with `--transport http` somewhere reachable by your MCP client.
+2. Create a caller app registration (separate from the server's app registration) and add its client ID to `--allowed-clients`.
+3. Update your MCP client configuration to use the HTTP transport (consult your client's docs — Claude Desktop supports HTTP transports as of v0.11).
+4. Verify auth with a sample token, then cut over.

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -39,15 +39,15 @@ Endpoints:
 
 The server validates the incoming JWT against Microsoft JWKS:
 
-| Check              | Value                                                      |
-| ------------------ | ---------------------------------------------------------- |
-| Algorithm          | `RS256` (only)                                             |
-| Issuer (`iss`)     | `https://login.microsoftonline.com/<tenant>/v2.0`          |
-| Tenant (`tid`)     | Must match `MS365_ADMIN_MCP_TENANT_ID`                     |
-| Client (`appid`/`azp`) | Must be in `--allowed-clients`                         |
-| Audience (`aud`)   | Matches `--expected-audience` (if configured)              |
-| Signature          | Verified via `https://login.microsoftonline.com/<tenant>/discovery/v2.0/keys` |
-| Clock tolerance    | 30 seconds                                                 |
+| Check                  | Value                                                                         |
+| ---------------------- | ----------------------------------------------------------------------------- |
+| Algorithm              | `RS256` (only)                                                                |
+| Issuer (`iss`)         | `https://login.microsoftonline.com/<tenant>/v2.0`                             |
+| Tenant (`tid`)         | Must match `MS365_ADMIN_MCP_TENANT_ID`                                        |
+| Client (`appid`/`azp`) | Must be in `--allowed-clients`                                                |
+| Audience (`aud`)       | Matches `--expected-audience` (if configured)                                 |
+| Signature              | Verified via `https://login.microsoftonline.com/<tenant>/discovery/v2.0/keys` |
+| Clock tolerance        | 30 seconds                                                                    |
 
 Failure modes:
 
@@ -82,14 +82,14 @@ curl -X POST http://localhost:8080/mcp \
 
 The server ships with these defenses enabled by default (see `src/http-server.ts`):
 
-| Defense            | Detail                                                             |
-| ------------------ | ------------------------------------------------------------------ |
-| Rate limit         | 100 req/min per source IP on `/mcp`                                |
-| Body size limit    | 100 KB                                                             |
-| Security headers   | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store`, CSP `default-src 'none'`, `Referrer-Policy: no-referrer` |
-| Default bind       | `127.0.0.1` (loopback)                                             |
-| Stateless sessions | Each request creates a fresh transport; no server-side session state |
-| Stack trace suppression | Errors return `500` with generic message; details in logs only |
+| Defense                 | Detail                                                                                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rate limit              | 100 req/min per source IP on `/mcp`                                                                                                             |
+| Body size limit         | 100 KB                                                                                                                                          |
+| Security headers        | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store`, CSP `default-src 'none'`, `Referrer-Policy: no-referrer` |
+| Default bind            | `127.0.0.1` (loopback)                                                                                                                          |
+| Stateless sessions      | Each request creates a fresh transport; no server-side session state                                                                            |
+| Stack trace suppression | Errors return `500` with generic message; details in logs only                                                                                  |
 
 ## Operator-provided hardening (you must do this)
 
@@ -155,14 +155,14 @@ az deployment group create \
 
 The server logs via Winston in JSON format. Key events:
 
-| Event                           | Level | Sample                                                          |
-| ------------------------------- | ----- | --------------------------------------------------------------- |
-| Tool invocation                 | info  | `Tool list-users called with params: [top, filter]`              |
-| Token acquisition (server-side) | info  | `Acquiring token via client credentials flow...`                |
-| Token validation failure        | warn  | `Token client ID not in allowed list`                           |
-| Graph API error                 | error | `testLogin Graph error 403: Forbidden`                          |
-| Tool registration summary       | info  | `Tool registration complete: 515 registered, 0 skipped, 0 failed` |
-| Rate limit hit                  | (express-rate-limit default) |                                                |
+| Event                           | Level                        | Sample                                                            |
+| ------------------------------- | ---------------------------- | ----------------------------------------------------------------- |
+| Tool invocation                 | info                         | `Tool list-users called with params: [top, filter]`               |
+| Token acquisition (server-side) | info                         | `Acquiring token via client credentials flow...`                  |
+| Token validation failure        | warn                         | `Token client ID not in allowed list`                             |
+| Graph API error                 | error                        | `testLogin Graph error 403: Forbidden`                            |
+| Tool registration summary       | info                         | `Tool registration complete: 515 registered, 0 skipped, 0 failed` |
+| Rate limit hit                  | (express-rate-limit default) |                                                                   |
 
 Enable verbose Graph request logging with `-v`.
 

--- a/docs/RISK_MODEL.md
+++ b/docs/RISK_MODEL.md
@@ -1,0 +1,156 @@
+# Risk Model
+
+Every write tool in `ms-365-admin-mcp-server` is labeled with a risk level. This document explains the classification, how it's surfaced, and how to use it.
+
+## Why risk levels
+
+LLMs operating admin tools can cause real damage: delete users, wipe devices, disable policies, drop retention holds. Explicit risk classification:
+
+- **Informs the LLM** — the risk level is appended to the tool description and visible to the model when it decides whether to call the tool.
+- **Gives operators a policy surface** — a wrapper can require human confirmation for `critical` or `high`, or block them entirely.
+- **Makes permission granting deliberate** — the risk level encourages granular consent rather than blanket `ReadWrite.All`.
+
+## Classification rubric
+
+| Level      | Reversibility                                          | Scope                             | Example tools                                                                  |
+| ---------- | ------------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------ |
+| `low`      | Fully reversible or read-only-by-intent                | Narrow (one entity or a query)    | `run-hunting-query`, `add-security-alert-comment`, `sync-managed-device`       |
+| `medium`   | Reversible with manual effort                          | Single entity                     | `update-user`, `add-group-member`, `create-invitation`, `remote-lock-device`    |
+| `high`     | Partly reversible; significant operational impact      | Single entity with broad effect, or policy change | `revoke-user-sessions`, `update-conditional-access-policy`, `retire-managed-device`, `confirm-compromised-users` |
+| `critical` | Irreversible without backups, or tenant-wide impact    | Tenant, multiple entities, data loss | `delete-user`, `wipe-managed-device`, `delete-conditional-access-policy`, `clean-windows-device`, `disable-user-account` |
+
+### Decision questions
+
+For a write tool, ask in order:
+
+1. **Can the change be undone without data loss or administrator intervention?**
+   - No, never → **critical**
+   - Yes, but only with notable effort (re-enable account, re-invite user, restore from recycle bin within 30 days) → **high**
+   - Yes, trivially (toggle a flag back) → **medium** or **low**
+
+2. **What's the blast radius?**
+   - Whole tenant or cross-tenant → elevate one level
+   - Single user or device → baseline
+   - Dry-run-only (POST that returns data without changing state) → **low**
+
+3. **Can it be used for privilege escalation or data exfiltration?**
+   - Yes → at least **high** regardless of other factors (e.g., `add-application-password`, `create-pim-role-assignment-request`)
+
+When in doubt, pick the higher level. It's easy to downgrade later if real-world use shows the caution was excessive; it's much harder to recover from an undervalued `critical`.
+
+## Examples
+
+### Why `wipe-managed-device` is `critical`
+
+Issuing a wipe:
+
+- Destroys user data on the device (reversibility: none without backups)
+- Cannot be recalled after execution (some seconds later, the device begins erasing)
+- Often fires without further user interaction
+
+Mitigation: the LLM description explicitly says "irreversible or has major security impact. Always confirm with the operator before executing."
+
+### Why `disable-user-account` is `critical`
+
+Although reversible (toggle `accountEnabled` back), disabling a user:
+
+- Cuts them off from every service (email, Teams, files) immediately
+- Can lock out a privileged admin in an emergency if the wrong account is picked
+- Is the first move in a compromise response where acting on the wrong user delays real containment
+
+### Why `revoke-user-sessions` is `high` (not `critical`)
+
+It terminates active tokens but does not change credentials. The user can sign in again immediately; no data is lost. It's a significant operational event (users are logged out everywhere) but fully recoverable.
+
+### Why `update-conditional-access-policy` is `high`
+
+CA changes can lock out the entire tenant. The mitigation is procedural (deploy in report-only, test, then enforce), not technical — hence the level reflects what *can* happen, not what *usually* happens.
+
+### Why `run-hunting-query` is `low`
+
+The endpoint uses POST (KQL in the body) but does not mutate tenant state. It's a read-with-payload. Classifying it as `high` just because of the HTTP verb would be misleading.
+
+### Why Intune report tools are `low`
+
+Intune's reporting APIs (e.g., `intune-device-noncompliance-report`) require POST because the query body can be large. They produce a report; they don't change anything.
+
+## Surface
+
+### In the tool description (runtime)
+
+`graph-tools.ts` appends `RISK LEVEL: <LEVEL>. <guidance>` to every non-GET tool:
+
+```
+RISK LEVEL: CRITICAL. This action is irreversible or has major security impact.
+Always confirm with the operator before executing.
+
+RISK LEVEL: HIGH. This action has significant impact. Verify the target carefully
+before executing.
+```
+
+`medium` and `low` receive the level without extra guidance text.
+
+### In `endpoints.json`
+
+```jsonc
+{
+  "toolName": "delete-user",
+  "pathPattern": "/users/{userId}",
+  "method": "DELETE",
+  "appPermissions": ["User.ReadWrite.All"],
+  "riskLevel": "critical"
+}
+```
+
+### In `--list-tools` output
+
+```json
+{
+  "name": "delete-user",
+  "method": "DELETE",
+  "path": "/users/{userId}",
+  "permissions": ["User.ReadWrite.All"]
+}
+```
+
+Risk level is not currently emitted by `--list-tools`; grep `endpoints.json` if you need it offline.
+
+## Operator playbook
+
+For a production or shared deployment, wrap the server behind a policy layer that enforces:
+
+1. **Critical operations require explicit out-of-band confirmation** — a Slack DM, a ticket approval, a second human. Not just LLM reasoning.
+2. **High operations require an audit trail entry** — who asked, why, what was the target.
+3. **All writes should produce a post-action verification** — e.g., after `disable-user-account`, query the user and confirm `accountEnabled == false`.
+4. **Dry-run by default for bulk operations** — before looping `disable-user-account` over 50 users, list them first and confirm.
+
+Template prompt pattern to encode in the system message:
+
+```
+Before any tool with riskLevel `high` or `critical`:
+
+1. Describe the exact action and its target.
+2. Describe the expected effect (who / what is affected).
+3. Describe how to reverse it, if possible.
+4. Ask the operator for explicit confirmation ("type `confirm` to proceed").
+5. Only then invoke the tool.
+
+After execution, query the affected entity and confirm the expected state change.
+```
+
+## Review
+
+Risk classifications are reviewed:
+
+- When a new write tool is added (during PR review)
+- When an incident reveals a misclassification (see CHANGELOG #22, #28)
+- As part of periodic security review
+
+Challenges and proposals are welcome as GitHub issues tagged `risk-classification`.
+
+## Glossary
+
+- **Reversibility.** The effort needed to undo the action without data loss.
+- **Blast radius.** How much of the tenant an action affects (one entity, one tenant, cross-tenant).
+- **Scope.** Same as blast radius in practice.
+- **Out-of-band confirmation.** Approval from a channel other than the LLM conversation itself.

--- a/docs/RISK_MODEL.md
+++ b/docs/RISK_MODEL.md
@@ -12,12 +12,12 @@ LLMs operating admin tools can cause real damage: delete users, wipe devices, di
 
 ## Classification rubric
 
-| Level      | Reversibility                                          | Scope                             | Example tools                                                                  |
-| ---------- | ------------------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------------ |
-| `low`      | Fully reversible or read-only-by-intent                | Narrow (one entity or a query)    | `run-hunting-query`, `add-security-alert-comment`, `sync-managed-device`       |
-| `medium`   | Reversible with manual effort                          | Single entity                     | `update-user`, `add-group-member`, `create-invitation`, `remote-lock-device`    |
-| `high`     | Partly reversible; significant operational impact      | Single entity with broad effect, or policy change | `revoke-user-sessions`, `update-conditional-access-policy`, `retire-managed-device`, `confirm-compromised-users` |
-| `critical` | Irreversible without backups, or tenant-wide impact    | Tenant, multiple entities, data loss | `delete-user`, `wipe-managed-device`, `delete-conditional-access-policy`, `clean-windows-device`, `disable-user-account` |
+| Level      | Reversibility                                       | Scope                                             | Example tools                                                                                                            |
+| ---------- | --------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `low`      | Fully reversible or read-only-by-intent             | Narrow (one entity or a query)                    | `run-hunting-query`, `add-security-alert-comment`, `sync-managed-device`                                                 |
+| `medium`   | Reversible with manual effort                       | Single entity                                     | `update-user`, `add-group-member`, `create-invitation`, `remote-lock-device`                                             |
+| `high`     | Partly reversible; significant operational impact   | Single entity with broad effect, or policy change | `revoke-user-sessions`, `update-conditional-access-policy`, `retire-managed-device`, `confirm-compromised-users`         |
+| `critical` | Irreversible without backups, or tenant-wide impact | Tenant, multiple entities, data loss              | `delete-user`, `wipe-managed-device`, `delete-conditional-access-policy`, `clean-windows-device`, `disable-user-account` |
 
 ### Decision questions
 
@@ -64,7 +64,7 @@ It terminates active tokens but does not change credentials. The user can sign i
 
 ### Why `update-conditional-access-policy` is `high`
 
-CA changes can lock out the entire tenant. The mitigation is procedural (deploy in report-only, test, then enforce), not technical — hence the level reflects what *can* happen, not what *usually* happens.
+CA changes can lock out the entire tenant. The mitigation is procedural (deploy in report-only, test, then enforce), not technical — hence the level reflects what _can_ happen, not what _usually_ happens.
 
 ### Why `run-hunting-query` is `low`
 
@@ -98,7 +98,7 @@ before executing.
   "pathPattern": "/users/{userId}",
   "method": "DELETE",
   "appPermissions": ["User.ReadWrite.All"],
-  "riskLevel": "critical"
+  "riskLevel": "critical",
 }
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,0 +1,230 @@
+# Troubleshooting
+
+Common errors and how to diagnose them.
+
+## Quick diagnostics
+
+```bash
+# Verify credentials and tenant connectivity
+node dist/index.js --verify-login
+
+# List tools that would load for your configuration
+node dist/index.js --preset <your-presets> --list-tools
+
+# List exact permissions your configuration needs
+node dist/index.js --preset <your-presets> --list-permissions
+
+# Run with verbose logging
+node dist/index.js -v
+```
+
+---
+
+## Startup errors
+
+### `MS365_ADMIN_MCP_CLIENT_ID is required`
+
+The env var is unset or empty. Set it in your environment or `.env` file.
+
+```bash
+export MS365_ADMIN_MCP_CLIENT_ID=<application-client-id-from-entra>
+```
+
+### `MS365_ADMIN_MCP_TENANT_ID must be a specific tenant ID (not "common")`
+
+Client credentials flow is single-tenant only. Replace `common` with your directory (tenant) GUID, visible in **Entra admin center → Overview**.
+
+### `Required secret ms365-admin-mcp-client-id not found in Key Vault`
+
+Key Vault mode expects these secret names exactly:
+
+- `ms365-admin-mcp-client-id`
+- `ms365-admin-mcp-tenant-id`
+- `ms365-admin-mcp-client-secret`
+- `ms365-admin-mcp-cloud-type` (optional)
+
+Also confirm the identity running the server has the `get` secret permission on the vault.
+
+### `Error: invalid --enabled-tools regex`
+
+Your regex did not compile. Test it in isolation:
+
+```bash
+node -e "new RegExp('your-pattern', 'i')"
+```
+
+The server also rejects patterns longer than 500 chars (ReDoS prevention).
+
+---
+
+## Authentication
+
+### `AADSTS700016: Application with identifier X was not found`
+
+The client ID is wrong or the app was deleted. Copy it fresh from **Entra → App registrations → Overview → Application (client) ID**.
+
+### `AADSTS7000215: Invalid client secret provided`
+
+- The secret expired. Check **Certificates & secrets → Client secrets → Expires** column.
+- You copied the `Secret ID` instead of the `Value`. Only the `Value` (shown once at creation time) works.
+- There are leading/trailing whitespace characters. Re-export without quotes.
+
+### `AADSTS65001: The user or administrator has not consented to use the application`
+
+Admin consent was never granted. In the Entra admin center → **API permissions** → **Grant admin consent for <tenant>**. You need Global Administrator or Privileged Role Administrator.
+
+### `AADSTS50059: No tenant-identifying information found in request`
+
+You probably passed `common` as the tenant. Use a specific tenant GUID.
+
+### `AADSTS90002: Tenant X not found`
+
+Typo in the tenant ID, or the tenant is in a different cloud (China, Government). For 21Vianet, add `--cloud china`.
+
+### `--verify-login` returns `success: false` with `Forbidden`
+
+- Admin consent granted but Graph has not propagated (wait 5-10 minutes).
+- The app has no `Organization.Read.All` or equivalent. `--verify-login` reads the org entity.
+
+---
+
+## Permissions at runtime
+
+### `Insufficient privileges to complete the operation`
+
+- The specific tool requires a permission you did not grant. Run:
+
+  ```bash
+  node dist/index.js --list-tools | grep <tool-name>
+  # then check its permissions list
+  ```
+
+- Add the missing permission in **Entra → API permissions** and grant admin consent.
+
+### `Request_ResourceNotFound` on `list-sign-ins`, `list-directory-audits`
+
+Azure AD audit logs require an **Entra ID P1** or **P2** license on the tenant. Basic/Free tenants return 403.
+
+### `Authorization_RequestDenied` on PIM tools
+
+PIM APIs require **Entra ID P2** plus the `RoleManagement.Read.Directory` / `.ReadWrite.Directory` permission.
+
+### `Authorization_IdentityNotFound` on Intune tools
+
+The tenant has no Intune subscription, or `DeviceManagementManagedDevices.Read.All` was not granted.
+
+---
+
+## Graph API runtime errors
+
+### `429 Too Many Requests`
+
+Microsoft Graph is throttling the app. Strategies:
+
+- Lower `$top` via `MS365_ADMIN_MCP_MAX_TOP=25`
+- Reduce parallel requests (MCP client config)
+- Add `Retry-After` handling at the caller (server does not auto-retry)
+- Split heavy scans across time windows
+
+### `400 Bad Request` with `Invalid filter clause`
+
+OData `$filter` has strict rules. Common gotchas:
+
+- String values must be single-quoted: `userType eq 'Guest'`
+- GUIDs are strings, not raw: `id eq '11111111-...'`
+- `startsWith()` and `endsWith()` are case-sensitive
+- Not every property is filterable (Graph API docs specify)
+
+### `ConsistencyLevel eventual` required
+
+Some filters (`$count`, advanced filters) need the header `ConsistencyLevel: eventual`. Currently the server does not inject this automatically — if you hit it, it's likely a Graph API change worth reporting as an issue.
+
+### Empty response with `@odata.nextLink`
+
+You hit a page boundary. The MCP client must follow `@odata.nextLink` manually or issue the next request with `$skiptoken`.
+
+---
+
+## HTTP transport
+
+### `401 Missing or invalid Authorization header`
+
+The request did not include `Authorization: Bearer <token>` or the header is malformed.
+
+### `403 Token validation failed`
+
+Common causes (enable verbose logging to see which check failed):
+
+- Token signed by a different tenant → `Token tenant ID mismatch`
+- Caller app ID not in `--allowed-clients` → `Token client ID not in allowed list`
+- Token expired → JWT `exp` check
+- Token audience does not match expected audience
+- `kid` (signing key ID) not found in JWKS — could be a clock skew or caching issue
+
+### `429 Too many requests, please try again later`
+
+You exceeded 100 req/min on `/mcp` from the source IP. Either back off, reshape client behavior, or put a queue in front.
+
+### Server not reachable from client
+
+- Is it bound to `127.0.0.1`? Set `--host 0.0.0.0` if exposing externally (and front with TLS).
+- Firewall / NSG rules blocking the port?
+- Check `GET /health` from the same network as the client.
+
+---
+
+## Key Vault
+
+### `DefaultAzureCredential failed to retrieve a token`
+
+- Local dev: run `az login`.
+- Azure-hosted: ensure the managed identity exists and is assigned to the compute resource.
+- The identity has no `get` secret permission on the vault.
+
+### `KeyVaultError: (Forbidden)`
+
+RBAC or access policy missing. Grant the identity `Key Vault Secrets User` role (RBAC) or `Get` on secrets (access policies).
+
+---
+
+## Tool inspection
+
+### `list-tools` shows fewer tools than expected
+
+- Did you pass `--read-only` (the default)? Write tools are excluded.
+- Did you pass `--preset`? Only matching tools load.
+- Did you set `ENABLED_TOOLS`? It filters further.
+
+### A write tool is unavailable even with `--allow-writes`
+
+- It may be filtered out by your `--preset` regex. Check the preset's pattern in `src/tool-categories.ts`.
+- For Intune report tools (POST-based but effectively read): they require `--allow-writes` because they use POST. This is expected.
+
+---
+
+## Claude Desktop / Claude Code integration
+
+### The server does not start when Claude Desktop launches it
+
+- Check Claude Desktop logs: `~/Library/Logs/Claude/` (macOS) or `%APPDATA%\Claude\Logs\` (Windows).
+- Ensure `command` is `node` and `args[0]` is the absolute path to `dist/index.js`.
+- Env vars in the MCP config are not read from your shell — declare them explicitly under `env`.
+
+### Tools appear but every call errors
+
+- Run `--verify-login` with the same env vars Claude Desktop uses.
+- If env vars come from a secret manager, ensure your MCP config doesn't use shell expansion (it doesn't run a shell).
+
+---
+
+## Getting help
+
+1. Run with `-v` and capture the log output.
+2. Redact secrets (`MS365_ADMIN_MCP_CLIENT_SECRET`, any bearer token).
+3. File an issue at [github.com/okapi-ca/ms-365-admin-mcp-server/issues](https://github.com/okapi-ca/ms-365-admin-mcp-server/issues) with:
+   - Version / commit SHA
+   - Command line
+   - Sanitized log excerpt
+   - Expected vs actual behavior
+
+For **security** issues, see [SECURITY.md](../SECURITY.md) — do not open a public issue.


### PR DESCRIPTION
## Summary

Adds the baseline documentation the repo was missing: legal, security, contribution, changelog, plus five end-user guides under `docs/`.

## What's added

### Root-level files
- `LICENSE` (MIT) — the README declared MIT but no file existed.
- `SECURITY.md` — private vulnerability reporting process and operator hardening checklist.
- `CONTRIBUTING.md` — dev setup, tool-adding workflow, risk-classification rubric, commit conventions.
- `CHANGELOG.md` — Keep a Changelog format, back-populated from git history (515 tools progression).

### `docs/`
- `APP_REGISTRATION.md` — step-by-step Entra app registration, permissions, admin consent, rotation.
- `HTTP_DEPLOYMENT.md` — HTTP transport details, JWT validation flow, Docker, Azure Container Apps.
- `TROUBLESHOOTING.md` — common startup / auth / Graph / HTTP / Key Vault errors and diagnoses.
- `ARCHITECTURE.md` — component layout, code-generation pipeline, extensibility points.
- `RISK_MODEL.md` — rubric for `low`/`medium`/`high`/`critical` on write tools, with operator playbook.

### `.github/`
- `PULL_REQUEST_TEMPLATE.md` — structured PR form (risk assessment, Graph permissions, testing, security checklist).
- `ISSUE_TEMPLATE/bug_report.md`, `feature_request.md`, `config.yml` — bug/feature forms plus a link to private vulnerability reporting.

### `README.md`
- New Documentation table indexing all the above.
- License line now links to `LICENSE`.

## Why

The project had only `README.md` and `docs/USE_CASES.md`. Missing pieces were blocking new users (no app-registration walkthrough, no troubleshooting) and creating legal/security gaps (no LICENSE file, no vulnerability reporting channel).

## Test plan

- [ ] Render each Markdown file on GitHub to verify formatting
- [ ] Check internal links (README -> docs/*, docs/* -> README and each other)
- [ ] Verify the issue templates render correctly when opening a new issue
- [ ] Verify the PR template renders on the next PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)