### PR TITLE
docs(playbooks): add 4 security incident response playbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Complementary to [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365
 | Document                                             | Purpose                                                       |
 | ---------------------------------------------------- | ------------------------------------------------------------- |
 | [docs/USE_CASES.md](docs/USE_CASES.md)               | 15 typical admin scenarios with sample prompts and tool lists |
+| [docs/playbooks/](docs/playbooks/README.md)          | End-to-end security incident response playbooks               |
 | [docs/APP_REGISTRATION.md](docs/APP_REGISTRATION.md) | Step-by-step Azure AD app registration and permission consent |
 | [docs/HTTP_DEPLOYMENT.md](docs/HTTP_DEPLOYMENT.md)   | HTTP transport, JWT validation, Docker, Azure Container Apps  |
 | [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)   | Common errors and how to diagnose them                        |

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -12,6 +12,8 @@ Each use case includes:
 
 > Read-only is the default. Write operations require `--allow-writes` and are annotated with a risk level (`low`, `medium`, `high`, `critical`).
 
+> For end-to-end security incident response scenarios with multi-phase procedures, see the [playbooks](playbooks/README.md) catalogue.
+
 ---
 
 ## 1. Daily security monitoring

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -1,0 +1,87 @@
+# Security Incident Response Playbooks
+
+Structured, end-to-end response scenarios for common security incidents, each driven through `ms-365-admin-mcp-server` by an LLM client.
+
+Playbooks are the long-form counterpart to [USE_CASES.md](../USE_CASES.md). A use case is a one-paragraph recipe (context + sample prompt + key tools). A playbook is a multi-phase procedure with tool-level mappings, dry-run guidance, scope boundaries, and demo prompts.
+
+Each playbook follows the same structure:
+
+1. **Trigger signals** — how the scenario is detected.
+2. **Scope boundary** (when relevant) — what the server *can* and *cannot* do for this scenario. Forensic or remediation steps that live outside this server are called out and handed off explicitly.
+3. **Prerequisites** — presets, delegated permissions, guardrails.
+4. **Phased procedure** — investigation → containment → hardening → documentation. Each step maps to a concrete MCP tool with its risk level.
+5. **Sample prompts** — per phase + a full-run single-shot prompt.
+6. **Demo talking points** — what each playbook showcases that the others do not.
+
+---
+
+## Catalogue
+
+| # | Playbook | Scope | Tool families | Completeness |
+|---|---|---|---|---|
+| 1 | [Compromised Account](compromised-account.md) | A single user identity is suspected compromised. | `identity`, `audit`, `security`, `response` | End-to-end (investigation → containment → audit). |
+| 2 | [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) | A phishing email reached multiple mailboxes. | `security`, `exchange`, `audit`, `identity` | Scoping + handoff (purge happens outside the server). |
+| 3 | [OAuth Illicit Consent](oauth-illicit-consent.md) | A malicious OAuth application holds delegated or application permissions. | `identity`, `audit`, `security`, `compliance`, `response` | End-to-end + prevention (permission-grant policy review). |
+| 4 | [SharePoint / OneDrive Exfiltration](sharepoint-exfiltration.md) | Anomalous external sharing or mass download on a SharePoint site or OneDrive. | `sharepointadmin`, `audit`, `security`, `identity`, `reports`, `response` | End-to-end at the site level + handoff to Purview for file-level forensics. |
+
+---
+
+## How to run a playbook
+
+Each playbook specifies its presets explicitly. As a baseline:
+
+- Start the server in **read-only** for the investigation phase.
+- Restart with `--allow-writes` only for the containment phase, and narrow the preset to what that phase requires.
+- For every tool flagged `high` or `critical`, have the LLM **dry-run first** (list the target entities, state the exact operation), wait for operator confirmation, then execute.
+- Keep a break-glass / emergency-access account excluded from any containment action. Confirm target UPN is not in the break-glass list before any identity write.
+
+See [USE_CASES.md — General recommendations](../USE_CASES.md#general-recommendations) for the broader safety guidance that applies to every scenario.
+
+---
+
+## How the playbooks relate
+
+```
+                 ┌────────────────────────────┐
+                 │ Phishing Campaign           │
+                 │ (tenant-wide delivery)      │
+                 └──────────────┬─────────────┘
+                                │ per confirmed victim
+                                ▼
+                 ┌────────────────────────────┐          ┌─────────────────────────┐
+                 │ Compromised Account         │◀────────│ OAuth Illicit Consent    │
+                 │ (per user)                  │ per user│ (malicious SP)           │
+                 └──────────────┬─────────────┘          └──────────────┬──────────┘
+                                │ if data was reached                     │ if scopes were Files.* / Sites.*
+                                ▼                                         ▼
+                 ┌────────────────────────────────────────────────────────────────┐
+                 │ SharePoint / OneDrive Exfiltration                             │
+                 │ (site-level exposure + Purview handoff for file forensics)     │
+                 └────────────────────────────────────────────────────────────────┘
+```
+
+Real incidents rarely fit one playbook cleanly. A phishing campaign can drop an OAuth app that consents to `Files.Read.All` and exfiltrates through SharePoint — three playbooks chained. Run them in sequence; each ends with clear handoff signals.
+
+---
+
+## Demo value (why these four)
+
+Selected to showcase distinct capability surfaces of the server in the shortest possible set:
+
+- **#1 Compromised Account** — end-to-end on a single identity. The baseline demo.
+- **#2 Phishing** — shows the server's honesty about scope boundaries. Stops at a handoff package instead of pretending to purge.
+- **#3 OAuth Illicit Consent** — shows sophistication (order of operations matters: disable SP *before* revoking sessions) and closes the prevention loop.
+- **#4 SharePoint Exfiltration** — widens the narrative beyond identity into data governance. Exercises a completely different preset family.
+
+Together they exercise 9 of the 15 tool-category presets defined in [src/tool-categories.ts](../../src/tool-categories.ts).
+
+---
+
+## Contributing a new playbook
+
+When adding a playbook:
+
+1. Confirm every MCP tool referenced actually exists in [src/endpoints.json](../../src/endpoints.json). Do not include tools that *should* exist — add them to the server first, or handle the gap with an explicit handoff section.
+2. Follow the 5-section structure listed at the top of this page. Consistency matters more than length.
+3. Classify each write tool's risk (`low` / `medium` / `high` / `critical`) in line with [docs/RISK_MODEL.md](../RISK_MODEL.md).
+4. Add the playbook to the catalogue table above and to any relevant *Related playbooks* section in existing files.

--- a/docs/playbooks/compromised-account.md
+++ b/docs/playbooks/compromised-account.md
@@ -1,0 +1,132 @@
+# Playbook — Compromised Account
+
+End-to-end incident response scenario driven through `ms-365-admin-mcp-server`. From the first risk signal to the post-incident audit report, every step maps to a concrete MCP tool.
+
+This is the flagship demo scenario: it chains 11+ tools across identity, audit, and response categories and exercises the read-only → `--allow-writes` progression.
+
+---
+
+## Trigger signals
+
+Any of the following typically opens this playbook:
+
+- A user appears in `list-risky-users` with `riskLevel = high`.
+- A security alert or incident (Microsoft 365 Defender / Identity Protection) targets a user identity.
+- A sign-in flagged *impossible travel*, *atypical location*, or *anonymous IP*.
+- A user self-reports a phishing click or a stolen credential.
+
+---
+
+## Prerequisites
+
+### Presets
+
+- **Investigation (Phase 1)** — read-only.
+  ```bash
+  node dist/index.js --preset identity,audit,security
+  ```
+- **Containment (Phase 2)** — writes enabled.
+  ```bash
+  node dist/index.js --preset identity,audit,security,response --allow-writes
+  ```
+
+### Delegated permissions
+
+The Entra ID application registration used by the MCP server must hold (at minimum):
+
+- `User.Read.All`, `AuditLog.Read.All`, `Directory.Read.All`
+- `IdentityRiskEvent.Read.All`, `IdentityRiskyUser.ReadWrite.All`
+- `UserAuthenticationMethod.ReadWrite.All`
+- `User.EnableDisableAccount.All`, `User.RevokeSessions.All`
+- `SecurityAlert.ReadWrite.All`, `SecurityIncident.ReadWrite.All`
+
+See [APP_REGISTRATION.md](../APP_REGISTRATION.md) for the full list and consent procedure.
+
+### Guardrail — break-glass exclusion
+
+Never run the containment phase against a break-glass account. Confirm the target `userPrincipalName` is **not** in the tenant's emergency-access list before any write.
+
+---
+
+## Phase 1 — Investigation (read-only)
+
+Goal: confirm the compromise, reconstruct the attacker's timeline, and measure the blast radius.
+
+| # | Objective | MCP tool(s) | Notes |
+|---|---|---|---|
+| 1 | Confirm the subject and baseline context | `get-user`, `get-risky-user` | Display name, UPN, job title, last interactive sign-in, current risk state. |
+| 2 | Reconstruct the sign-in timeline | `list-sign-ins` | Filter on `userId` and the last 24–72 h. Extract IP, location, client app, conditional access result, risk level per sign-in. |
+| 3 | Correlate with Identity Protection detections | `list-risk-detections`, `list-risky-user-history` | Maps detections (e.g. *malwareInfectedIPAddress*, *unfamiliarFeatures*) to sign-ins from step 2. |
+| 4 | Measure blast radius — what did the attacker do? | `list-directory-audits` | Filter `initiatedBy.user.id = <userId>`. Look for new OAuth consents, new role assignments, password resets, mail rules, group memberships, application registrations. |
+| 5 | Detect MFA persistence added by the attacker | `list-user-auth-methods` | A phone or authenticator app registered during the compromise window is a classic persistence mechanism. |
+
+### Sample investigation prompt
+
+> "User `jdoe@contoso.com` was just flagged as risky high. Pull their profile, list every sign-in from the last 48 hours with IP, location, client, and risk level, correlate with Identity Protection risk detections, and list every directory-audit operation they initiated in the same window. Flag any MFA method registered in the last 7 days."
+
+---
+
+## Phase 2 — Containment (writes)
+
+Goal: kill active access, remove attacker persistence, and feed the Identity Protection model.
+
+> Always run every write in dry-run first: have the LLM list the target entity and the exact operation, wait for operator confirmation, then execute.
+
+| # | Action | MCP tool | Risk | Effect |
+|---|---|---|---|---|
+| 6 | Revoke all active sessions (refresh tokens) | `revoke-user-sessions` | **high** | Forces re-authentication on every client within minutes. |
+| 7 | Disable the account if severity warrants it | `disable-user-account` | **critical** | Blocks all sign-ins. Use when the user can be reached through an alternate channel. |
+| 8 | Remove attacker-added phone MFA | `delete-user-phone-auth-method` | **high** | Removes the rogue phone. Repeat with other `delete-user-*-auth-method` tools if authenticator or FIDO was added. |
+| 9 | Confirm compromised in Identity Protection | `confirm-compromised-users` | **high** | Marks `riskState = confirmedCompromised`. Feeds the ML model and triggers dependent Conditional Access policies. |
+
+### Sample containment prompt
+
+> "Containment phase for `jdoe@contoso.com`. Before each write, show me the target and wait for my confirmation. Steps: (1) revoke all sessions, (2) disable the account, (3) delete any phone auth method registered after 2026-04-15, (4) mark the user as confirmed compromised in Identity Protection."
+
+---
+
+## Phase 3 — Documentation and audit
+
+Goal: record the response on the incident/alert, and produce a traceability report proving every action taken.
+
+| # | Action | MCP tool | Notes |
+|---|---|---|---|
+| 10 | Update the security incident | `update-security-incident` | Status (e.g. `active` → `inProgress`), classification, assignee. |
+| 11 | Leave a narrative trail on the alert | `add-security-alert-comment` | Short chronology referencing the audit window. |
+| 12 | Generate the post-incident audit report | `list-directory-audits` | Filter on the operator service principal / delegated user, over the response window. Every write from Phase 2 appears there — the loop closes. |
+
+### Sample documentation prompt
+
+> "Update incident `<id>` with status `inProgress`, classification `truePositive / compromisedAccount`, and assign it to me. Add a comment to the related alert summarizing the timeline (first malicious sign-in, containment actions, MFA cleanup). Finally, pull every directory-audit entry written during the containment window and produce a markdown table."
+
+---
+
+## Full-run demo prompt (single-shot)
+
+Use this when demoing the end-to-end flow in one shot. The LLM will chain all three phases, pausing for confirmation before each write.
+
+> "User `jdoe@contoso.com` was just flagged as risky high. Run the compromised-account playbook:
+>
+> 1. Investigation — profile, sign-in timeline over 48 h, correlated risk detections, directory-audit operations they initiated, and any auth method registered in the last 7 days.
+> 2. Containment — wait for my explicit confirmation before each write: revoke sessions, disable the account, delete attacker-added MFA, mark as confirmed compromised.
+> 3. Documentation — update the related security incident, comment the alert, and pull the final audit report covering my containment window.
+>
+> Use the least-privilege preset and stop immediately if the target matches a break-glass naming pattern."
+
+---
+
+## Demo talking points
+
+- **Breadth** — 11 distinct Graph endpoints orchestrated in one conversation, across 4 tool categories (`identity`, `audit`, `security`, `response`).
+- **Safety rails** — read-only by default, `--allow-writes` required for Phase 2, and every `high`/`critical` tool runs dry-run-then-confirm.
+- **Closed loop** — the final `list-directory-audits` call (step 12) surfaces the exact operations the analyst just executed, which is both an audit artefact and a meta-validation of the MCP server itself.
+- **LLM value-add** — natural-language correlation between sign-ins, risk detections, and directory audits is the part that is painful with raw Graph calls and becomes trivial here.
+
+---
+
+## Related playbooks
+
+- Phishing campaign (tenant-wide) — *draft*
+- OAuth illicit consent — *draft*
+
+See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.

--- a/docs/playbooks/oauth-illicit-consent.md
+++ b/docs/playbooks/oauth-illicit-consent.md
@@ -1,0 +1,173 @@
+# Playbook — OAuth Illicit Consent (Consent Phishing)
+
+End-to-end response to a malicious OAuth application that has obtained delegated or application permissions in the tenant. Unlike credential phishing, the attacker holds a **refresh token**, not a password — session revocation and MFA reset do not, by themselves, remove access. The service principal must be neutralised.
+
+Scope note: this admin server can perform the **full loop** (scope, contain, harden, document) without external handoff. This is the contrast point versus the [phishing playbook](phishing-tenant-wide.md).
+
+---
+
+## Background
+
+Consent phishing: the attacker sends a link to a Microsoft consent screen for an OAuth application they control. The user clicks *Accept* and grants delegated scopes like `Mail.Read`, `Files.Read.All`, `offline_access`. The attacker receives an access token + refresh token for that user. A tenant admin variant asks for admin consent on `AllPrincipals`, gaining access to every user in one click.
+
+Key properties:
+
+- **Password rotation does not help** — OAuth tokens are independent of password state.
+- **MFA does not help** — MFA was already satisfied at consent time.
+- **Session revocation alone is insufficient** — a revoked session does not invalidate an already-issued refresh token tied to an app-grant on the service principal.
+- **Correct remediation is service-principal-scoped**: disable or delete the SP, then revoke sessions.
+
+---
+
+## Trigger signals
+
+- Service principal appears in `list-risky-service-principals` with `riskLevel = high`.
+- Defender / Identity Protection alert referencing a suspicious OAuth application.
+- A user reports they clicked *Accept* on an unexpected consent screen.
+- Spike of Graph API calls by a newly-created service principal (see `list-sign-ins` filtered on `appDisplayName`).
+- A pending request in `list-app-consent-requests` from an unknown publisher.
+
+---
+
+## Prerequisites
+
+### Presets
+
+- **Investigation (read-only)**
+  ```bash
+  node dist/index.js --preset identity,audit,security,compliance
+  ```
+- **Containment (writes)**
+  ```bash
+  node dist/index.js --preset identity,audit,security,compliance,response --allow-writes
+  ```
+
+### Delegated permissions (minimum)
+
+- `Application.ReadWrite.All` — to update / delete service principals.
+- `Directory.Read.All`, `AuditLog.Read.All`
+- `IdentityRiskyServicePrincipal.ReadWrite.All`
+- `DelegatedPermissionGrant.ReadWrite.All`
+- `SecurityAlert.ReadWrite.All`, `SecurityIncident.ReadWrite.All`
+
+See [APP_REGISTRATION.md](../APP_REGISTRATION.md).
+
+---
+
+## Phase 1 — Identify the malicious application
+
+Goal: go from the signal to a full profile of the suspect service principal.
+
+| # | Objective | MCP tool(s) | Notes |
+|---|---|---|---|
+| 1 | Pull the service principal profile | `get-service-principal` | `appId`, `publisherName`, `verifiedPublisher`, `signInAudience`, `createdDateTime`. Newly created + unverified publisher + multi-tenant = strong signal. |
+| 2 | Check registered credentials | `list-app-federated-credentials` | Federated credentials are a modern persistence vector. Any FIC added recently is suspicious. |
+| 3 | Check ownership | `list-service-principal-owners`, `list-application-owners` | A compromised internal user who owns a suspicious app is a secondary compromise. |
+| 4 | Pull risk detections on the SP | `list-service-principal-risk-detections`, `get-risky-service-principal` | Microsoft-flagged risky behaviours (leaked credentials, anomalous activity). |
+| 5 | Find the home application object | `get-application` | Only present if the app is registered in *this* tenant (single-tenant or multi-tenant publisher = home tenant). |
+
+### Sample prompt
+
+> "Profile the service principal with objectId `<spObjectId>`: publisher, sign-in audience, creation date, federated credentials, owners, related risk detections, and (if registered here) the home application object. Flag every indicator of a newly-created, unverified, multi-tenant app."
+
+---
+
+## Phase 2 — Measure blast radius
+
+Goal: enumerate every grant this service principal holds, and every user affected.
+
+| # | Objective | MCP tool(s) | Notes |
+|---|---|---|---|
+| 6 | Enumerate delegated permission grants | `list-oauth2-grants` | Filter `clientId eq '<spObjectId>'`. Each result: `principalId` (user who consented), `scope` (space-separated). `consentType = AllPrincipals` means tenant-wide admin consent — blast radius = every user. |
+| 7 | Enumerate application permission grants | `list-sp-app-role-assignments` | App-only permissions (e.g. `Mail.Read` as application) — no user interaction needed, attacker can call Graph on every mailbox. Highest severity. |
+| 8 | List configured delegated permissions | `list-sp-delegated-permissions` | What scopes *could* the SP request — baseline for Phase 4 policy tightening. |
+| 9 | Who actually authenticated to it | `list-sign-ins` | Filter `appDisplayName eq '<malicious app>'` over the window since creation. Gives the real list of active victims, separate from the consented list. |
+| 10 | Consent event timeline | `list-directory-audits` | Filter on `activityDisplayName in ('Consent to application', 'Add app role assignment grant to service principal')` and the SP's `targetResources`. Produces the forensic timeline. |
+
+### Severity classification
+
+- **Critical** — one or more `list-sp-app-role-assignments` entries (application permissions). Whole tenant exposed.
+- **High** — `list-oauth2-grants` with `consentType = AllPrincipals` on sensitive scopes (`Mail.ReadWrite`, `Files.ReadWrite.All`, `User.Read.All`).
+- **Medium** — per-user delegated consent on sensitive scopes by more than a handful of users, or by any privileged user.
+- **Low** — per-user delegated consent on low-impact scopes (`User.Read`, `openid`, `profile`, `offline_access` alone).
+
+---
+
+## Phase 3 — Containment
+
+Order matters. Neutralise the SP **before** revoking user sessions — otherwise the attacker uses the remaining refresh-token window to re-consent on fresh sessions or pivot.
+
+| # | Action | MCP tool | Risk | Effect |
+|---|---|---|---|---|
+| 11 | Soft-block the service principal | `update-service-principal` with `accountEnabled = false` | **high** | Prevents all new token issuance. Preserves the audit trail and the grants themselves for forensics. Preferred first step. |
+| 12 | Strip attacker-added credentials | `remove-sp-key`, `remove-sp-password` | **high** | If credentials were added post-compromise, remove them. Do not remove credentials you cannot correlate to the attacker. |
+| 13 | Remove rogue owners | `remove-sp-owner` | **medium** | If an internal user owns the malicious SP and is confirmed complicit / compromised. |
+| 14 | Mark as confirmed compromised | `confirm-compromised-service-principals` | **high** | Feeds Identity Protection, triggers dependent Conditional Access policies for SPs. |
+| 15 | Revoke affected user sessions | `revoke-user-sessions` | **high** | For every user in steps 6 and 9. Kills active access tokens. |
+| 16 | Delete the service principal (optional, after forensics) | `delete-service-principal` | **critical** | Only after evidence preservation. Destroys the SP object and all grants. Irreversible. |
+
+> The compromised-account playbook is triggered for each user who consented to sensitive scopes — especially those whose sign-ins in step 9 show attacker-infrastructure IPs.
+
+### Sample containment prompt
+
+> "Containment for service principal `<spObjectId>`. Dry-run every write first:
+> 1. Set `accountEnabled = false` on the SP.
+> 2. List any secret/key added after `<creation date + 1 day>` and propose removal.
+> 3. Mark the SP as confirmed compromised.
+> 4. Revoke sessions for every user identified in Phase 2 steps 6 and 9.
+>
+> Wait for my explicit confirmation before each write. Do not delete the SP yet — flag it for post-forensics cleanup."
+
+---
+
+## Phase 4 — Harden to prevent recurrence
+
+The single highest-leverage control against consent phishing is **restricting user consent**.
+
+| # | Objective | MCP tool(s) | Action |
+|---|---|---|---|
+| 17 | Review the tenant's consent policy | `list-permission-grant-policies` | Confirm which app-role / delegated scopes users can consent to without admin approval. Default is often too permissive. |
+| 18 | Review outstanding consent requests | `list-app-consent-requests`, `list-user-consent-requests` | Clear the queue; look for other suspicious pending requests from the same attacker. |
+| 19 | Recommend the admin-consent workflow if not enabled | *(read-only — configuration change is out of MCP scope)* | Directs any consent for risky scopes to admin review. Biggest prevention win. |
+
+---
+
+## Phase 5 — Documentation and audit
+
+| # | Action | MCP tool | Notes |
+|---|---|---|---|
+| 20 | Update the security incident | `update-security-incident` | Classification `truePositive / maliciousApp`, status `resolved` once Phase 3 complete. |
+| 21 | Narrative on the alert | `add-security-alert-comment` | Chronology + scope summary + containment steps. |
+| 22 | Investigation audit log | `list-directory-audits` | Filter on the responder, response window. Attach to the incident. |
+
+---
+
+## Full-run demo prompt (single-shot)
+
+> "Service principal `<spObjectId>` was just flagged as risky high. Run the OAuth illicit consent playbook:
+>
+> 1. Profile — pull SP details, federated credentials, owners, risk detections, and the home application if it exists. Flag every newly-created / unverified / multi-tenant indicator.
+> 2. Blast radius — enumerate delegated grants, application permission assignments, all sign-ins to this app, and the consent event timeline. Classify severity (critical / high / medium / low).
+> 3. Containment — wait for my confirmation before each write: soft-block the SP, strip credentials added post-compromise, mark as confirmed compromised, revoke sessions of every affected user. Do not delete the SP yet.
+> 4. Hardening — summarize the tenant permission-grant policy and outstanding consent requests; recommend follow-ups.
+> 5. Documentation — update the incident, comment the alert, produce the investigation audit log.
+>
+> Route every user who consented to sensitive scopes (Mail.*, Files.*, User.Read.All) to the compromised-account playbook as a side-output."
+
+---
+
+## Demo talking points
+
+- **Full loop inside the server** — contrast with the phishing playbook where purge lives outside. Here investigation → containment → hardening → documentation all chain through the MCP server, no handoff.
+- **Token-economy literacy** — the playbook surfaces *why* revoking sessions before killing the SP is the wrong order. The LLM explains the invariant; the tools enforce it.
+- **Severity classification** — critical (app permissions) vs high (tenant-wide delegated) vs medium / low. Mechanical but routinely mishandled by human responders under pressure.
+- **Preventive follow-up** — Phase 4 exposes the permission-grant policy as the root cause. Most incident playbooks stop at remediation; this one closes the prevention loop in the same conversation.
+
+---
+
+## Related playbooks
+
+- [Compromised Account](compromised-account.md) — invoked per affected user.
+- [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) — consent phishing often starts as a phishing email.
+
+See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.

--- a/docs/playbooks/phishing-tenant-wide.md
+++ b/docs/playbooks/phishing-tenant-wide.md
@@ -1,0 +1,154 @@
+# Playbook — Phishing Campaign (Tenant-Wide)
+
+Scoping, victim identification, and handoff-to-containment for a phishing campaign that reached multiple mailboxes. The MCP server is used as the **investigation plane** (visibility, correlation, documentation). Mailbox-content purge happens in Defender Threat Explorer or via a mailbox-scoped MCP — see the [scope boundary](#scope-boundary) below.
+
+---
+
+## Trigger signals
+
+- A user reports a suspicious message (help desk ticket, Report Phishing button).
+- A Defender / Identity Protection alert mentions a phishing indicator (sender, URL, IP).
+- A [threat intel article](https://learn.microsoft.com/en-us/graph/api/resources/security-article) matches a pattern seen in the tenant.
+- Unusual `list-message-traces` volume from a suspicious sender domain.
+
+---
+
+## Scope boundary
+
+This admin-focused server does **not** expose per-message mailbox operations (no `delete-mail-message` across users, no `list-mail-rules` for arbitrary users). Those belong to a mailbox-scoped Graph app (`Mail.ReadWrite`, `MailboxSettings.ReadWrite` on every mailbox) or to Microsoft Defender Threat Explorer.
+
+What this server **does** give you for phishing:
+
+- Tenant-wide message-trace visibility — *who received what, when, from where*.
+- Victim correlation — sign-ins, risk detections, directory audits post-delivery.
+- Security incident / alert lifecycle — classification, comments, closure.
+- Threat intel enrichment — IOC lookups, article cross-reference.
+
+The playbook ends with a **handoff package** (list of affected UPNs, message IDs, IOCs) ready for the team or tool that will perform the purge.
+
+---
+
+## Prerequisites
+
+### Presets
+
+- **Scoping + correlation (read-only)**
+  ```bash
+  node dist/index.js --preset security,exchange,audit,identity
+  ```
+- **Documentation (writes on incidents/alerts only)**
+  ```bash
+  node dist/index.js --preset security --allow-writes
+  ```
+
+### Delegated permissions (minimum)
+
+- `SecurityAlert.ReadWrite.All`, `SecurityIncident.ReadWrite.All`
+- `ThreatIntelligence.Read.All`, `ThreatAssessment.Read.All`
+- `Mail.ReadBasic.All` *(for message trace)* or the Exchange Online `MessageTracking` role
+- `AuditLog.Read.All`, `Directory.Read.All`
+- `IdentityRiskEvent.Read.All`, `IdentityRiskyUser.Read.All`
+
+See [APP_REGISTRATION.md](../APP_REGISTRATION.md).
+
+---
+
+## Phase 1 — Scope the campaign
+
+Goal: turn a single signal into a list of delivered messages, sender infrastructure, and affected recipients.
+
+| # | Objective | MCP tool(s) | Notes |
+|---|---|---|---|
+| 1 | Enumerate related alerts and incidents | `list-security-alerts`, `list-security-incidents`, `get-security-incident` | Filter on `category = Phishing` or keywords from the reported message. |
+| 2 | Pull user-submitted reports | `list-threat-assessment-requests` | Employees using the *Report Phishing* button surface here. |
+| 3 | Match against known campaigns | `list-threat-intel-articles`, `list-threat-intel-article-indicators` | Cross-reference sender domain, URL, IP against Microsoft threat intel articles. |
+| 4 | Measure delivery footprint | `list-message-traces` | Filter by `senderAddress`, `subject`, `fromDateTime`, `toDateTime`. Extract recipient list, delivery status, message IDs. |
+| 5 | Inspect a suspicious delivery in detail | `get-message-trace` | For each high-signal message ID, get the full trace (hops, spam verdict, policy hits). |
+
+### Sample prompt
+
+> "Over the last 72 hours, list all inbound message traces where the sender domain is `contoso-billing.co` or the subject contains `invoice overdue`. Group by recipient and show delivery status. Cross-reference the sender IP against threat-intel articles and pull any related security alerts."
+
+---
+
+## Phase 2 — Identify victims who engaged
+
+A recipient is not yet a victim. Engagement is inferred from sign-in activity, risk detections, and tenant operations **after** delivery.
+
+For each recipient from Phase 1:
+
+| # | Objective | MCP tool(s) | Notes |
+|---|---|---|---|
+| 6 | Baseline the user | `get-user` | Confirm identity, department, privileged-role membership (privileged targets escalate severity). |
+| 7 | Detect post-delivery suspicious sign-ins | `list-sign-ins` | Window starts at message delivery time. Look for atypical location, anonymous IP, legacy auth, MFA-not-satisfied-but-granted. |
+| 8 | Correlate with Identity Protection | `list-risk-detections`, `list-risky-users` | A detection timestamped just after delivery is a strong engagement signal. |
+| 9 | Spot attacker actions post-click | `list-directory-audits` | Filter `initiatedBy.user.id = <recipientId>` from delivery onward. New OAuth consents and mail rules (visible as audit entries) are the two highest-signal events. |
+
+### Classification output
+
+Classify each recipient into one of:
+
+- **Unaffected** — no engagement signal.
+- **Engaged** — clicked or authenticated from suspicious context, no compromise confirmed yet.
+- **Confirmed compromised** — risk detection + post-delivery directory-audit activity or session from attacker infra.
+
+Confirmed compromised recipients → trigger the [Compromised Account playbook](compromised-account.md) per user.
+
+---
+
+## Phase 3 — Handoff package for purge
+
+The server cannot delete messages from every mailbox itself. Instead, produce a structured handoff the purge operator (Defender Threat Explorer, Exchange PowerShell, or mailbox-scoped MCP) can act on in one shot.
+
+The handoff should include:
+
+- **Message identity** — list of `internetMessageId` / `messageTraceId` values from Phase 1.
+- **Sender IOCs** — addresses, domains, IPs, URLs.
+- **Recipient list** — every UPN with delivery status `Delivered` or `Quarantined→Released`.
+- **Time window** — earliest and latest delivery timestamp.
+- **Confirmed compromised UPNs** — already routed to the compromised-account playbook.
+
+### Sample prompt
+
+> "From Phase 1 results, generate a markdown handoff package with: (a) deduplicated internetMessageId list, (b) sender IOC table (address, domain, sending IP, URL), (c) recipient table with delivery status and engagement classification, (d) first/last delivery timestamps. Format so it can be pasted into a Defender Threat Explorer bulk action."
+
+---
+
+## Phase 4 — Documentation and closure
+
+| # | Action | MCP tool | Notes |
+|---|---|---|---|
+| 10 | Bind related alerts to a single incident | `update-security-incident` | Classification `truePositivePhishing`, assignee, status `inProgress`. |
+| 11 | Narrative on each alert | `add-security-alert-comment` | Timeline bullet points — detection, scope, victims, handoff sent. |
+| 12 | Audit trail of the investigation window | `list-directory-audits` | Capture every operation the responder performed through the server. Attach to the incident record. |
+
+---
+
+## Full-run demo prompt (single-shot)
+
+> "A user just reported a phishing email from `no-reply@contoso-billing.co` with subject `Invoice overdue — action required`. Run the phishing playbook:
+>
+> 1. Scope — list all message traces of this campaign in the last 72 h, cross-reference sender IP with threat-intel articles, and list related security alerts/incidents.
+> 2. Victims — for every recipient, pull their profile, sign-ins post-delivery, risk detections, and directory-audit operations. Classify them as unaffected, engaged, or confirmed compromised.
+> 3. Handoff — produce a markdown handoff package (message IDs, IOCs, recipient table) ready for Defender Threat Explorer.
+> 4. Documentation — update the related incident to `inProgress / truePositivePhishing`, add a timeline comment to each alert, and pull the investigation audit log.
+>
+> Confirm with me before the documentation writes. Flag privileged-role members among recipients immediately."
+
+---
+
+## Demo talking points
+
+- **Cross-surface correlation** — message trace + sign-ins + risk detections + directory audits, all from one conversation. Painful to stitch together manually, trivial here.
+- **Honest scope** — the playbook stops at the handoff instead of pretending to purge. Demonstrates an MCP server that knows its boundaries.
+- **Severity triage** — flagging privileged-role recipients early is the kind of judgment call LLMs do well and shell scripts don't.
+- **Meta-audit closure** — same pattern as the compromised-account playbook: the investigator's own actions end up in `list-directory-audits`.
+
+---
+
+## Related playbooks
+
+- [Compromised Account](compromised-account.md) — triggered per confirmed victim.
+- OAuth illicit consent — *draft*. Often a phishing lure leads to consent phishing instead of credential theft — that flow is covered separately.
+
+See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.

--- a/docs/playbooks/sharepoint-exfiltration.md
+++ b/docs/playbooks/sharepoint-exfiltration.md
@@ -1,0 +1,163 @@
+# Playbook — SharePoint / OneDrive Exfiltration
+
+Response to suspected data exfiltration through SharePoint Online or OneDrive for Business: anomalous external sharing, departing-employee download spike, or an accidental tenant-wide share. The server scopes the exposure, enumerates who has what access, and rolls back permissions at site level.
+
+---
+
+## Trigger signals
+
+- A Defender or DLP alert referencing anomalous download volume or mass-sharing.
+- HR notifies of an employee departure; a privileged offboarding review is required.
+- A user reports an accidental *Anyone with the link* share on a sensitive document.
+- A quarterly audit surfaces sites with excessive external guests or anonymous links.
+- Spike in `get-sharepoint-usage-report` external-users metric.
+
+---
+
+## Scope boundary
+
+This server exposes tenant and site-level SharePoint administration through Graph:
+
+- Tenant external-sharing settings (`get-sharepoint-settings`).
+- Sites, site drives, site lists, content types, permissions.
+- Site analytics (aggregated activity).
+- Tenant-level usage reports.
+
+It does **not** query per-file access events (who opened / downloaded file X, when). That forensic detail lives in Microsoft Purview's Unified Audit Log. If the scenario requires file-level access forensics, pair this playbook with Purview Audit Search or a Purview-scoped MCP. The playbook explicitly flags the handoff where it applies.
+
+---
+
+## Prerequisites
+
+### Presets
+
+- **Investigation (read-only)**
+  ```bash
+  node dist/index.js --preset sharepointadmin,audit,security,identity,reports
+  ```
+- **Containment (site permission changes)**
+  ```bash
+  node dist/index.js --preset sharepointadmin,audit,security,identity,response --allow-writes
+  ```
+
+### Delegated permissions (minimum)
+
+- `Sites.FullControl.All` — to revoke / downgrade site permissions.
+- `Sites.Read.All`, `Files.Read.All`
+- `Directory.Read.All`, `AuditLog.Read.All`
+- `Reports.Read.All`
+- `InformationProtectionPolicy.Read.All` — to cross-reference sensitivity labels.
+- `SecurityAlert.ReadWrite.All`, `SecurityIncident.ReadWrite.All`
+
+See [APP_REGISTRATION.md](../APP_REGISTRATION.md).
+
+### Guardrail — prod site recovery
+
+Before revoking or downgrading a permission on a production site, confirm the site is not a shared team workspace where the revocation would break legitimate collaboration. When in doubt, **downgrade** (`update-site-permission`) instead of **remove** (`delete-site-permission`).
+
+---
+
+## Phase 1 — Scope the exposure
+
+Goal: quantify *what is shared*, *with whom*, *how broadly*.
+
+| # | Objective | MCP tool(s) | Notes |
+|---|---|---|---|
+| 1 | Pull the tenant external-sharing baseline | `get-sharepoint-settings` | Tenant-level defaults for external sharing, guest experience, link expiration. Baseline for what *should* be allowed. |
+| 2 | Identify the suspect site(s) | `list-sharepoint-sites`, `get-sharepoint-site` | Filter by owner UPN for an offboarding scenario; filter by URL / title for a reported incident. |
+| 3 | Enumerate site permissions | `list-site-permissions`, `get-site-permission` | Per site: grantee identities, roles (`read` / `write` / `owner`), scope (direct user, group, anonymous link, org-wide share). |
+| 4 | Enumerate site drives and subsites | `list-site-drives`, `get-site-default-drive`, `list-site-subsites` | Establishes the full storage surface to review, not just the root site. |
+| 5 | Measure site activity | `get-site-analytics`, `get-sharepoint-usage-report` | Views, unique viewers, time window. An activity spike aligned with the alert is a strong signal. |
+| 6 | Correlate with sensitivity labels | `list-sensitivity-labels`, `list-sensitivity-sublabels` | Identifies whether the exposed content *should* have been labeled `Confidential` / `Highly Confidential` and was not — a labeling gap is a recurring root cause. |
+
+### Sample prompt
+
+> "Site `<siteUrl>` is suspected of excessive external sharing. Pull tenant SharePoint settings, the site profile, every permission entry with grantee identity and role, all site drives and subsites, and the last 30 days of site analytics. Flag anonymous links, org-wide shares, and any external grantee whose domain is not in the tenant's allowlist."
+
+---
+
+## Phase 2 — Actor and timeline
+
+Goal: attribute the permission changes and correlate with user activity. For offboarding scenarios, establish what the departing user shared in their final weeks.
+
+| # | Objective | MCP tool(s) | Notes |
+|---|---|---|---|
+| 7 | Baseline the actor | `get-user` | Role, department, manager, tenure. Privileged-role members trigger higher severity. |
+| 8 | Sharing events from directory audit | `list-directory-audits` | Filter on `category = SharePoint` and `activityDisplayName` patterns like *Add site collection administrator*, *Update site*, *Share*. Populates the operator-attributed timeline visible to Entra ID. |
+| 9 | Sign-in activity | `list-sign-ins` | Window = last 30 days. Unusual location or anonymous IP during a share-creation window is a strong engagement signal for insider-threat scenarios. |
+| 10 | Related security alerts | `list-security-alerts`, `list-security-incidents` | DLP, insider-risk, or Defender for Cloud Apps alerts on the same user or site. |
+| 11 | *(If file-level forensics required)* | **Handoff to Purview Unified Audit Log** | Per-file `FileDownloaded`, `FileSyncDownloadedFull`, `SharingSet` events are not exposed by Graph. Hand off the user UPN, site URL, and time window. |
+
+---
+
+## Phase 3 — Containment
+
+Order: revoke / downgrade at the site first, then tighten the actor's identity if warranted.
+
+| # | Action | MCP tool | Risk | Effect |
+|---|---|---|---|---|
+| 12 | Remove anonymous / excessive share links | `delete-site-permission` | **high** | Revokes a specific permission entry. Use for anonymous links and grantees clearly outside policy. |
+| 13 | Downgrade over-permissive grants | `update-site-permission` | **medium** | Prefer downgrade (`write` → `read`) over delete when collaboration must continue. |
+| 14 | Lock down the site configuration if needed | `update-sharepoint-site` | **medium** | Constrain site-level sharing capabilities while investigation continues. |
+| 15 | If the actor is confirmed malicious or departed | `revoke-user-sessions` | **high** | Per-user session kill. Pair with the [compromised-account](compromised-account.md) playbook if insider compromise is confirmed. |
+
+> Tenant-level external-sharing policy changes (e.g. disabling *Anyone* links tenant-wide) are **not** exposed as an update tool in this server — that change is made in the SharePoint admin center or via Microsoft Graph beta endpoints not currently mapped. Flag it as a follow-up recommendation in Phase 5.
+
+### Sample containment prompt
+
+> "Containment on site `<siteUrl>`. Dry-run each write. For every permission entry where grantee is `Anonymous` or domain is outside the tenant allowlist: propose `delete-site-permission`. For entries with role `write` on external domains in our partner list: propose `update-site-permission` to `read`. Wait for my confirmation before each write."
+
+---
+
+## Phase 4 — Data governance follow-up
+
+Recurring root cause for exfiltration incidents is missing classification. Close the loop so the same event does not happen twice.
+
+| # | Objective | MCP tool(s) | Action |
+|---|---|---|---|
+| 16 | Review sensitivity labels coverage | `list-sensitivity-labels`, `list-sensitivity-sublabels` | Identify whether a suitable label exists for the exposed content type; recommend mandatory labeling. |
+| 17 | Check retention labels | `list-retention-labels`, `list-retention-events`, `list-retention-event-types` | Confirm the content was not under an active retention or hold policy that the revocation could violate. |
+| 18 | Cross-check legal holds | `list-subject-rights-requests` | If an open DSAR or litigation hold covers this content, coordinate with Legal before any further action. |
+| 19 | Recommend tenant hardening | *(advisory — read-only for settings)* | Disable *Anyone* links tenant-wide, enforce link expiration, require guest MFA. Documented in Phase 5 as a follow-up. |
+
+---
+
+## Phase 5 — Documentation and audit
+
+| # | Action | MCP tool | Notes |
+|---|---|---|---|
+| 20 | Update the security incident | `update-security-incident` | Classification (`truePositive / dataExfiltration` or `falsePositive / accidentalShare`), status. |
+| 21 | Narrative comment on the alert | `add-security-alert-comment` | Scope (site + drives), actor, permission changes applied. |
+| 22 | Investigation audit log | `list-directory-audits` | Filter on the responder, window of the response. Attach to the incident. |
+| 23 | Governance follow-ups register | *(output as markdown)* | Tenant hardening, labeling gaps, missing retention — anything the investigation surfaced that is out of scope for the incident itself. |
+
+---
+
+## Full-run demo prompt (single-shot)
+
+> "Site `<siteUrl>` was flagged by DLP with an anomalous external-share volume. Run the SharePoint exfiltration playbook:
+>
+> 1. Scope — pull tenant sharing settings, the site profile, all permissions, drives and subsites, 30-day analytics, and sensitivity labels.
+> 2. Actor / timeline — profile the site owner, pull directory-audit sharing events and sign-ins over 30 days, correlate with open security alerts. If file-level forensics are needed, output a handoff for Purview.
+> 3. Containment — dry-run every write: delete anonymous / out-of-allowlist grants, downgrade over-permissive partner grants to read-only, wait for my confirmation before each action.
+> 4. Governance — check sensitivity and retention label coverage; flag any hold conflict.
+> 5. Documentation — update the incident, comment the alert, produce the investigation audit log, and a governance follow-up register for tenant hardening recommendations."
+
+---
+
+## Demo talking points
+
+- **Different tool family** — exercises `sharepointadmin` and `reports` presets, which the first three playbooks do not. Demonstrates the breadth beyond identity.
+- **Downgrade-first philosophy** — `update-site-permission` before `delete-site-permission`. Reflects real-world practice: don't break collaboration while responding.
+- **Scope honesty** — file-level access forensics is explicitly handed off to Purview rather than faked. Same pattern as the phishing playbook.
+- **Prevention loop** — Phase 4 surfaces labeling and tenant-settings gaps. Keeps the playbook from being pure reaction.
+
+---
+
+## Related playbooks
+
+- [Compromised Account](compromised-account.md) — triggered when the sharing actor is a confirmed compromise (not a negligent or departing insider).
+- [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) — a phishing lure sometimes drops an OAuth app *or* coerces a user into sharing a OneDrive link externally.
+- [OAuth Illicit Consent](oauth-illicit-consent.md) — apps granted `Files.Read.All` or `Sites.Read.All` through consent phishing show up here as the exfiltration vector.
+
+See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.


### PR DESCRIPTION
## Summary

- Adds `docs/playbooks/` with four multi-phase security incident response scenarios, each mapping every step to a concrete MCP tool verified against `src/endpoints.json`:
  - **Compromised Account** — end-to-end user-scoped response (investigation → containment → audit).
  - **Phishing Campaign (Tenant-Wide)** — scoping + explicit handoff to Defender Threat Explorer / Purview for mailbox purge (the admin server does not expose per-message ops).
  - **OAuth Illicit Consent** — service-principal-scoped response with token-economy guidance (disable SP before revoking sessions) + permission-grant-policy hardening.
  - **SharePoint / OneDrive Exfiltration** — site-level response with a downgrade-before-delete philosophy and a Purview handoff for file-level forensics.
- Catalogue at `docs/playbooks/README.md` — tool-family matrix, inter-playbook handoff diagram, contribution guidance.
- Cross-links added from `README.md` and `docs/USE_CASES.md` so the playbooks are discoverable from the top of the docs tree.
- Together the four playbooks exercise 9 of the 15 tool-category presets defined in `src/tool-categories.ts` and complement the one-paragraph recipes already in `USE_CASES.md`.

No code or tool changes — documentation only.

## Test plan

- [ ] Render `docs/playbooks/README.md` and each of the four playbook files on GitHub — tables, headings, and ASCII diagram render correctly.
- [ ] Click every inter-document link from the new files (`../APP_REGISTRATION.md`, `../USE_CASES.md`, `../RISK_MODEL.md`, `../../src/tool-categories.ts`, `../../src/endpoints.json`, and cross-playbook links).
- [ ] Verify the two integration links land correctly: `README.md` docs table → `docs/playbooks/README.md`; `docs/USE_CASES.md` preamble → `playbooks/README.md`.
- [ ] Spot-check tool names referenced in the playbooks against `src/endpoints.json` (already verified during authoring; reviewer can re-check a sample).

🤖 Generated with [Claude Code](https://claude.com/claude-code)