### PR TITLE
fix(http): per-request MCP server to unbreak Streamable HTTP (v0.2.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.2.4] — 2026-04-20
+
+Fixes the StreamableHTTP transport so more than one `/mcp` request per process actually works. With the shared `McpServer` instance, the second call to `server.connect(transport)` threw `Already connected to a transport`, which surfaced as repeated 500s after the OAuth flow finally succeeded.
+
+### Fixed
+
+- HTTP mode now builds a fresh `McpServer` + `StreamableHTTPServerTransport` per request and closes both on `res.close`. The `server` parameter of `startHttpServer` is replaced with a `createServer: () => McpServer` factory.
+
 ## [0.2.3] — 2026-04-20
 
 Fixes the OAuth 2.0 flow end-to-end: access tokens can now actually be validated by the MCP server. v0.2.0 → v0.2.2 produced `invalid signature` failures because Microsoft Graph access tokens (`aud=00000003-…`) are opaque and cannot be verified by third parties against the public JWKS.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -11,7 +11,7 @@ import { registerOAuthRoutes, type OAuthProxyOptions } from './oauth-proxy.js';
 export interface HttpServerOptions {
   port: number;
   host?: string;
-  server: McpServer;
+  createServer: () => McpServer;
   tokenValidatorOptions?: TokenValidatorOptions;
   userTokenValidatorOptions?: UserTokenValidatorOptions;
   oauthProxyOptions?: OAuthProxyOptions;
@@ -119,9 +119,14 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   });
 
   async function handleMcpRequest(req: Request, res: Response): Promise<void> {
+    const server = options.createServer();
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    res.on('close', () => {
+      void transport.close().catch(() => {});
+      void server.close().catch(() => {});
+    });
     try {
-      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
-      await options.server.connect(transport);
+      await server.connect(transport);
       await transport.handleRequest(req, res, req.body);
     } catch (error) {
       logger.error(`MCP request error: ${(error as Error).message}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,17 +28,16 @@ class AdminGraphServer {
     this.version = version;
     this.graphClient = new GraphClient(this.authManager, this.secrets);
 
-    this.server = new McpServer({
+    this.server = this.createServer();
+  }
+
+  private createServer(): McpServer {
+    const server = new McpServer({
       name: 'Microsoft365AdminMCP',
       version: this.version,
     });
-
-    registerGraphTools(
-      this.server,
-      this.graphClient,
-      this.options.readOnly,
-      this.options.enabledTools
-    );
+    registerGraphTools(server, this.graphClient!, this.options.readOnly, this.options.enabledTools);
+    return server;
   }
 
   async start(): Promise<void> {
@@ -109,7 +108,7 @@ class AdminGraphServer {
       await startHttpServer({
         port,
         host: this.options.host || '127.0.0.1',
-        server: this.server!,
+        createServer: () => this.createServer(),
         tokenValidatorOptions,
         userTokenValidatorOptions,
         oauthProxyOptions,


### PR DESCRIPTION
## Summary
After 0.2.3 unblocked token validation, every authenticated \`/mcp\` call crashed with:

\`\`\`
MCP request error: Already connected to a transport. Call close() before connecting to a new transport, or use a separate Protocol instance per connection.
\`\`\`

Cause: \`handleMcpRequest\` created a fresh \`StreamableHTTPServerTransport\` per request but called \`connect()\` on the single shared \`McpServer\` — the second call throws.

Fix: accept a \`createServer: () => McpServer\` factory in \`HttpServerOptions\`, spin up a fresh \`McpServer\` + transport per request, and close both on \`res.close\`. stdio stays on the one eager-initialised instance.

## Test plan
- [x] \`npm run verify\` green
- [ ] Redeploy to LCI, retry SSO from Claude.ai, confirm tool calls actually reach the MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)