### PR TITLE
chore(release): prepare 0.1.0 with npm + ghcr publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run verify
+
+  publish-npm:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - run: npm ci
+      - run: npm run generate
+      - run: npm run build
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-docker:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  github-release:
+    needs: [publish-npm, publish-docker]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --notes "See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for release notes."

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+coverage
+src/generated
+.venv
+.claude
+openapi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Initial public release. **515 tools** covering Microsoft 365 admin operations vi
 - Complete documentation set: `USE_CASES`, `APP_REGISTRATION`, `HTTP_DEPLOYMENT`, `TROUBLESHOOTING`, `ARCHITECTURE`, `RISK_MODEL` (#29, #30)
 - `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` (MIT), `CHANGELOG.md`
 - `.github/PULL_REQUEST_TEMPLATE.md` and issue templates
-- Published to npm as `@okapi-ca/ms-365-admin-mcp-server` and to GHCR as `ghcr.io/okapi-ca/ms-365-admin-mcp-server`
+- Published to npm as `@okapi_ca/ms-365-admin-mcp-server` and to GHCR as `ghcr.io/okapi-ca/ms-365-admin-mcp-server`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,18 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
-### Added
+## [0.1.0] — 2026-04-17
 
-- `docs/USE_CASES.md` — 15 typical admin scenarios (security monitoring, incident response, PIM hygiene, Intune, eDiscovery, Conditional Access, etc.)
-- `docs/APP_REGISTRATION.md` — step-by-step Azure AD app registration guide
-- `docs/HTTP_DEPLOYMENT.md` — HTTP transport and Azure Container Apps deployment
-- `docs/TROUBLESHOOTING.md` — common errors and diagnosis
-- `docs/ARCHITECTURE.md` — internal architecture and code generation flow
-- `docs/RISK_MODEL.md` — risk classification methodology
-- `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` (MIT), `CHANGELOG.md`
-- `.github/PULL_REQUEST_TEMPLATE.md` and issue templates
-
-## [0.1.0] — 515 tools
+Initial public release. **515 tools** covering Microsoft 365 admin operations via Graph API application permissions.
 
 ### Added
 
 - 71 admin write endpoints, bringing the total to **515 tools** (#26)
 - eDiscovery hold actions exposed via the `response` preset
+- Complete documentation set: `USE_CASES`, `APP_REGISTRATION`, `HTTP_DEPLOYMENT`, `TROUBLESHOOTING`, `ARCHITECTURE`, `RISK_MODEL` (#29, #30)
+- `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` (MIT), `CHANGELOG.md`
+- `.github/PULL_REQUEST_TEMPLATE.md` and issue templates
+- Published to npm as `@okapi-ca/ms-365-admin-mcp-server` and to GHCR as `ghcr.io/okapi-ca/ms-365-admin-mcp-server`
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ms-365-admin-mcp-server
 
+[![CI](https://github.com/okapi-ca/ms-365-admin-mcp-server/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/okapi-ca/ms-365-admin-mcp-server/actions/workflows/ci.yml)
+[![npm version](https://img.shields.io/npm/v/@okapi-ca/ms-365-admin-mcp-server.svg)](https://www.npmjs.com/package/@okapi-ca/ms-365-admin-mcp-server)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for Microsoft 365 administration via Graph API **application permissions** (client credentials).
 
 Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365-mcp-server) which uses delegated permissions. This server is designed for admin operations: security monitoring, identity audits, incident response, and service health.
@@ -36,6 +40,26 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 - A specific tenant ID (not "common")
 
 ## Installation
+
+### npm (recommended)
+
+```bash
+npm install -g @okapi-ca/ms-365-admin-mcp-server
+ms-365-admin-mcp-server --help
+```
+
+### Docker
+
+```bash
+docker pull ghcr.io/okapi-ca/ms-365-admin-mcp-server:latest
+docker run --rm -i \
+  -e MS365_ADMIN_MCP_CLIENT_ID=... \
+  -e MS365_ADMIN_MCP_CLIENT_SECRET=... \
+  -e MS365_ADMIN_MCP_TENANT_ID=... \
+  ghcr.io/okapi-ca/ms-365-admin-mcp-server:latest
+```
+
+### From source
 
 ```bash
 git clone https://github.com/okapi-ca/ms-365-admin-mcp-server.git

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ms-365-admin-mcp-server
 
 [![CI](https://github.com/okapi-ca/ms-365-admin-mcp-server/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/okapi-ca/ms-365-admin-mcp-server/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/@okapi-ca/ms-365-admin-mcp-server.svg)](https://www.npmjs.com/package/@okapi-ca/ms-365-admin-mcp-server)
+[![npm version](https://img.shields.io/npm/v/@okapi_ca/ms-365-admin-mcp-server.svg)](https://www.npmjs.com/package/@okapi_ca/ms-365-admin-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for Microsoft 365 administration via Graph API **application permissions** (client credentials).
@@ -44,7 +44,7 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 ### npm (recommended)
 
 ```bash
-npm install -g @okapi-ca/ms-365-admin-mcp-server
+npm install -g @okapi_ca/ms-365-admin-mcp-server
 ms-365-admin-mcp-server --help
 ```
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,7 @@ export default [
       'bin/**',
       'src/generated/**',
       '.venv/**',
+      '.claude/**',
     ],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ms-365-admin-mcp-server",
+  "name": "@okapi-ca/ms-365-admin-mcp-server",
   "version": "0.1.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
@@ -7,6 +7,23 @@
   "bin": {
     "ms-365-admin-mcp-server": "dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/okapi-ca/ms-365-admin-mcp-server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/okapi-ca/ms-365-admin-mcp-server/issues"
+  },
+  "homepage": "https://github.com/okapi-ca/ms-365-admin-mcp-server#readme",
   "scripts": {
     "generate": "node bin/generate-graph-client.mjs",
     "build": "tsup",
@@ -28,7 +45,7 @@
     "server",
     "graph-api"
   ],
-  "author": "",
+  "author": "okapi-ca",
   "license": "MIT",
   "dependencies": {
     "@azure/msal-node": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@okapi-ca/ms-365-admin-mcp-server",
+  "name": "@okapi_ca/ms-365-admin-mcp-server",
   "version": "0.1.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**', '.claude/**'],
+  },
+});


### PR DESCRIPTION
## Summary

- Scope package as `@okapi-ca/ms-365-admin-mcp-server` (public access)
- Release workflow triggered on `v*` tags:
  - `npm publish --provenance`
  - Multi-arch (amd64/arm64) Docker image to `ghcr.io/okapi-ca/ms-365-admin-mcp-server`
  - GitHub Release creation
- Badges (CI, npm, license) and install instructions (npm + Docker) in README
- `[0.1.0]` dated 2026-04-17 in CHANGELOG
- Exclude stale `.claude/worktrees/**` from eslint, prettier, and vitest

## Before tagging v0.1.0

- [ ] Create `NPM_TOKEN` secret at the repo level (npm automation token with publish rights on `@okapi-ca` scope)
- [ ] Confirm `@okapi-ca` scope exists on npmjs.com and the publisher is a member
- [ ] Verify GHCR is enabled for the repo (default: yes, uses `GITHUB_TOKEN`)

## Test plan

- [x] `npm run verify` passes locally
- [ ] CI green on this PR
- [ ] After merge: push tag `v0.1.0` and confirm release workflow publishes to npm + ghcr

🤖 Generated with [Claude Code](https://claude.com/claude-code)