### PR TITLE
chore(release): bump to 0.1.2 with changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-04-19
+
+First release that actually boots on Azure Container Apps end-to-end. The `0.1.0` Docker image crashed at startup because `src/generated/client.ts` was not generated in the builder stage. `0.1.1` was skipped on npm (version not bumped).
+
+### Fixed
+
+- Docker builder now runs `npm run generate` before `npm run build`, so the published image has the client bundle it needs at runtime (#34)
+- Container entrypoint split into `command` + `args` in the reference Bicep, so `node` receives `dist/index.js` instead of treating `--transport` as its own flag (#34)
+- Winston logger now uses `MS365_ADMIN_MCP_LOG_DIR=/tmp/...` by default in the Bicep template, avoiding `EACCES` against `/nonexistent/.ms365-admin-mcp/logs` when the image runs as a rootless user without a home directory (#34)
+
+### Added
+
+- `allowedClients` Bicep parameter (required; HTTP mode refuses to start without it) (#34)
+- `tags` Bicep parameter propagated to every resource, required by org-level AppMapping/CapMapping tag policies (#34)
+- `acrLoginServer` Bicep parameter + `registries` block using the UAMI for AcrPull, to support pulling from a private Azure Container Registry (#34)
+
 ## [0.1.0] — 2026-04-17
 
 Initial public release. **515 tools** covering Microsoft 365 admin operations via Graph API application permissions.
@@ -80,5 +96,6 @@ Initial public release. **515 tools** covering Microsoft 365 admin operations vi
 
 ---
 
-[Unreleased]: https://github.com/okapi-ca/ms-365-admin-mcp-server/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/okapi-ca/ms-365-admin-mcp-server/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/okapi-ca/ms-365-admin-mcp-server/releases/tag/v0.1.2
 [0.1.0]: https://github.com/okapi-ca/ms-365-admin-mcp-server/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@okapi-ca/ms-365-admin-mcp-server",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
v0.1.1 tag built and published the corrected Docker image to GHCR, but npm publish failed with `E403 cannot publish over 0.1.0` because `package.json` was still on 0.1.0. This bumps to 0.1.2 and documents the deploy fixes from #34 in the changelog so the next tag releases cleanly on both registries.

## Test plan
- [x] `npm run format:check` passes.
- [x] `npm run build` succeeds.
- [ ] After merge, tag `v0.1.2` and verify all four release jobs (`verify`, `publish-docker`, `publish-npm`, `github-release`) succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)