### PR TITLE
fix(release): use @okapi-ca (hyphen) scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Initial public release. **515 tools** covering Microsoft 365 admin operations vi
 - Complete documentation set: `USE_CASES`, `APP_REGISTRATION`, `HTTP_DEPLOYMENT`, `TROUBLESHOOTING`, `ARCHITECTURE`, `RISK_MODEL` (#29, #30)
 - `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE` (MIT), `CHANGELOG.md`
 - `.github/PULL_REQUEST_TEMPLATE.md` and issue templates
-- Published to npm as `@okapi_ca/ms-365-admin-mcp-server` and to GHCR as `ghcr.io/okapi-ca/ms-365-admin-mcp-server`
+- Published to npm as `@okapi-ca/ms-365-admin-mcp-server` and to GHCR as `ghcr.io/okapi-ca/ms-365-admin-mcp-server`
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ms-365-admin-mcp-server
 
 [![CI](https://github.com/okapi-ca/ms-365-admin-mcp-server/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/okapi-ca/ms-365-admin-mcp-server/actions/workflows/ci.yml)
-[![npm version](https://img.shields.io/npm/v/@okapi_ca/ms-365-admin-mcp-server.svg)](https://www.npmjs.com/package/@okapi_ca/ms-365-admin-mcp-server)
+[![npm version](https://img.shields.io/npm/v/@okapi-ca/ms-365-admin-mcp-server.svg)](https://www.npmjs.com/package/@okapi-ca/ms-365-admin-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server for Microsoft 365 administration via Graph API **application permissions** (client credentials).
@@ -44,7 +44,7 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 ### npm (recommended)
 
 ```bash
-npm install -g @okapi_ca/ms-365-admin-mcp-server
+npm install -g @okapi-ca/ms-365-admin-mcp-server
 ms-365-admin-mcp-server --help
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@okapi_ca/ms-365-admin-mcp-server",
+  "name": "@okapi-ca/ms-365-admin-mcp-server",
   "version": "0.1.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",


### PR DESCRIPTION
## Summary

npm org is `okapi-ca` (hyphen), not `okapi_ca` (underscore). Reverting the package scope so v0.1.0 publishing succeeds.

## Test plan

- [x] `npm run verify` locally
- [ ] CI green
- [ ] After merge: delete tag v0.1.0, re-tag on new main, confirm release workflow publishes to npm + ghcr

🤖 Generated with [Claude Code](https://claude.com/claude-code)