### PR TITLE
fix(http): add WWW-Authenticate on /mcp 401/403 for OAuth discovery (v0.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.2.1] — 2026-04-20
+
+Fixes the OAuth 2.0 discovery flow so Claude.ai Web and Claude Desktop can actually complete authorization against an OAuth-mode HTTP deployment.
+
+### Fixed
+
+- `/mcp` now returns `WWW-Authenticate: Bearer resource_metadata="…"` on `401` (missing token) and `WWW-Authenticate: Bearer resource_metadata="…", error="invalid_token"` on `403` (token validation failure). Without this header Claude clients could not discover the protected-resource metadata and surfaced `Authorization with the MCP server failed` before ever reaching `/authorize`.
+- Express `trust proxy` is now set to `1` so `X-Forwarded-For` from the Container Apps / reverse-proxy edge stops tripping the `express-rate-limit` validator (`ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`).
+
 ## [0.2.0] — 2026-04-19
 
 Adds OAuth 2.0 proxy support to the HTTP transport so Claude Desktop, Claude Code, and Claude.ai Web remote MCP connectors can authenticate users through Entra ID without any client-side configuration beyond the server URL.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -27,9 +27,21 @@ function securityHeaders(_req: Request, res: Response, next: NextFunction): void
   next();
 }
 
+function stripTrailingSlash(s: string): string {
+  return s.endsWith('/') ? s.slice(0, -1) : s;
+}
+
+function resourceMetadataUrl(req: Request, publicUrl?: string): string {
+  if (publicUrl) return `${stripTrailingSlash(publicUrl)}/.well-known/oauth-protected-resource`;
+  const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol;
+  const host = (req.headers['x-forwarded-host'] as string) || req.headers.host;
+  return `${proto}://${host}/.well-known/oauth-protected-resource`;
+}
+
 export async function startHttpServer(options: HttpServerOptions): Promise<void> {
   const app = express();
 
+  app.set('trust proxy', 1);
   app.use(securityHeaders);
   app.use(express.json({ limit: '100kb' }));
   app.use(express.urlencoded({ extended: true, limit: '100kb' }));
@@ -63,9 +75,21 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     );
   }
 
+  const oauthPublicUrl = options.oauthProxyOptions?.publicUrl;
+  const oauthEnabled = Boolean(options.oauthProxyOptions);
+
+  function setChallengeHeader(req: Request, res: Response, errorCode?: string): void {
+    if (!oauthEnabled) return;
+    const metadata = resourceMetadataUrl(req, oauthPublicUrl);
+    const parts = [`resource_metadata="${metadata}"`];
+    if (errorCode) parts.push(`error="${errorCode}"`);
+    res.setHeader('WWW-Authenticate', `Bearer ${parts.join(', ')}`);
+  }
+
   app.use('/mcp', async (req: Request, res: Response, next: NextFunction) => {
     const authHeader = req.headers.authorization;
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      setChallengeHeader(req, res);
       res.status(401).json({ error: 'Missing or invalid Authorization header' });
       return;
     }
@@ -88,6 +112,7 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
       }
     }
 
+    setChallengeHeader(req, res, 'invalid_token');
     res.status(403).json({ error: 'Token validation failed' });
   });
 


### PR DESCRIPTION
## Summary
- Claude.ai Web / Desktop could not complete OAuth against the `--oauth-mode` HTTP transport: the `/mcp` 401 lacked the `WWW-Authenticate: Bearer resource_metadata="…"` challenge, so the client never discovered the protected-resource metadata and surfaced *"Authorization with the MCP server failed"* before reaching `/authorize`.
- Adds the challenge header on both `401` (missing token) and `403` (invalid token, `error="invalid_token"`), using `--public-url` when set or `X-Forwarded-Proto`/`Host` as fallback.
- Sets Express `trust proxy` to `1` so `express-rate-limit` stops tripping on the edge-added `X-Forwarded-For` (`ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` in logs).
- Bumps version to `0.2.1` with CHANGELOG entry.

## Test plan
- [x] `npm run lint` — clean (pre-existing warning in `logger.ts` only)
- [x] `npm run build` — green
- [x] `npm run test` — 3/3 passing after `npm run generate`
- [ ] After tag `v0.2.1` → CI publishes npm + `ghcr.io/okapi-ca/ms-365-admin-mcp-server:0.2.1`
- [ ] Update Container App revision, confirm `/mcp` now returns `WWW-Authenticate` on unauthenticated requests
- [ ] End-to-end OAuth flow from Claude.ai Web connects successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)