### PR TITLE
fix(oauth): switch default scope to api://<client>/access_as_user (v0.2.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.2.3] — 2026-04-20
+
+Fixes the OAuth 2.0 flow end-to-end: access tokens can now actually be validated by the MCP server. v0.2.0 → v0.2.2 produced `invalid signature` failures because Microsoft Graph access tokens (`aud=00000003-…`) are opaque and cannot be verified by third parties against the public JWKS.
+
+### Changed
+
+- OAuth proxy now defaults to requesting the app's own API scope (`api://<client-id>/access_as_user`) alongside `openid profile email offline_access`, so Entra issues a standard v2 JWT with `aud=<client-id>` signed with the tenant's publishable key.
+- When the caller supplies custom `scopes`, the proxy honours them; otherwise it falls back to the app-owned scope above.
+
+### Deployment note
+
+The Entra app registration must expose the delegated scope `access_as_user` under `api://<client-id>` with `requestedAccessTokenVersion: 2`, and admin consent must be granted for that scope. This was done on the LCI deployment as part of the 0.2.3 rollout.
+
 ## [0.2.2] — 2026-04-20
 
 Observability fix: logs were written only to files inside the container, so nothing showed up in Log Analytics and post-Entra OAuth failures were invisible.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -60,7 +60,10 @@ function resolveIssuer(req: Request, configured: string): string {
 
 export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): void {
   const authority = `https://login.microsoftonline.com/${options.tenantId}`;
-  const fallbackScope = 'openid profile email offline_access User.Read';
+  const fallbackScope =
+    options.scopes.length > 0
+      ? options.scopes.join(' ')
+      : `openid profile email offline_access api://${options.clientId}/access_as_user`;
 
   app.get('/.well-known/oauth-authorization-server', (req: Request, res: Response) => {
     const issuer = resolveIssuer(req, options.publicUrl);

--- a/src/server.ts
+++ b/src/server.ts
@@ -95,7 +95,13 @@ class AdminGraphServer {
             tenantId: this.secrets!.tenantId,
             clientId: this.secrets!.clientId,
             clientSecret: this.secrets!.clientSecret,
-            scopes: ['openid', 'profile', 'email', 'offline_access', 'User.Read'],
+            scopes: [
+              'openid',
+              'profile',
+              'email',
+              'offline_access',
+              `api://${this.secrets!.clientId}/access_as_user`,
+            ],
             enableDynamicRegistration: this.options.dynamicRegistration !== false,
           }
         : undefined;


### PR DESCRIPTION
## Summary
Root cause of the post-Entra OAuth failure: the proxy was requesting \`User.Read\`, so Entra issued a Microsoft Graph access token (\`aud=00000003-…\`). Graph tokens are opaque to third parties — they can't be signature-verified against the tenant JWKS — so every \`/mcp\` call came back with \`403 User token validation failed: invalid signature\`.

Fix: request the MCP app's own delegated API scope (\`api://<client-id>/access_as_user\`). Entra then returns a standard v2 JWT with \`aud=<client-id>\`, signed with the published tenant key the validator already accepts.

## Deployment prerequisite
Already applied on the LCI deployment:
- Added \`identifierUris = api://86f46c1e-…\` to the app
- Exposed \`access_as_user\` (User consent, v2 tokens)
- Granted admin consent (\`oauth2PermissionGrants\`, consentType AllPrincipals)

For other deployments, do the same before upgrading to 0.2.3.

## Test plan
- [x] \`npm run verify\` (generate + lint + format + build + test) green
- [ ] Roll 0.2.3 to LCI Container App, retry SSO flow, confirm token now validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)