### PR TITLE
feat: OAuth 2.0 proxy endpoints for Claude MCP clients (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-04-19
+
+Adds OAuth 2.0 proxy support to the HTTP transport so Claude Desktop, Claude Code, and Claude.ai Web remote MCP connectors can authenticate users through Entra ID without any client-side configuration beyond the server URL.
+
+### Added
+
+- `--oauth-mode` flag enables Entra-backed OAuth 2.0 + PKCE proxy endpoints on the HTTP transport:
+  - `GET /.well-known/oauth-authorization-server` and `GET /.well-known/oauth-protected-resource` metadata
+  - `POST /register` Dynamic Client Registration (stub returning a synthesized `client_id`)
+  - `GET /authorize` 302 to Entra's authorize endpoint, with a two-leg PKCE bridge so the client's `code_challenge` never has to survive the round trip
+  - `POST /token` exchanges `authorization_code` / `refresh_token` grants against Entra using the server-side verifier
+- `--public-url` sets the issuer URL advertised in OAuth metadata (required behind a reverse proxy)
+- `--authorized-users` is a comma-separated allowlist of Entra user `oid` claims; users outside the list get `403`
+- `--no-dynamic-registration` opt-out for the DCR endpoint
+- User-token validation (`src/user-token-validator.ts`) checks signature, issuer, tenant, audience, and the `oid` allowlist
+- Bicep: new `oauthMode`, `authorizedUsers`, `publicUrl` parameters; `allowedClients` is now optional
+
+### Changed
+
+- `--allowed-clients` is no longer mandatory — HTTP transport now requires `--allowed-clients` or `--oauth-mode` (or both)
+- `/mcp` auth middleware tries user-token validation first (if `--oauth-mode`), then service-token validation (if `--allowed-clients`), returning `403` only if both fail
+
+### Security
+
+- User tokens are used only as an authN gate — Graph calls still run with the server's application credentials, so an authenticated user does not gain access to anything beyond the server's granted roles
+
 ## [0.1.2] — 2026-04-19
 
 First release that actually boots on Azure Container Apps end-to-end. The `0.1.0` Docker image crashed at startup because `src/generated/client.ts` was not generated in the builder stage. `0.1.1` was skipped on npm (version not bumped).
@@ -96,6 +122,7 @@ Initial public release. **515 tools** covering Microsoft 365 admin operations vi
 
 ---
 
-[Unreleased]: https://github.com/okapi-ca/ms-365-admin-mcp-server/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/okapi-ca/ms-365-admin-mcp-server/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/okapi-ca/ms-365-admin-mcp-server/releases/tag/v0.2.0
 [0.1.2]: https://github.com/okapi-ca/ms-365-admin-mcp-server/releases/tag/v0.1.2
 [0.1.0]: https://github.com/okapi-ca/ms-365-admin-mcp-server/releases/tag/v0.1.0

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -20,22 +20,79 @@ Do **not** use HTTP when stdio is sufficient — it's simpler and has a smaller 
 
 ## Quick start
 
+Two auth modes are available, and can be combined:
+
+- **Service-to-service** (machine callers): pre-acquired Entra bearer tokens are validated via `--allowed-clients`.
+- **OAuth proxy** (human users on Claude Desktop/Code/Web): the server exposes `/authorize`, `/token`, DCR, and metadata endpoints, delegating auth to Entra and gating by user object ID via `--authorized-users`.
+
 ```bash
+# Machine-to-machine only
 node dist/index.js \
   --transport http \
   --port 8080 \
   --host 127.0.0.1 \
   --allowed-clients "caller-app-id-1,caller-app-id-2"
+
+# Human OAuth only (Claude Desktop/Code/Web)
+node dist/index.js \
+  --transport http \
+  --port 8080 \
+  --host 127.0.0.1 \
+  --oauth-mode \
+  --public-url "https://mcp.example.com" \
+  --authorized-users "<user-oid-1>,<user-oid-2>"
+
+# Both at once
+node dist/index.js \
+  --transport http --port 8080 --host 127.0.0.1 \
+  --allowed-clients "<caller-app-id>" \
+  --oauth-mode --authorized-users "<user-oid>" --public-url "https://mcp.example.com"
 ```
 
-`--allowed-clients` is **mandatory** in HTTP mode. There is no anonymous access.
+At least one of `--allowed-clients` or `--oauth-mode` is **mandatory** in HTTP mode. There is no anonymous access.
 
 Endpoints:
 
 - `GET /health` — unauthenticated liveness probe. Returns `{ status: "ok", transport: "http", timestamp: "..." }`.
 - `POST /mcp`, `DELETE /mcp`, `GET /mcp` — MCP protocol endpoints. Require `Authorization: Bearer <token>`.
 
+When `--oauth-mode` is enabled, the following are added:
+
+- `GET /.well-known/oauth-authorization-server` — AS metadata advertising this server as an OAuth 2.0 authorization server (proxying Entra).
+- `GET /.well-known/oauth-protected-resource` — RS metadata for MCP spec compliance.
+- `POST /register` — Dynamic Client Registration (stub; returns a synthesized `client_id` — all OAuth traffic actually flows through the server's single Entra app).
+- `GET /authorize` — 302-redirects to Entra `/oauth2/v2.0/authorize` using a server-side PKCE verifier that bridges to the client's code_challenge.
+- `POST /token` — exchanges authorization codes / refresh tokens against Entra, substituting the server's PKCE verifier.
+
 ## Authentication model
+
+### OAuth proxy mode (`--oauth-mode`)
+
+The server is an OAuth 2.0 proxy to Entra ID, not a full authorization server. User tokens issued by Entra land on `/mcp` and are validated on each call:
+
+| Check                  | Value                                                                                              |
+| ---------------------- | -------------------------------------------------------------------------------------------------- |
+| Algorithm              | `RS256` (only)                                                                                     |
+| Issuer (`iss`)         | `https://login.microsoftonline.com/<tenant>/v2.0` or `https://sts.windows.net/<tenant>/`           |
+| Tenant (`tid`)         | Must match `MS365_ADMIN_MCP_TENANT_ID`                                                             |
+| Audience (`aud`)       | One of: `<server-app-id>`, `api://<server-app-id>`, `00000003-0000-0000-c000-000000000000` (Graph) |
+| User object ID (`oid`) | Must be present and, if `--authorized-users` is set, in the allowlist                              |
+| Signature              | Verified via `https://login.microsoftonline.com/<tenant>/discovery/v2.0/keys`                      |
+| Clock tolerance        | 30 seconds                                                                                         |
+
+**Important**: the user's token is used only as an **authN gate**. The server does not call Graph on behalf of the user — it calls Graph with its own client-credentials (application permissions), so tool results are identical regardless of which user authenticated.
+
+#### Entra ID setup for OAuth mode
+
+The server's single Entra app registration must have:
+
+- **Web platform** redirect URIs for every client that will authenticate (e.g., `https://claude.ai/api/mcp/auth_callback`, `http://localhost:3000/oauth/callback`, `https://<your-fqdn>/oauth/callback`).
+- **Delegated permissions**: `openid`, `profile`, `email`, `offline_access`, `User.Read` on Microsoft Graph. Admin-consent them once.
+- **Allow public client flows** = Yes (so Claude's PKCE-without-secret clients can exchange codes).
+
+Callers (Claude Desktop/Code/Web) discover the server via `/.well-known/oauth-authorization-server` — no client-side config beyond the server URL.
+
+### Service-to-service mode (`--allowed-clients`)
 
 The server validates the incoming JWT against Microsoft JWKS:
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -38,8 +38,17 @@ param maxReplicas int = 3
 @description('Tags applied to every resource (must satisfy org tag policies)')
 param tags object = {}
 
-@description('Comma-separated Entra app IDs allowed to call the MCP server (required for HTTP transport)')
-param allowedClients string
+@description('Comma-separated Entra app IDs allowed to call the MCP server via service-to-service tokens. Leave empty when only --oauth-mode is used.')
+param allowedClients string = ''
+
+@description('Enable OAuth proxy endpoints (DCR, /authorize, /token) for human-user clients (Claude Desktop/Code/Web).')
+param oauthMode bool = false
+
+@description('Comma-separated Entra user object IDs (oid) authorized to authenticate via OAuth. Required when oauthMode=true.')
+param authorizedUsers string = ''
+
+@description('Public URL that browsers reach the server at (used in OAuth metadata issuer). Leave empty to let the server derive it from request headers.')
+param publicUrl string = ''
 
 @description('Optional Azure Container Registry login server (e.g., myacr.azurecr.io). Leave empty for public images (ghcr, mcr).')
 param acrLoginServer string = ''
@@ -53,6 +62,31 @@ var appName = '${baseName}-app'
 
 var kvSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
 var kvSecretsOfficerRoleId = 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7'
+
+var baseArgs = [
+  '--transport'
+  'http'
+  '--port'
+  '8080'
+  '--host'
+  '0.0.0.0'
+]
+var serviceAuthArgs = empty(allowedClients) ? [] : [
+  '--allowed-clients'
+  allowedClients
+]
+var oauthArgs = oauthMode ? [
+  '--oauth-mode'
+] : []
+var publicUrlArgs = (oauthMode && !empty(publicUrl)) ? [
+  '--public-url'
+  publicUrl
+] : []
+var authorizedUserArgs = (oauthMode && !empty(authorizedUsers)) ? [
+  '--authorized-users'
+  authorizedUsers
+] : []
+var containerArgs = concat(baseArgs, serviceAuthArgs, oauthArgs, publicUrlArgs, authorizedUserArgs)
 
 // --- User-Assigned Managed Identity ---
 
@@ -191,16 +225,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             'node'
             'dist/index.js'
           ]
-          args: [
-            '--transport'
-            'http'
-            '--port'
-            '8080'
-            '--host'
-            '0.0.0.0'
-            '--allowed-clients'
-            allowedClients
-          ]
+          args: containerArgs
           resources: {
             cpu: json('0.5')
             memory: '1Gi'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@okapi-ca/ms-365-admin-mcp-server",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,7 +36,23 @@ program
   .option('--host <address>', 'HTTP bind address (default: 127.0.0.1)', '127.0.0.1')
   .option(
     '--allowed-clients <ids>',
-    'Comma-separated Entra app IDs allowed to connect (required for HTTP mode)'
+    'Comma-separated Entra app IDs allowed to connect via service-to-service tokens (HTTP mode)'
+  )
+  .option(
+    '--oauth-mode',
+    'Enable OAuth proxy endpoints (DCR, /authorize, /token) for human-user MCP clients (Claude Desktop/Code/Web)'
+  )
+  .option(
+    '--public-url <url>',
+    'Public base URL for OAuth metadata (required with --oauth-mode when behind a reverse proxy)'
+  )
+  .option(
+    '--authorized-users <oids>',
+    'Comma-separated Entra user object IDs (oid) allowed to authenticate via OAuth mode'
+  )
+  .option(
+    '--no-dynamic-registration',
+    'Disable the OAuth Dynamic Client Registration endpoint (default: enabled with --oauth-mode)'
   );
 
 export interface CommandOptions {
@@ -54,6 +70,10 @@ export interface CommandOptions {
   port?: string;
   host?: string;
   allowedClients?: string;
+  oauthMode?: boolean;
+  publicUrl?: string;
+  authorizedUsers?: string;
+  dynamicRegistration?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -5,12 +5,16 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import rateLimit from 'express-rate-limit';
 import logger from './logger.js';
 import { validateEntraToken, type TokenValidatorOptions } from './token-validator.js';
+import { validateUserToken, type UserTokenValidatorOptions } from './user-token-validator.js';
+import { registerOAuthRoutes, type OAuthProxyOptions } from './oauth-proxy.js';
 
 export interface HttpServerOptions {
   port: number;
   host?: string;
   server: McpServer;
-  tokenValidatorOptions: TokenValidatorOptions;
+  tokenValidatorOptions?: TokenValidatorOptions;
+  userTokenValidatorOptions?: UserTokenValidatorOptions;
+  oauthProxyOptions?: OAuthProxyOptions;
 }
 
 function securityHeaders(_req: Request, res: Response, next: NextFunction): void {
@@ -26,13 +30,10 @@ function securityHeaders(_req: Request, res: Response, next: NextFunction): void
 export async function startHttpServer(options: HttpServerOptions): Promise<void> {
   const app = express();
 
-  // SEC-07: Security headers on all responses
   app.use(securityHeaders);
-
-  // SEC-05: Explicit body size limit
   app.use(express.json({ limit: '100kb' }));
+  app.use(express.urlencoded({ extended: true, limit: '100kb' }));
 
-  // SEC-04: Rate limiting
   app.use(
     '/mcp',
     rateLimit({
@@ -48,8 +49,20 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     res.json({ status: 'ok', transport: 'http', timestamp: new Date().toISOString() });
   });
 
-  // SEC-03: Auth middleware is always applied (--allowed-clients is mandatory)
-  const validatorOptions = options.tokenValidatorOptions;
+  if (options.oauthProxyOptions) {
+    registerOAuthRoutes(app, options.oauthProxyOptions);
+    logger.info('OAuth proxy routes enabled (/authorize, /token, DCR, metadata)');
+  }
+
+  const serviceValidator = options.tokenValidatorOptions;
+  const userValidator = options.userTokenValidatorOptions;
+
+  if (!serviceValidator && !userValidator) {
+    throw new Error(
+      'HTTP transport requires at least one auth mode: --allowed-clients or --oauth-mode'
+    );
+  }
+
   app.use('/mcp', async (req: Request, res: Response, next: NextFunction) => {
     const authHeader = req.headers.authorization;
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -57,19 +70,29 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
       return;
     }
     const token = authHeader.slice(7);
-    const valid = await validateEntraToken(token, validatorOptions);
-    if (!valid) {
-      res.status(403).json({ error: 'Token validation failed' });
-      return;
+
+    if (userValidator) {
+      const userClaims = await validateUserToken(token, userValidator);
+      if (userClaims) {
+        logger.info(`MCP request authenticated as user ${userClaims.upn ?? userClaims.oid}`);
+        next();
+        return;
+      }
     }
-    next();
+
+    if (serviceValidator) {
+      const serviceValid = await validateEntraToken(token, serviceValidator);
+      if (serviceValid) {
+        next();
+        return;
+      }
+    }
+
+    res.status(403).json({ error: 'Token validation failed' });
   });
 
-  // SEC-12: Wrap handlers in try-catch
   async function handleMcpRequest(req: Request, res: Response): Promise<void> {
     try {
-      // SEC-E: Stateless — each request creates a fresh transport. Session affinity is
-      // handled by the Entra token validation (tenant + allowed-clients).
       const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
       await options.server.connect(transport);
       await transport.handleRequest(req, res, req.body);
@@ -85,7 +108,6 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   app.delete('/mcp', handleMcpRequest);
   app.get('/mcp', handleMcpRequest);
 
-  // SEC-12: Global error handler — suppress stack traces
   app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
     logger.error(`Unhandled Express error: ${err.message}`);
     if (!res.headersSent) {
@@ -93,7 +115,6 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     }
   });
 
-  // SEC-06: Bind to specific host (127.0.0.1 by default)
   const host = options.host || '127.0.0.1';
   app.listen(options.port, host, () => {
     logger.info(`HTTP MCP server listening on ${host}:${options.port}`);

--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -1,0 +1,218 @@
+import crypto from 'crypto';
+import type { Express, Request, Response } from 'express';
+import logger from './logger.js';
+
+export interface OAuthProxyOptions {
+  publicUrl: string;
+  tenantId: string;
+  clientId: string;
+  clientSecret?: string;
+  scopes: string[];
+  enableDynamicRegistration: boolean;
+}
+
+interface PkceEntry {
+  serverVerifier: string;
+  redirectUri: string;
+  expiresAt: number;
+}
+
+const PKCE_TTL_MS = 10 * 60 * 1000;
+const PKCE_MAX_ENTRIES = 1000;
+const pkceBridge = new Map<string, PkceEntry>();
+
+function pruneExpired(): void {
+  const now = Date.now();
+  if (pkceBridge.size <= PKCE_MAX_ENTRIES) {
+    for (const [k, v] of pkceBridge) {
+      if (v.expiresAt < now) pkceBridge.delete(k);
+    }
+    return;
+  }
+  const entries = [...pkceBridge.entries()].sort((a, b) => a[1].expiresAt - b[1].expiresAt);
+  for (let i = 0; i < entries.length - PKCE_MAX_ENTRIES; i++) {
+    pkceBridge.delete(entries[i][0]);
+  }
+}
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function sha256Base64url(input: string): string {
+  return base64url(crypto.createHash('sha256').update(input).digest());
+}
+
+function randomVerifier(): string {
+  return base64url(crypto.randomBytes(64));
+}
+
+function stripTrailingSlash(s: string): string {
+  return s.endsWith('/') ? s.slice(0, -1) : s;
+}
+
+function resolveIssuer(req: Request, configured: string): string {
+  if (configured) return stripTrailingSlash(configured);
+  const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol;
+  const host = (req.headers['x-forwarded-host'] as string) || req.headers.host;
+  return `${proto}://${host}`;
+}
+
+export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): void {
+  const authority = `https://login.microsoftonline.com/${options.tenantId}`;
+  const fallbackScope = 'openid profile email offline_access User.Read';
+
+  app.get('/.well-known/oauth-authorization-server', (req: Request, res: Response) => {
+    const issuer = resolveIssuer(req, options.publicUrl);
+    res.json({
+      issuer,
+      authorization_endpoint: `${issuer}/authorize`,
+      token_endpoint: `${issuer}/token`,
+      registration_endpoint: options.enableDynamicRegistration ? `${issuer}/register` : undefined,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      code_challenge_methods_supported: ['S256'],
+      token_endpoint_auth_methods_supported: ['none'],
+      scopes_supported: options.scopes.length > 0 ? options.scopes : fallbackScope.split(' '),
+    });
+  });
+
+  app.get('/.well-known/oauth-protected-resource', (req: Request, res: Response) => {
+    const issuer = resolveIssuer(req, options.publicUrl);
+    res.json({
+      resource: `${issuer}/mcp`,
+      authorization_servers: [issuer],
+      bearer_methods_supported: ['header'],
+    });
+  });
+
+  if (options.enableDynamicRegistration) {
+    app.post('/register', (req: Request, res: Response) => {
+      const body = req.body ?? {};
+      const clientId = `mcp-client-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
+      res.status(201).json({
+        client_id: clientId,
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        redirect_uris: body.redirect_uris ?? [],
+        grant_types: body.grant_types ?? ['authorization_code', 'refresh_token'],
+        response_types: body.response_types ?? ['code'],
+        token_endpoint_auth_method: 'none',
+        scope: body.scope ?? fallbackScope,
+      });
+    });
+  }
+
+  app.get('/authorize', (req: Request, res: Response) => {
+    const {
+      redirect_uri: redirectUri,
+      state,
+      code_challenge: clientChallenge,
+      code_challenge_method: clientChallengeMethod,
+      scope,
+    } = req.query as Record<string, string | undefined>;
+
+    if (!redirectUri || !clientChallenge) {
+      res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'Missing redirect_uri or code_challenge',
+      });
+      return;
+    }
+    if (clientChallengeMethod && clientChallengeMethod !== 'S256') {
+      res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'Only S256 code_challenge_method is supported',
+      });
+      return;
+    }
+
+    pruneExpired();
+    const serverVerifier = randomVerifier();
+    const serverChallenge = sha256Base64url(serverVerifier);
+    pkceBridge.set(clientChallenge, {
+      serverVerifier,
+      redirectUri,
+      expiresAt: Date.now() + PKCE_TTL_MS,
+    });
+
+    const upstream = new URL(`${authority}/oauth2/v2.0/authorize`);
+    upstream.searchParams.set('client_id', options.clientId);
+    upstream.searchParams.set('response_type', 'code');
+    upstream.searchParams.set('redirect_uri', redirectUri);
+    upstream.searchParams.set('response_mode', 'query');
+    upstream.searchParams.set('scope', scope || fallbackScope);
+    upstream.searchParams.set('code_challenge', serverChallenge);
+    upstream.searchParams.set('code_challenge_method', 'S256');
+    if (state) upstream.searchParams.set('state', state);
+
+    res.redirect(302, upstream.toString());
+  });
+
+  app.post('/token', async (req: Request, res: Response) => {
+    const body = req.body ?? {};
+    const grantType = body.grant_type;
+
+    const form = new URLSearchParams();
+    form.set('client_id', options.clientId);
+    if (options.clientSecret) form.set('client_secret', options.clientSecret);
+
+    if (grantType === 'authorization_code') {
+      const code = body.code as string | undefined;
+      const clientVerifier = body.code_verifier as string | undefined;
+      const redirectUri = body.redirect_uri as string | undefined;
+
+      if (!code || !clientVerifier || !redirectUri) {
+        res.status(400).json({
+          error: 'invalid_request',
+          error_description: 'Missing code, code_verifier, or redirect_uri',
+        });
+        return;
+      }
+
+      const clientChallenge = sha256Base64url(clientVerifier);
+      const bridge = pkceBridge.get(clientChallenge);
+      if (!bridge || bridge.expiresAt < Date.now()) {
+        res.status(400).json({
+          error: 'invalid_grant',
+          error_description: 'PKCE bridge entry missing or expired',
+        });
+        return;
+      }
+      pkceBridge.delete(clientChallenge);
+
+      form.set('grant_type', 'authorization_code');
+      form.set('code', code);
+      form.set('redirect_uri', redirectUri);
+      form.set('code_verifier', bridge.serverVerifier);
+    } else if (grantType === 'refresh_token') {
+      const refreshToken = body.refresh_token as string | undefined;
+      if (!refreshToken) {
+        res
+          .status(400)
+          .json({ error: 'invalid_request', error_description: 'Missing refresh_token' });
+        return;
+      }
+      form.set('grant_type', 'refresh_token');
+      form.set('refresh_token', refreshToken);
+      if (body.scope) form.set('scope', body.scope as string);
+    } else {
+      res.status(400).json({ error: 'unsupported_grant_type' });
+      return;
+    }
+
+    try {
+      const upstream = await fetch(`${authority}/oauth2/v2.0/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: form.toString(),
+      });
+      const payload = await upstream.text();
+      res.status(upstream.status).type('application/json').send(payload);
+    } catch (error) {
+      logger.error(`Entra token exchange failed: ${(error as Error).message}`);
+      res
+        .status(502)
+        .json({ error: 'server_error', error_description: 'Upstream token exchange failed' });
+    }
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -54,10 +54,9 @@ class AdminGraphServer {
     }
 
     if (this.options.transport === 'http') {
-      if (!this.options.allowedClients) {
+      if (!this.options.allowedClients && !this.options.oauthMode) {
         throw new Error(
-          '--allowed-clients is required when using --transport http. ' +
-            'Provide comma-separated Entra app IDs to secure the HTTP endpoint.'
+          'HTTP transport requires at least one auth mode: --allowed-clients (service-to-service) or --oauth-mode (human users).'
         );
       }
 
@@ -67,17 +66,47 @@ class AdminGraphServer {
         throw new Error(`Invalid port: ${this.options.port}. Must be between 1 and 65535.`);
       }
 
-      const tokenValidatorOptions = {
-        tenantId: this.secrets!.tenantId,
-        allowedClientIds: this.options.allowedClients.split(',').map((id: string) => id.trim()),
-        expectedAudience: `api://${this.secrets!.clientId}`,
-      };
+      const tokenValidatorOptions = this.options.allowedClients
+        ? {
+            tenantId: this.secrets!.tenantId,
+            allowedClientIds: this.options.allowedClients.split(',').map((id: string) => id.trim()),
+            expectedAudience: `api://${this.secrets!.clientId}`,
+          }
+        : undefined;
+
+      const userTokenValidatorOptions = this.options.oauthMode
+        ? {
+            tenantId: this.secrets!.tenantId,
+            expectedAudiences: [
+              this.secrets!.clientId,
+              `api://${this.secrets!.clientId}`,
+              '00000003-0000-0000-c000-000000000000',
+            ],
+            authorizedUserOids: (this.options.authorizedUsers || '')
+              .split(',')
+              .map((o: string) => o.trim())
+              .filter(Boolean),
+          }
+        : undefined;
+
+      const oauthProxyOptions = this.options.oauthMode
+        ? {
+            publicUrl: this.options.publicUrl || '',
+            tenantId: this.secrets!.tenantId,
+            clientId: this.secrets!.clientId,
+            clientSecret: this.secrets!.clientSecret,
+            scopes: ['openid', 'profile', 'email', 'offline_access', 'User.Read'],
+            enableDynamicRegistration: this.options.dynamicRegistration !== false,
+          }
+        : undefined;
 
       await startHttpServer({
         port,
         host: this.options.host || '127.0.0.1',
         server: this.server!,
         tokenValidatorOptions,
+        userTokenValidatorOptions,
+        oauthProxyOptions,
       });
       logger.info(`Server connected to HTTP transport on port ${port}`);
     } else {

--- a/src/user-token-validator.ts
+++ b/src/user-token-validator.ts
@@ -1,0 +1,123 @@
+import jwt from 'jsonwebtoken';
+import jwksRsa from 'jwks-rsa';
+import logger from './logger.js';
+
+export interface UserTokenValidatorOptions {
+  tenantId: string;
+  expectedAudiences: string[];
+  authorizedUserOids: string[];
+}
+
+export interface UserTokenClaims {
+  oid: string;
+  upn?: string;
+  name?: string;
+  appid?: string;
+}
+
+interface UserTokenPayload {
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  oid?: string;
+  upn?: string;
+  preferred_username?: string;
+  name?: string;
+  tid?: string;
+  appid?: string;
+  azp?: string;
+  scp?: string;
+}
+
+const jwksClients = new Map<string, jwksRsa.JwksClient>();
+
+function getJwksClient(tenantId: string): jwksRsa.JwksClient {
+  let client = jwksClients.get(tenantId);
+  if (!client) {
+    client = jwksRsa({
+      jwksUri: `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`,
+      cache: true,
+      cacheMaxAge: 600_000,
+      rateLimit: true,
+    });
+    jwksClients.set(tenantId, client);
+  }
+  return client;
+}
+
+function getSigningKey(client: jwksRsa.JwksClient, header: jwt.JwtHeader): Promise<string> {
+  return new Promise((resolve, reject) => {
+    if (!header.kid) {
+      reject(new Error('JWT header missing kid'));
+      return;
+    }
+    client.getSigningKey(header.kid, (err, key) => {
+      if (err) return reject(err);
+      if (!key) return reject(new Error('No signing key found'));
+      resolve(key.getPublicKey());
+    });
+  });
+}
+
+function audienceMatches(tokenAud: string | string[] | undefined, expected: string[]): boolean {
+  if (!tokenAud || expected.length === 0) return false;
+  const list = Array.isArray(tokenAud) ? tokenAud : [tokenAud];
+  return list.some((a) => expected.includes(a));
+}
+
+export async function validateUserToken(
+  token: string,
+  options: UserTokenValidatorOptions
+): Promise<UserTokenClaims | null> {
+  try {
+    const client = getJwksClient(options.tenantId);
+
+    const decoded = jwt.decode(token, { complete: true });
+    if (!decoded || typeof decoded === 'string') {
+      logger.warn('User token could not be decoded');
+      return null;
+    }
+
+    const publicKey = await getSigningKey(client, decoded.header);
+
+    const payload = jwt.verify(token, publicKey, {
+      algorithms: ['RS256'],
+      issuer: [
+        `https://login.microsoftonline.com/${options.tenantId}/v2.0`,
+        `https://sts.windows.net/${options.tenantId}/`,
+      ],
+      clockTolerance: 30,
+    }) as UserTokenPayload;
+
+    if (payload.tid && payload.tid !== options.tenantId) {
+      logger.warn('User token tenant mismatch');
+      return null;
+    }
+
+    if (!audienceMatches(payload.aud, options.expectedAudiences)) {
+      logger.warn('User token audience not in expected list');
+      return null;
+    }
+
+    const oid = payload.oid;
+    if (!oid) {
+      logger.warn('User token missing oid claim');
+      return null;
+    }
+
+    if (options.authorizedUserOids.length > 0 && !options.authorizedUserOids.includes(oid)) {
+      logger.warn(`User oid ${oid} not in authorized-users allowlist`);
+      return null;
+    }
+
+    return {
+      oid,
+      upn: payload.upn || payload.preferred_username,
+      name: payload.name,
+      appid: payload.appid || payload.azp,
+    };
+  } catch (error) {
+    logger.error(`User token validation failed: ${(error as Error).message}`);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Adds OAuth 2.0 + PKCE proxy to the HTTP transport so Claude Desktop, Claude Code, and Claude.ai Web remote MCP connectors can authenticate users via Entra ID with zero client-side configuration beyond the server URL. Mirrors the [softeria/ms-365-mcp-server](https://github.com/softeria/ms-365-mcp-server) pattern, adapted to this fork's application-permissions model.

## Key design decision
The user's Entra token is used **only as an authN gate**. All Graph calls still run with the server's `client_credentials` (application permissions) — tool results are identical regardless of which user authenticated. User tokens are validated for signature, issuer, tenant, audience, and `oid`-allowlist membership.

## New endpoints (with `--oauth-mode`)
- `GET /.well-known/oauth-authorization-server` — AS metadata
- `GET /.well-known/oauth-protected-resource` — RS metadata
- `POST /register` — DCR stub (synthesized `client_id`)
- `GET /authorize` — 302 to Entra with two-leg PKCE bridge
- `POST /token` — exchanges `authorization_code` + `refresh_token` against Entra

## New CLI flags
- `--oauth-mode`, `--public-url <url>`, `--authorized-users <oids>`, `--no-dynamic-registration`
- `--allowed-clients` is now **optional** — HTTP mode requires at least one of `--allowed-clients` or `--oauth-mode` (both can be combined)

## Bicep
New parameters: `oauthMode` (bool), `authorizedUsers` (string), `publicUrl` (string). Container args are built conditionally. `allowedClients` is now optional.

## Entra ID prerequisites for OAuth mode
Document on the server app registration:
- **Web** redirect URIs per client (`https://claude.ai/api/mcp/auth_callback`, `http://localhost:3000/oauth/callback`, `https://<fqdn>/oauth/callback`)
- **Delegated** permissions: `openid`, `profile`, `email`, `offline_access`, `User.Read` on Graph, admin-consented
- `isFallbackPublicClient = true`

## Test plan
- [x] `npm run verify` (format, lint, build, tests) all green
- [x] Local smoke test: `/health`, metadata endpoints, `/register`, `/authorize` 302 to Entra, `/mcp` 401 without token — all correct
- [ ] After merge + `v0.2.0` tag: release workflow publishes npm + GHCR images
- [ ] Redeploy Container App with `oauthMode=true` + authorized-users and verify Claude.ai Web DCR flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)