### PR TITLE
chore(observability): console logs in HTTP mode + OAuth trace (v0.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.2.2] — 2026-04-20
+
+Observability fix: logs were written only to files inside the container, so nothing showed up in Log Analytics and post-Entra OAuth failures were invisible.
+
+### Changed
+
+- HTTP transport now auto-enables the Winston Console transport (`-v` still forces it on stdio). stdio mode still keeps stdout clean for the JSON-RPC stream.
+- OAuth proxy logs each `/authorize` redirect (redirect_uri, scope) and each `/token` exchange (`grant_type`, Entra HTTP status and body excerpt on failure).
+- `/mcp` auth middleware logs 401/403 outcomes with the method/path.
+- User-token validator failure logs now include the offending `aud`, `tid`, and `upn` so the root cause of a rejected token is obvious.
+
 ## [0.2.1] — 2026-04-20
 
 Fixes the OAuth 2.0 discovery flow so Claude.ai Web and Claude Desktop can actually complete authorization against an OAuth-mode HTTP deployment.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -89,6 +89,7 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   app.use('/mcp', async (req: Request, res: Response, next: NextFunction) => {
     const authHeader = req.headers.authorization;
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      logger.info(`MCP ${req.method} ${req.path} → 401 (no bearer)`);
       setChallengeHeader(req, res);
       res.status(401).json({ error: 'Missing or invalid Authorization header' });
       return;
@@ -112,6 +113,7 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
       }
     }
 
+    logger.warn(`MCP ${req.method} ${req.path} → 403 (token validation failed)`);
     setChallengeHeader(req, res, 'invalid_token');
     res.status(403).json({ error: 'Token validation failed' });
   });

--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -112,6 +112,7 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     } = req.query as Record<string, string | undefined>;
 
     if (!redirectUri || !clientChallenge) {
+      logger.warn('OAuth /authorize rejected: missing redirect_uri or code_challenge');
       res.status(400).json({
         error: 'invalid_request',
         error_description: 'Missing redirect_uri or code_challenge',
@@ -119,6 +120,9 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       return;
     }
     if (clientChallengeMethod && clientChallengeMethod !== 'S256') {
+      logger.warn(
+        `OAuth /authorize rejected: unsupported challenge method ${clientChallengeMethod}`
+      );
       res.status(400).json({
         error: 'invalid_request',
         error_description: 'Only S256 code_challenge_method is supported',
@@ -145,6 +149,9 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     upstream.searchParams.set('code_challenge_method', 'S256');
     if (state) upstream.searchParams.set('state', state);
 
+    logger.info(
+      `OAuth /authorize → Entra (redirect_uri=${redirectUri}, scope=${scope || fallbackScope})`
+    );
     res.redirect(302, upstream.toString());
   });
 
@@ -207,6 +214,13 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
         body: form.toString(),
       });
       const payload = await upstream.text();
+      if (upstream.status >= 400) {
+        logger.warn(
+          `Entra /token returned ${upstream.status} for grant_type=${grantType}: ${payload.slice(0, 500)}`
+        );
+      } else {
+        logger.info(`Entra /token exchange ok (grant_type=${grantType})`);
+      }
       res.status(upstream.status).type('application/json').send(payload);
     } catch (error) {
       logger.error(`Entra token exchange failed: ${(error as Error).message}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,7 @@ class AdminGraphServer {
   }
 
   async start(): Promise<void> {
-    if (this.options.v) {
+    if (this.options.v || this.options.transport === 'http') {
       enableConsoleLogging();
     }
 

--- a/src/user-token-validator.ts
+++ b/src/user-token-validator.ts
@@ -90,12 +90,14 @@ export async function validateUserToken(
     }) as UserTokenPayload;
 
     if (payload.tid && payload.tid !== options.tenantId) {
-      logger.warn('User token tenant mismatch');
+      logger.warn(`User token tenant mismatch: tid=${payload.tid}, expected=${options.tenantId}`);
       return null;
     }
 
     if (!audienceMatches(payload.aud, options.expectedAudiences)) {
-      logger.warn('User token audience not in expected list');
+      logger.warn(
+        `User token audience not in expected list: aud=${JSON.stringify(payload.aud)}, expected=${JSON.stringify(options.expectedAudiences)}`
+      );
       return null;
     }
 
@@ -106,7 +108,9 @@ export async function validateUserToken(
     }
 
     if (options.authorizedUserOids.length > 0 && !options.authorizedUserOids.includes(oid)) {
-      logger.warn(`User oid ${oid} not in authorized-users allowlist`);
+      logger.warn(
+        `User oid ${oid} (${payload.upn || payload.preferred_username || 'no upn'}) not in authorized-users allowlist`
+      );
       return null;
     }
 


### PR DESCRIPTION
## Summary
- Winston console transport was only added with \`-v\`, so HTTP-mode deployments produced zero logs in Log Analytics. Post-Entra OAuth failures were invisible.
- Auto-enable Winston Console when \`transport=http\` (stdio stays clean).
- Add info/warn logs around \`/authorize\`, \`/token\`, and \`/mcp\` auth so we can see exactly where an OAuth flow fails.
- User-token validator rejection messages now include the offending \`aud\`, \`tid\`, and \`upn\`.

## Test plan
- [x] \`npm run lint\` clean (pre-existing logger warning only)
- [x] \`npm run build\` green
- [x] \`npm run test\` 3/3
- [ ] Deploy \`0.2.2\` image, confirm logs appear in Log Analytics, capture the real reason the OAuth flow fails after SSO

🤖 Generated with [Claude Code](https://claude.com/claude-code)