### PR TITLE
infra: switch Container Apps template to UAMI + Key Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -1198,22 +1198,26 @@ docker run -p 8080:8080 \
 
 ### Azure Container Apps
 
-A Bicep skeleton is provided in `infra/main.bicep`. It deploys:
+A Bicep template is provided in `infra/main.bicep`. It deploys:
 
-- Log Analytics workspace
-- Application Insights
+- User-Assigned Managed Identity (UAMI)
+- Key Vault (RBAC, purge protection, 90-day soft-delete)
+- Log Analytics workspace + Application Insights
 - Container App Environment
-- Container App with system-assigned managed identity
+- Container App using the UAMI, with `MS365_ADMIN_MCP_KEYVAULT_URL` wired to the vault
 
 ```bash
+MY_OID=$(az ad signed-in-user show --query id -o tsv)
+
 az deployment group create \
   --resource-group rg-mcp-admin \
   --template-file infra/main.bicep \
-  --parameters containerImage=your-acr.azurecr.io/ms365-admin-mcp:latest \
-               tenantId=your-tenant-id \
-               clientId=your-client-id \
-               clientSecret=your-client-secret
+  --parameters baseName=ms365mcpprod \
+               containerImage=your-acr.azurecr.io/ms365-admin-mcp:latest \
+               kvAdminObjectIds="['$MY_OID']"
 ```
+
+Seed the vault with `ms365-admin-mcp-{client-id,tenant-id,client-secret}` after deploy — see [docs/HTTP_DEPLOYMENT.md](docs/HTTP_DEPLOYMENT.md#seed-key-vault-secrets).
 
 ## Development
 

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -121,10 +121,14 @@ The Docker image runs as a non-root user. Do not mount writable volumes unless n
 
 A reference Bicep template lives at [infra/main.bicep](../infra/main.bicep). It deploys:
 
+- User-Assigned Managed Identity (UAMI)
+- Key Vault (RBAC authorization, purge protection, 90-day soft-delete)
 - Log Analytics workspace (retention 30 days)
 - Application Insights (linked to the workspace)
 - Container App Environment
-- Container App with system-assigned managed identity
+- Container App using the UAMI, with `MS365_ADMIN_MCP_KEYVAULT_URL` wired to the vault
+
+The UAMI is granted `Key Vault Secrets User`; secrets are seeded after deploy (not via Bicep).
 
 ### Deploy
 
@@ -132,24 +136,93 @@ A reference Bicep template lives at [infra/main.bicep](../infra/main.bicep). It 
 # Build and push the image to your ACR
 az acr build --registry <your-acr> --image ms365-admin-mcp:latest .
 
+# Object IDs that should be able to rotate KV secrets (e.g., you + the ops group)
+MY_OID=$(az ad signed-in-user show --query id -o tsv)
+
 # Deploy
 az deployment group create \
   --resource-group rg-mcp-admin \
   --template-file infra/main.bicep \
   --parameters \
+    baseName=ms365mcpprod \
     containerImage=<your-acr>.azurecr.io/ms365-admin-mcp:latest \
-    tenantId=$TENANT_ID \
-    clientId=$CLIENT_ID \
-    clientSecret=$CLIENT_SECRET
+    kvAdminObjectIds="['$MY_OID']"
 ```
+
+### Seed Key Vault secrets
+
+```bash
+KV=$(az deployment group show -g rg-mcp-admin -n main --query properties.outputs.keyVaultName.value -o tsv)
+az keyvault secret set --vault-name $KV --name ms365-admin-mcp-client-id     --value <app-client-id>
+az keyvault secret set --vault-name $KV --name ms365-admin-mcp-tenant-id     --value <tenant-id>
+az keyvault secret set --vault-name $KV --name ms365-admin-mcp-client-secret --value <client-secret>
+
+# Force the Container App to pick up the new secrets on next revision
+APP=$(az deployment group show -g rg-mcp-admin -n main --query properties.outputs.containerAppUrl.value -o tsv | awk -F/ '{print $3}' | cut -d. -f1)
+az containerapp update -n $APP -g rg-mcp-admin --revision-suffix "seed$(date +%s)"
+```
+
+Role-assignment propagation to the UAMI takes ~5 minutes. If the app logs
+`Fetching secrets from Key Vault` followed by a 403, wait and redeploy the revision.
 
 ### Post-deploy recommendations
 
 1. **Front with Application Gateway or Front Door** for WAF and TLS termination.
-2. **Switch to managed identity** — remove the client-secret parameter, assign the Container App's managed identity the Graph permissions directly, and use `DefaultAzureCredential` (requires a code change to swap MSAL client-credentials for managed-identity token acquisition, planned).
-3. **Use Key Vault for the secret** — set `MS365_ADMIN_MCP_KEYVAULT_URL` and store the client secret as `ms365-admin-mcp-client-secret`. Grant the Container App's managed identity `get` access on the vault secrets.
-4. **Log forwarding.** Container App stdout is ingested into Log Analytics. Configure a diagnostic setting to stream to your SIEM.
-5. **Autoscale.** The server is stateless; scale horizontally on request volume or CPU.
+2. **Restrict ingress** with `ipSecurityRestrictions` on the Container App, or mark the ingress as `internal: true` behind a private endpoint if callers are in-VNet.
+3. **Log forwarding.** Container App stdout is ingested into Log Analytics. Configure a diagnostic setting to stream to your SIEM.
+4. **Autoscale.** The server is stateless; scale horizontally on request volume or CPU.
+
+## Operating runbook
+
+### Tail logs
+
+```bash
+az containerapp logs show -n <app> -g <rg> --follow
+```
+
+### Force a restart / new revision
+
+```bash
+az containerapp update -n <app> -g <rg> --revision-suffix "manual$(date +%s)"
+```
+
+### Update the image
+
+```bash
+az containerapp update -n <app> -g <rg> \
+  --image <your-acr>.azurecr.io/ms365-admin-mcp:<new-tag>
+```
+
+### Rotate the client secret
+
+```bash
+# 1. Create a new secret in Entra ID → App registrations → Certificates & secrets
+# 2. Push it to Key Vault (the app reads at startup, so a new revision is needed)
+az keyvault secret set --vault-name <kv> --name ms365-admin-mcp-client-secret --value <new-secret>
+az containerapp update -n <app> -g <rg> --revision-suffix "rotate$(date +%s)"
+# 3. Delete the old secret in Entra ID once the new revision is healthy
+```
+
+### Scale tweak
+
+```bash
+# Keep one warm instance (no cold start)
+az containerapp update -n <app> -g <rg> --min-replicas 1 --max-replicas 5
+```
+
+## Estimated cost (Canada East, 2026)
+
+| Resource         | Config                      | Monthly (idle)                    |
+| ---------------- | --------------------------- | --------------------------------- |
+| Container App    | Consumption, scale 0–3      | ~0 $ scale-to-zero · ~15–25 $ min=1 |
+| Log Analytics    | 30-day retention            | ~2–5 $ depending on log volume    |
+| Key Vault        | Standard, low op volume     | <1 $                              |
+| Managed Identity | UAMI                        | free                              |
+| **Total**        | **scale-to-zero (default)** | **~3–6 $ / month**                |
+| **Total**        | **min=1 replica**           | **~20–30 $ / month**              |
+
+Scale-to-zero produces a cold start of ~2–5 s on the first request after inactivity.
+Set `minReplicas=1` in the Bicep parameters if you cannot tolerate this latency.
 
 ## Observability
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,41 +1,119 @@
-// Azure Container Apps deployment for ms-365-admin-mcp-server
-// Skeleton template — fill in parameters and role assignments before deploying.
+// Azure Container Apps deployment for ms-365-admin-mcp-server.
+// Secrets live in Key Vault (RBAC + purge protection). The Container App reads them
+// via a user-assigned managed identity, using the Key Vault provider in src/secrets.ts.
+//
+// After deploy, seed the vault with:
+//   az keyvault secret set --vault-name <kv> --name ms365-admin-mcp-client-id     --value <...>
+//   az keyvault secret set --vault-name <kv> --name ms365-admin-mcp-tenant-id     --value <...>
+//   az keyvault secret set --vault-name <kv> --name ms365-admin-mcp-client-secret --value <...>
+//
+// Graph API application permissions must be granted to the app registration whose
+// clientId is stored in Key Vault (this template does not touch Entra ID).
 
 @description('Azure region for all resources')
 param location string = resourceGroup().location
 
+@description('Base name used as prefix for all resources (lowercase, 3-20 chars)')
+@minLength(3)
+@maxLength(20)
+param baseName string
+
 @description('Container image to deploy')
 param containerImage string
 
-@description('Azure AD tenant ID for Graph API auth')
-@secure()
-param tenantId string
+@description('Object IDs granted Key Vault Secrets Officer (for seeding/rotating secrets)')
+param kvAdminObjectIds array = []
 
-@description('App registration client ID')
-@secure()
-param clientId string
+@description('Log Analytics retention in days')
+param logRetentionDays int = 30
 
-@description('App registration client secret')
-@secure()
-param clientSecret string
+@description('Container App min replicas (0 enables scale-to-zero)')
+@minValue(0)
+param minReplicas int = 0
 
-// --- Log Analytics Workspace ---
+@description('Container App max replicas')
+@minValue(1)
+param maxReplicas int = 3
+
+var uamiName = '${baseName}-uami'
+var kvName = take('${replace(baseName, '-', '')}kv${uniqueString(resourceGroup().id)}', 24)
+var lawName = '${baseName}-law'
+var appInsightsName = '${baseName}-ai'
+var caeName = '${baseName}-cae'
+var appName = '${baseName}-app'
+
+var kvSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
+var kvSecretsOfficerRoleId = 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7'
+
+// --- User-Assigned Managed Identity ---
+
+resource uami 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: uamiName
+  location: location
+}
+
+// --- Key Vault (RBAC, purge protection, 90-day soft-delete) ---
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: kvName
+  location: location
+  properties: {
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    tenantId: subscription().tenantId
+    enableRbacAuthorization: true
+    enableSoftDelete: true
+    softDeleteRetentionInDays: 90
+    enablePurgeProtection: true
+    publicNetworkAccess: 'Enabled'
+  }
+}
+
+resource uamiKvAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: keyVault
+  name: guid(keyVault.id, uami.id, kvSecretsUserRoleId)
+  properties: {
+    principalId: uami.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      kvSecretsUserRoleId
+    )
+  }
+}
+
+resource kvAdmins 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
+  for oid in kvAdminObjectIds: {
+    scope: keyVault
+    name: guid(keyVault.id, oid, kvSecretsOfficerRoleId)
+    properties: {
+      principalId: oid
+      principalType: 'User'
+      roleDefinitionId: subscriptionResourceId(
+        'Microsoft.Authorization/roleDefinitions',
+        kvSecretsOfficerRoleId
+      )
+    }
+  }
+]
+
+// --- Log Analytics + Application Insights ---
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
-  name: 'law-mcp-admin'
+  name: lawName
   location: location
   properties: {
     sku: {
       name: 'PerGB2018'
     }
-    retentionInDays: 30
+    retentionInDays: logRetentionDays
   }
 }
 
-// --- Application Insights ---
-
 resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
-  name: 'ai-mcp-admin'
+  name: appInsightsName
   location: location
   kind: 'web'
   properties: {
@@ -47,7 +125,7 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' = {
 // --- Container App Environment ---
 
 resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
-  name: 'cae-mcp-admin'
+  name: caeName
   location: location
   properties: {
     appLogsConfiguration: {
@@ -63,11 +141,17 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2024-03-01' = {
 // --- Container App ---
 
 resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
-  name: 'ca-mcp-admin'
+  name: appName
   location: location
   identity: {
-    type: 'SystemAssigned'
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${uami.id}': {}
+    }
   }
+  dependsOn: [
+    uamiKvAccess
+  ]
   properties: {
     managedEnvironmentId: containerAppEnv.id
     configuration: {
@@ -76,11 +160,6 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         targetPort: 8080
         transport: 'http'
       }
-      secrets: [
-        { name: 'client-id', value: clientId }
-        { name: 'client-secret', value: clientSecret }
-        { name: 'tenant-id', value: tenantId }
-      ]
     }
     template: {
       containers: [
@@ -92,25 +171,30 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             memory: '1Gi'
           }
           env: [
-            { name: 'MS365_ADMIN_MCP_CLIENT_ID', secretRef: 'client-id' }
-            { name: 'MS365_ADMIN_MCP_CLIENT_SECRET', secretRef: 'client-secret' }
-            { name: 'MS365_ADMIN_MCP_TENANT_ID', secretRef: 'tenant-id' }
-            { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsights.properties.ConnectionString }
+            {
+              name: 'MS365_ADMIN_MCP_KEYVAULT_URL'
+              value: keyVault.properties.vaultUri
+            }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: uami.properties.clientId
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              value: appInsights.properties.ConnectionString
+            }
           ]
         }
       ]
       scale: {
-        minReplicas: 0
-        maxReplicas: 3
+        minReplicas: minReplicas
+        maxReplicas: maxReplicas
       }
     }
   }
 }
 
-// TODO: Add role assignments for the system-assigned managed identity
-// - Microsoft Graph API permissions cannot be assigned via Bicep directly
-// - Use a post-deployment script with az ad app permission grant
-// - Or use Azure CLI: az role assignment create --assignee <principalId> ...
-
 output containerAppUrl string = 'https://${containerApp.properties.configuration.ingress.fqdn}'
-output principalId string = containerApp.identity.principalId
+output keyVaultName string = keyVault.name
+output uamiPrincipalId string = uami.properties.principalId
+output uamiClientId string = uami.properties.clientId


### PR DESCRIPTION
## Summary
- Replace the placeholder Bicep (which passed `clientSecret` as a secure param) with a hardened deployment: User-Assigned Managed Identity, Key Vault with RBAC + purge protection + 90-day soft-delete, and `Key Vault Secrets User` role for the UAMI.
- Secrets are seeded post-deploy via `az keyvault secret set`, never through Bicep parameters. The Container App reads them via `MS365_ADMIN_MCP_KEYVAULT_URL` and `DefaultAzureCredential` (existing code path in `src/secrets.ts`), with `AZURE_CLIENT_ID` wiring the right UAMI.
- Docs: add an operating runbook (logs, restart, image/secret rotation, scale tweak) and an estimated monthly cost table with a scale-to-zero cold-start note. README bicep example aligned with the new parameters.

## Test plan
- [ ] `az bicep build --file infra/main.bicep` compiles cleanly (verified locally).
- [ ] Deploy to a test RG with `baseName`, `containerImage`, `kvAdminObjectIds` and confirm UAMI + KV + Container App come up.
- [ ] Seed `ms365-admin-mcp-{client-id,tenant-id,client-secret}` in KV, trigger a new revision, and confirm the app logs `Fetching secrets from Key Vault` followed by a successful Graph call.
- [ ] Confirm the UAMI receives `Key Vault Secrets User` on the vault (role propagation ~5 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)