### PR TITLE
style(playbooks): fix prettier formatting

### DIFF
--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -7,7 +7,7 @@ Playbooks are the long-form counterpart to [USE_CASES.md](../USE_CASES.md). A us
 Each playbook follows the same structure:
 
 1. **Trigger signals** — how the scenario is detected.
-2. **Scope boundary** (when relevant) — what the server *can* and *cannot* do for this scenario. Forensic or remediation steps that live outside this server are called out and handed off explicitly.
+2. **Scope boundary** (when relevant) — what the server _can_ and _cannot_ do for this scenario. Forensic or remediation steps that live outside this server are called out and handed off explicitly.
 3. **Prerequisites** — presets, delegated permissions, guardrails.
 4. **Phased procedure** — investigation → containment → hardening → documentation. Each step maps to a concrete MCP tool with its risk level.
 5. **Sample prompts** — per phase + a full-run single-shot prompt.
@@ -17,12 +17,12 @@ Each playbook follows the same structure:
 
 ## Catalogue
 
-| # | Playbook | Scope | Tool families | Completeness |
-|---|---|---|---|---|
-| 1 | [Compromised Account](compromised-account.md) | A single user identity is suspected compromised. | `identity`, `audit`, `security`, `response` | End-to-end (investigation → containment → audit). |
-| 2 | [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) | A phishing email reached multiple mailboxes. | `security`, `exchange`, `audit`, `identity` | Scoping + handoff (purge happens outside the server). |
-| 3 | [OAuth Illicit Consent](oauth-illicit-consent.md) | A malicious OAuth application holds delegated or application permissions. | `identity`, `audit`, `security`, `compliance`, `response` | End-to-end + prevention (permission-grant policy review). |
-| 4 | [SharePoint / OneDrive Exfiltration](sharepoint-exfiltration.md) | Anomalous external sharing or mass download on a SharePoint site or OneDrive. | `sharepointadmin`, `audit`, `security`, `identity`, `reports`, `response` | End-to-end at the site level + handoff to Purview for file-level forensics. |
+| #   | Playbook                                                         | Scope                                                                         | Tool families                                                             | Completeness                                                                |
+| --- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 1   | [Compromised Account](compromised-account.md)                    | A single user identity is suspected compromised.                              | `identity`, `audit`, `security`, `response`                               | End-to-end (investigation → containment → audit).                           |
+| 2   | [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md)       | A phishing email reached multiple mailboxes.                                  | `security`, `exchange`, `audit`, `identity`                               | Scoping + handoff (purge happens outside the server).                       |
+| 3   | [OAuth Illicit Consent](oauth-illicit-consent.md)                | A malicious OAuth application holds delegated or application permissions.     | `identity`, `audit`, `security`, `compliance`, `response`                 | End-to-end + prevention (permission-grant policy review).                   |
+| 4   | [SharePoint / OneDrive Exfiltration](sharepoint-exfiltration.md) | Anomalous external sharing or mass download on a SharePoint site or OneDrive. | `sharepointadmin`, `audit`, `security`, `identity`, `reports`, `response` | End-to-end at the site level + handoff to Purview for file-level forensics. |
 
 ---
 
@@ -70,7 +70,7 @@ Selected to showcase distinct capability surfaces of the server in the shortest 
 
 - **#1 Compromised Account** — end-to-end on a single identity. The baseline demo.
 - **#2 Phishing** — shows the server's honesty about scope boundaries. Stops at a handoff package instead of pretending to purge.
-- **#3 OAuth Illicit Consent** — shows sophistication (order of operations matters: disable SP *before* revoking sessions) and closes the prevention loop.
+- **#3 OAuth Illicit Consent** — shows sophistication (order of operations matters: disable SP _before_ revoking sessions) and closes the prevention loop.
 - **#4 SharePoint Exfiltration** — widens the narrative beyond identity into data governance. Exercises a completely different preset family.
 
 Together they exercise 9 of the 15 tool-category presets defined in [src/tool-categories.ts](../../src/tool-categories.ts).
@@ -81,7 +81,7 @@ Together they exercise 9 of the 15 tool-category presets defined in [src/tool-ca
 
 When adding a playbook:
 
-1. Confirm every MCP tool referenced actually exists in [src/endpoints.json](../../src/endpoints.json). Do not include tools that *should* exist — add them to the server first, or handle the gap with an explicit handoff section.
+1. Confirm every MCP tool referenced actually exists in [src/endpoints.json](../../src/endpoints.json). Do not include tools that _should_ exist — add them to the server first, or handle the gap with an explicit handoff section.
 2. Follow the 5-section structure listed at the top of this page. Consistency matters more than length.
 3. Classify each write tool's risk (`low` / `medium` / `high` / `critical`) in line with [docs/RISK_MODEL.md](../RISK_MODEL.md).
-4. Add the playbook to the catalogue table above and to any relevant *Related playbooks* section in existing files.
+4. Add the playbook to the catalogue table above and to any relevant _Related playbooks_ section in existing files.

--- a/docs/playbooks/compromised-account.md
+++ b/docs/playbooks/compromised-account.md
@@ -12,7 +12,7 @@ Any of the following typically opens this playbook:
 
 - A user appears in `list-risky-users` with `riskLevel = high`.
 - A security alert or incident (Microsoft 365 Defender / Identity Protection) targets a user identity.
-- A sign-in flagged *impossible travel*, *atypical location*, or *anonymous IP*.
+- A sign-in flagged _impossible travel_, _atypical location_, or _anonymous IP_.
 - A user self-reports a phishing click or a stolen credential.
 
 ---
@@ -52,13 +52,13 @@ Never run the containment phase against a break-glass account. Confirm the targe
 
 Goal: confirm the compromise, reconstruct the attacker's timeline, and measure the blast radius.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 1 | Confirm the subject and baseline context | `get-user`, `get-risky-user` | Display name, UPN, job title, last interactive sign-in, current risk state. |
-| 2 | Reconstruct the sign-in timeline | `list-sign-ins` | Filter on `userId` and the last 24–72 h. Extract IP, location, client app, conditional access result, risk level per sign-in. |
-| 3 | Correlate with Identity Protection detections | `list-risk-detections`, `list-risky-user-history` | Maps detections (e.g. *malwareInfectedIPAddress*, *unfamiliarFeatures*) to sign-ins from step 2. |
-| 4 | Measure blast radius — what did the attacker do? | `list-directory-audits` | Filter `initiatedBy.user.id = <userId>`. Look for new OAuth consents, new role assignments, password resets, mail rules, group memberships, application registrations. |
-| 5 | Detect MFA persistence added by the attacker | `list-user-auth-methods` | A phone or authenticator app registered during the compromise window is a classic persistence mechanism. |
+| #   | Objective                                        | MCP tool(s)                                       | Notes                                                                                                                                                                  |
+| --- | ------------------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Confirm the subject and baseline context         | `get-user`, `get-risky-user`                      | Display name, UPN, job title, last interactive sign-in, current risk state.                                                                                            |
+| 2   | Reconstruct the sign-in timeline                 | `list-sign-ins`                                   | Filter on `userId` and the last 24–72 h. Extract IP, location, client app, conditional access result, risk level per sign-in.                                          |
+| 3   | Correlate with Identity Protection detections    | `list-risk-detections`, `list-risky-user-history` | Maps detections (e.g. _malwareInfectedIPAddress_, _unfamiliarFeatures_) to sign-ins from step 2.                                                                       |
+| 4   | Measure blast radius — what did the attacker do? | `list-directory-audits`                           | Filter `initiatedBy.user.id = <userId>`. Look for new OAuth consents, new role assignments, password resets, mail rules, group memberships, application registrations. |
+| 5   | Detect MFA persistence added by the attacker     | `list-user-auth-methods`                          | A phone or authenticator app registered during the compromise window is a classic persistence mechanism.                                                               |
 
 ### Sample investigation prompt
 
@@ -72,12 +72,12 @@ Goal: kill active access, remove attacker persistence, and feed the Identity Pro
 
 > Always run every write in dry-run first: have the LLM list the target entity and the exact operation, wait for operator confirmation, then execute.
 
-| # | Action | MCP tool | Risk | Effect |
-|---|---|---|---|---|
-| 6 | Revoke all active sessions (refresh tokens) | `revoke-user-sessions` | **high** | Forces re-authentication on every client within minutes. |
-| 7 | Disable the account if severity warrants it | `disable-user-account` | **critical** | Blocks all sign-ins. Use when the user can be reached through an alternate channel. |
-| 8 | Remove attacker-added phone MFA | `delete-user-phone-auth-method` | **high** | Removes the rogue phone. Repeat with other `delete-user-*-auth-method` tools if authenticator or FIDO was added. |
-| 9 | Confirm compromised in Identity Protection | `confirm-compromised-users` | **high** | Marks `riskState = confirmedCompromised`. Feeds the ML model and triggers dependent Conditional Access policies. |
+| #   | Action                                      | MCP tool                        | Risk         | Effect                                                                                                           |
+| --- | ------------------------------------------- | ------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| 6   | Revoke all active sessions (refresh tokens) | `revoke-user-sessions`          | **high**     | Forces re-authentication on every client within minutes.                                                         |
+| 7   | Disable the account if severity warrants it | `disable-user-account`          | **critical** | Blocks all sign-ins. Use when the user can be reached through an alternate channel.                              |
+| 8   | Remove attacker-added phone MFA             | `delete-user-phone-auth-method` | **high**     | Removes the rogue phone. Repeat with other `delete-user-*-auth-method` tools if authenticator or FIDO was added. |
+| 9   | Confirm compromised in Identity Protection  | `confirm-compromised-users`     | **high**     | Marks `riskState = confirmedCompromised`. Feeds the ML model and triggers dependent Conditional Access policies. |
 
 ### Sample containment prompt
 
@@ -89,11 +89,11 @@ Goal: kill active access, remove attacker persistence, and feed the Identity Pro
 
 Goal: record the response on the incident/alert, and produce a traceability report proving every action taken.
 
-| # | Action | MCP tool | Notes |
-|---|---|---|---|
-| 10 | Update the security incident | `update-security-incident` | Status (e.g. `active` → `inProgress`), classification, assignee. |
-| 11 | Leave a narrative trail on the alert | `add-security-alert-comment` | Short chronology referencing the audit window. |
-| 12 | Generate the post-incident audit report | `list-directory-audits` | Filter on the operator service principal / delegated user, over the response window. Every write from Phase 2 appears there — the loop closes. |
+| #   | Action                                  | MCP tool                     | Notes                                                                                                                                          |
+| --- | --------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 10  | Update the security incident            | `update-security-incident`   | Status (e.g. `active` → `inProgress`), classification, assignee.                                                                               |
+| 11  | Leave a narrative trail on the alert    | `add-security-alert-comment` | Short chronology referencing the audit window.                                                                                                 |
+| 12  | Generate the post-incident audit report | `list-directory-audits`      | Filter on the operator service principal / delegated user, over the response window. Every write from Phase 2 appears there — the loop closes. |
 
 ### Sample documentation prompt
 
@@ -126,7 +126,7 @@ Use this when demoing the end-to-end flow in one shot. The LLM will chain all th
 
 ## Related playbooks
 
-- Phishing campaign (tenant-wide) — *draft*
-- OAuth illicit consent — *draft*
+- Phishing campaign (tenant-wide) — _draft_
+- OAuth illicit consent — _draft_
 
 See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.

--- a/docs/playbooks/oauth-illicit-consent.md
+++ b/docs/playbooks/oauth-illicit-consent.md
@@ -8,7 +8,7 @@ Scope note: this admin server can perform the **full loop** (scope, contain, har
 
 ## Background
 
-Consent phishing: the attacker sends a link to a Microsoft consent screen for an OAuth application they control. The user clicks *Accept* and grants delegated scopes like `Mail.Read`, `Files.Read.All`, `offline_access`. The attacker receives an access token + refresh token for that user. A tenant admin variant asks for admin consent on `AllPrincipals`, gaining access to every user in one click.
+Consent phishing: the attacker sends a link to a Microsoft consent screen for an OAuth application they control. The user clicks _Accept_ and grants delegated scopes like `Mail.Read`, `Files.Read.All`, `offline_access`. The attacker receives an access token + refresh token for that user. A tenant admin variant asks for admin consent on `AllPrincipals`, gaining access to every user in one click.
 
 Key properties:
 
@@ -23,7 +23,7 @@ Key properties:
 
 - Service principal appears in `list-risky-service-principals` with `riskLevel = high`.
 - Defender / Identity Protection alert referencing a suspicious OAuth application.
-- A user reports they clicked *Accept* on an unexpected consent screen.
+- A user reports they clicked _Accept_ on an unexpected consent screen.
 - Spike of Graph API calls by a newly-created service principal (see `list-sign-ins` filtered on `appDisplayName`).
 - A pending request in `list-app-consent-requests` from an unknown publisher.
 
@@ -58,13 +58,13 @@ See [APP_REGISTRATION.md](../APP_REGISTRATION.md).
 
 Goal: go from the signal to a full profile of the suspect service principal.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 1 | Pull the service principal profile | `get-service-principal` | `appId`, `publisherName`, `verifiedPublisher`, `signInAudience`, `createdDateTime`. Newly created + unverified publisher + multi-tenant = strong signal. |
-| 2 | Check registered credentials | `list-app-federated-credentials` | Federated credentials are a modern persistence vector. Any FIC added recently is suspicious. |
-| 3 | Check ownership | `list-service-principal-owners`, `list-application-owners` | A compromised internal user who owns a suspicious app is a secondary compromise. |
-| 4 | Pull risk detections on the SP | `list-service-principal-risk-detections`, `get-risky-service-principal` | Microsoft-flagged risky behaviours (leaked credentials, anomalous activity). |
-| 5 | Find the home application object | `get-application` | Only present if the app is registered in *this* tenant (single-tenant or multi-tenant publisher = home tenant). |
+| #   | Objective                          | MCP tool(s)                                                             | Notes                                                                                                                                                    |
+| --- | ---------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Pull the service principal profile | `get-service-principal`                                                 | `appId`, `publisherName`, `verifiedPublisher`, `signInAudience`, `createdDateTime`. Newly created + unverified publisher + multi-tenant = strong signal. |
+| 2   | Check registered credentials       | `list-app-federated-credentials`                                        | Federated credentials are a modern persistence vector. Any FIC added recently is suspicious.                                                             |
+| 3   | Check ownership                    | `list-service-principal-owners`, `list-application-owners`              | A compromised internal user who owns a suspicious app is a secondary compromise.                                                                         |
+| 4   | Pull risk detections on the SP     | `list-service-principal-risk-detections`, `get-risky-service-principal` | Microsoft-flagged risky behaviours (leaked credentials, anomalous activity).                                                                             |
+| 5   | Find the home application object   | `get-application`                                                       | Only present if the app is registered in _this_ tenant (single-tenant or multi-tenant publisher = home tenant).                                          |
 
 ### Sample prompt
 
@@ -76,13 +76,13 @@ Goal: go from the signal to a full profile of the suspect service principal.
 
 Goal: enumerate every grant this service principal holds, and every user affected.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 6 | Enumerate delegated permission grants | `list-oauth2-grants` | Filter `clientId eq '<spObjectId>'`. Each result: `principalId` (user who consented), `scope` (space-separated). `consentType = AllPrincipals` means tenant-wide admin consent — blast radius = every user. |
-| 7 | Enumerate application permission grants | `list-sp-app-role-assignments` | App-only permissions (e.g. `Mail.Read` as application) — no user interaction needed, attacker can call Graph on every mailbox. Highest severity. |
-| 8 | List configured delegated permissions | `list-sp-delegated-permissions` | What scopes *could* the SP request — baseline for Phase 4 policy tightening. |
-| 9 | Who actually authenticated to it | `list-sign-ins` | Filter `appDisplayName eq '<malicious app>'` over the window since creation. Gives the real list of active victims, separate from the consented list. |
-| 10 | Consent event timeline | `list-directory-audits` | Filter on `activityDisplayName in ('Consent to application', 'Add app role assignment grant to service principal')` and the SP's `targetResources`. Produces the forensic timeline. |
+| #   | Objective                               | MCP tool(s)                     | Notes                                                                                                                                                                                                       |
+| --- | --------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 6   | Enumerate delegated permission grants   | `list-oauth2-grants`            | Filter `clientId eq '<spObjectId>'`. Each result: `principalId` (user who consented), `scope` (space-separated). `consentType = AllPrincipals` means tenant-wide admin consent — blast radius = every user. |
+| 7   | Enumerate application permission grants | `list-sp-app-role-assignments`  | App-only permissions (e.g. `Mail.Read` as application) — no user interaction needed, attacker can call Graph on every mailbox. Highest severity.                                                            |
+| 8   | List configured delegated permissions   | `list-sp-delegated-permissions` | What scopes _could_ the SP request — baseline for Phase 4 policy tightening.                                                                                                                                |
+| 9   | Who actually authenticated to it        | `list-sign-ins`                 | Filter `appDisplayName eq '<malicious app>'` over the window since creation. Gives the real list of active victims, separate from the consented list.                                                       |
+| 10  | Consent event timeline                  | `list-directory-audits`         | Filter on `activityDisplayName in ('Consent to application', 'Add app role assignment grant to service principal')` and the SP's `targetResources`. Produces the forensic timeline.                         |
 
 ### Severity classification
 
@@ -97,20 +97,21 @@ Goal: enumerate every grant this service principal holds, and every user affecte
 
 Order matters. Neutralise the SP **before** revoking user sessions — otherwise the attacker uses the remaining refresh-token window to re-consent on fresh sessions or pivot.
 
-| # | Action | MCP tool | Risk | Effect |
-|---|---|---|---|---|
-| 11 | Soft-block the service principal | `update-service-principal` with `accountEnabled = false` | **high** | Prevents all new token issuance. Preserves the audit trail and the grants themselves for forensics. Preferred first step. |
-| 12 | Strip attacker-added credentials | `remove-sp-key`, `remove-sp-password` | **high** | If credentials were added post-compromise, remove them. Do not remove credentials you cannot correlate to the attacker. |
-| 13 | Remove rogue owners | `remove-sp-owner` | **medium** | If an internal user owns the malicious SP and is confirmed complicit / compromised. |
-| 14 | Mark as confirmed compromised | `confirm-compromised-service-principals` | **high** | Feeds Identity Protection, triggers dependent Conditional Access policies for SPs. |
-| 15 | Revoke affected user sessions | `revoke-user-sessions` | **high** | For every user in steps 6 and 9. Kills active access tokens. |
-| 16 | Delete the service principal (optional, after forensics) | `delete-service-principal` | **critical** | Only after evidence preservation. Destroys the SP object and all grants. Irreversible. |
+| #   | Action                                                   | MCP tool                                                 | Risk         | Effect                                                                                                                    |
+| --- | -------------------------------------------------------- | -------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| 11  | Soft-block the service principal                         | `update-service-principal` with `accountEnabled = false` | **high**     | Prevents all new token issuance. Preserves the audit trail and the grants themselves for forensics. Preferred first step. |
+| 12  | Strip attacker-added credentials                         | `remove-sp-key`, `remove-sp-password`                    | **high**     | If credentials were added post-compromise, remove them. Do not remove credentials you cannot correlate to the attacker.   |
+| 13  | Remove rogue owners                                      | `remove-sp-owner`                                        | **medium**   | If an internal user owns the malicious SP and is confirmed complicit / compromised.                                       |
+| 14  | Mark as confirmed compromised                            | `confirm-compromised-service-principals`                 | **high**     | Feeds Identity Protection, triggers dependent Conditional Access policies for SPs.                                        |
+| 15  | Revoke affected user sessions                            | `revoke-user-sessions`                                   | **high**     | For every user in steps 6 and 9. Kills active access tokens.                                                              |
+| 16  | Delete the service principal (optional, after forensics) | `delete-service-principal`                               | **critical** | Only after evidence preservation. Destroys the SP object and all grants. Irreversible.                                    |
 
 > The compromised-account playbook is triggered for each user who consented to sensitive scopes — especially those whose sign-ins in step 9 show attacker-infrastructure IPs.
 
 ### Sample containment prompt
 
 > "Containment for service principal `<spObjectId>`. Dry-run every write first:
+>
 > 1. Set `accountEnabled = false` on the SP.
 > 2. List any secret/key added after `<creation date + 1 day>` and propose removal.
 > 3. Mark the SP as confirmed compromised.
@@ -124,21 +125,21 @@ Order matters. Neutralise the SP **before** revoking user sessions — otherwise
 
 The single highest-leverage control against consent phishing is **restricting user consent**.
 
-| # | Objective | MCP tool(s) | Action |
-|---|---|---|---|
-| 17 | Review the tenant's consent policy | `list-permission-grant-policies` | Confirm which app-role / delegated scopes users can consent to without admin approval. Default is often too permissive. |
-| 18 | Review outstanding consent requests | `list-app-consent-requests`, `list-user-consent-requests` | Clear the queue; look for other suspicious pending requests from the same attacker. |
-| 19 | Recommend the admin-consent workflow if not enabled | *(read-only — configuration change is out of MCP scope)* | Directs any consent for risky scopes to admin review. Biggest prevention win. |
+| #   | Objective                                           | MCP tool(s)                                               | Action                                                                                                                  |
+| --- | --------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 17  | Review the tenant's consent policy                  | `list-permission-grant-policies`                          | Confirm which app-role / delegated scopes users can consent to without admin approval. Default is often too permissive. |
+| 18  | Review outstanding consent requests                 | `list-app-consent-requests`, `list-user-consent-requests` | Clear the queue; look for other suspicious pending requests from the same attacker.                                     |
+| 19  | Recommend the admin-consent workflow if not enabled | _(read-only — configuration change is out of MCP scope)_  | Directs any consent for risky scopes to admin review. Biggest prevention win.                                           |
 
 ---
 
 ## Phase 5 — Documentation and audit
 
-| # | Action | MCP tool | Notes |
-|---|---|---|---|
-| 20 | Update the security incident | `update-security-incident` | Classification `truePositive / maliciousApp`, status `resolved` once Phase 3 complete. |
-| 21 | Narrative on the alert | `add-security-alert-comment` | Chronology + scope summary + containment steps. |
-| 22 | Investigation audit log | `list-directory-audits` | Filter on the responder, response window. Attach to the incident. |
+| #   | Action                       | MCP tool                     | Notes                                                                                  |
+| --- | ---------------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
+| 20  | Update the security incident | `update-security-incident`   | Classification `truePositive / maliciousApp`, status `resolved` once Phase 3 complete. |
+| 21  | Narrative on the alert       | `add-security-alert-comment` | Chronology + scope summary + containment steps.                                        |
+| 22  | Investigation audit log      | `list-directory-audits`      | Filter on the responder, response window. Attach to the incident.                      |
 
 ---
 
@@ -152,14 +153,14 @@ The single highest-leverage control against consent phishing is **restricting us
 > 4. Hardening — summarize the tenant permission-grant policy and outstanding consent requests; recommend follow-ups.
 > 5. Documentation — update the incident, comment the alert, produce the investigation audit log.
 >
-> Route every user who consented to sensitive scopes (Mail.*, Files.*, User.Read.All) to the compromised-account playbook as a side-output."
+> Route every user who consented to sensitive scopes (Mail._, Files._, User.Read.All) to the compromised-account playbook as a side-output."
 
 ---
 
 ## Demo talking points
 
 - **Full loop inside the server** — contrast with the phishing playbook where purge lives outside. Here investigation → containment → hardening → documentation all chain through the MCP server, no handoff.
-- **Token-economy literacy** — the playbook surfaces *why* revoking sessions before killing the SP is the wrong order. The LLM explains the invariant; the tools enforce it.
+- **Token-economy literacy** — the playbook surfaces _why_ revoking sessions before killing the SP is the wrong order. The LLM explains the invariant; the tools enforce it.
 - **Severity classification** — critical (app permissions) vs high (tenant-wide delegated) vs medium / low. Mechanical but routinely mishandled by human responders under pressure.
 - **Preventive follow-up** — Phase 4 exposes the permission-grant policy as the root cause. Most incident playbooks stop at remediation; this one closes the prevention loop in the same conversation.
 

--- a/docs/playbooks/phishing-tenant-wide.md
+++ b/docs/playbooks/phishing-tenant-wide.md
@@ -19,7 +19,7 @@ This admin-focused server does **not** expose per-message mailbox operations (no
 
 What this server **does** give you for phishing:
 
-- Tenant-wide message-trace visibility — *who received what, when, from where*.
+- Tenant-wide message-trace visibility — _who received what, when, from where_.
 - Victim correlation — sign-ins, risk detections, directory audits post-delivery.
 - Security incident / alert lifecycle — classification, comments, closure.
 - Threat intel enrichment — IOC lookups, article cross-reference.
@@ -45,7 +45,7 @@ The playbook ends with a **handoff package** (list of affected UPNs, message IDs
 
 - `SecurityAlert.ReadWrite.All`, `SecurityIncident.ReadWrite.All`
 - `ThreatIntelligence.Read.All`, `ThreatAssessment.Read.All`
-- `Mail.ReadBasic.All` *(for message trace)* or the Exchange Online `MessageTracking` role
+- `Mail.ReadBasic.All` _(for message trace)_ or the Exchange Online `MessageTracking` role
 - `AuditLog.Read.All`, `Directory.Read.All`
 - `IdentityRiskEvent.Read.All`, `IdentityRiskyUser.Read.All`
 
@@ -57,13 +57,13 @@ See [APP_REGISTRATION.md](../APP_REGISTRATION.md).
 
 Goal: turn a single signal into a list of delivered messages, sender infrastructure, and affected recipients.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 1 | Enumerate related alerts and incidents | `list-security-alerts`, `list-security-incidents`, `get-security-incident` | Filter on `category = Phishing` or keywords from the reported message. |
-| 2 | Pull user-submitted reports | `list-threat-assessment-requests` | Employees using the *Report Phishing* button surface here. |
-| 3 | Match against known campaigns | `list-threat-intel-articles`, `list-threat-intel-article-indicators` | Cross-reference sender domain, URL, IP against Microsoft threat intel articles. |
-| 4 | Measure delivery footprint | `list-message-traces` | Filter by `senderAddress`, `subject`, `fromDateTime`, `toDateTime`. Extract recipient list, delivery status, message IDs. |
-| 5 | Inspect a suspicious delivery in detail | `get-message-trace` | For each high-signal message ID, get the full trace (hops, spam verdict, policy hits). |
+| #   | Objective                               | MCP tool(s)                                                                | Notes                                                                                                                     |
+| --- | --------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Enumerate related alerts and incidents  | `list-security-alerts`, `list-security-incidents`, `get-security-incident` | Filter on `category = Phishing` or keywords from the reported message.                                                    |
+| 2   | Pull user-submitted reports             | `list-threat-assessment-requests`                                          | Employees using the _Report Phishing_ button surface here.                                                                |
+| 3   | Match against known campaigns           | `list-threat-intel-articles`, `list-threat-intel-article-indicators`       | Cross-reference sender domain, URL, IP against Microsoft threat intel articles.                                           |
+| 4   | Measure delivery footprint              | `list-message-traces`                                                      | Filter by `senderAddress`, `subject`, `fromDateTime`, `toDateTime`. Extract recipient list, delivery status, message IDs. |
+| 5   | Inspect a suspicious delivery in detail | `get-message-trace`                                                        | For each high-signal message ID, get the full trace (hops, spam verdict, policy hits).                                    |
 
 ### Sample prompt
 
@@ -77,12 +77,12 @@ A recipient is not yet a victim. Engagement is inferred from sign-in activity, r
 
 For each recipient from Phase 1:
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 6 | Baseline the user | `get-user` | Confirm identity, department, privileged-role membership (privileged targets escalate severity). |
-| 7 | Detect post-delivery suspicious sign-ins | `list-sign-ins` | Window starts at message delivery time. Look for atypical location, anonymous IP, legacy auth, MFA-not-satisfied-but-granted. |
-| 8 | Correlate with Identity Protection | `list-risk-detections`, `list-risky-users` | A detection timestamped just after delivery is a strong engagement signal. |
-| 9 | Spot attacker actions post-click | `list-directory-audits` | Filter `initiatedBy.user.id = <recipientId>` from delivery onward. New OAuth consents and mail rules (visible as audit entries) are the two highest-signal events. |
+| #   | Objective                                | MCP tool(s)                                | Notes                                                                                                                                                              |
+| --- | ---------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 6   | Baseline the user                        | `get-user`                                 | Confirm identity, department, privileged-role membership (privileged targets escalate severity).                                                                   |
+| 7   | Detect post-delivery suspicious sign-ins | `list-sign-ins`                            | Window starts at message delivery time. Look for atypical location, anonymous IP, legacy auth, MFA-not-satisfied-but-granted.                                      |
+| 8   | Correlate with Identity Protection       | `list-risk-detections`, `list-risky-users` | A detection timestamped just after delivery is a strong engagement signal.                                                                                         |
+| 9   | Spot attacker actions post-click         | `list-directory-audits`                    | Filter `initiatedBy.user.id = <recipientId>` from delivery onward. New OAuth consents and mail rules (visible as audit entries) are the two highest-signal events. |
 
 ### Classification output
 
@@ -116,11 +116,11 @@ The handoff should include:
 
 ## Phase 4 — Documentation and closure
 
-| # | Action | MCP tool | Notes |
-|---|---|---|---|
-| 10 | Bind related alerts to a single incident | `update-security-incident` | Classification `truePositivePhishing`, assignee, status `inProgress`. |
-| 11 | Narrative on each alert | `add-security-alert-comment` | Timeline bullet points — detection, scope, victims, handoff sent. |
-| 12 | Audit trail of the investigation window | `list-directory-audits` | Capture every operation the responder performed through the server. Attach to the incident record. |
+| #   | Action                                   | MCP tool                     | Notes                                                                                              |
+| --- | ---------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| 10  | Bind related alerts to a single incident | `update-security-incident`   | Classification `truePositivePhishing`, assignee, status `inProgress`.                              |
+| 11  | Narrative on each alert                  | `add-security-alert-comment` | Timeline bullet points — detection, scope, victims, handoff sent.                                  |
+| 12  | Audit trail of the investigation window  | `list-directory-audits`      | Capture every operation the responder performed through the server. Attach to the incident record. |
 
 ---
 
@@ -149,6 +149,6 @@ The handoff should include:
 ## Related playbooks
 
 - [Compromised Account](compromised-account.md) — triggered per confirmed victim.
-- OAuth illicit consent — *draft*. Often a phishing lure leads to consent phishing instead of credential theft — that flow is covered separately.
+- OAuth illicit consent — _draft_. Often a phishing lure leads to consent phishing instead of credential theft — that flow is covered separately.
 
 See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.

--- a/docs/playbooks/sharepoint-exfiltration.md
+++ b/docs/playbooks/sharepoint-exfiltration.md
@@ -8,7 +8,7 @@ Response to suspected data exfiltration through SharePoint Online or OneDrive fo
 
 - A Defender or DLP alert referencing anomalous download volume or mass-sharing.
 - HR notifies of an employee departure; a privileged offboarding review is required.
-- A user reports an accidental *Anyone with the link* share on a sensitive document.
+- A user reports an accidental _Anyone with the link_ share on a sensitive document.
 - A quarterly audit surfaces sites with excessive external guests or anonymous links.
 - Spike in `get-sharepoint-usage-report` external-users metric.
 
@@ -59,16 +59,16 @@ Before revoking or downgrading a permission on a production site, confirm the si
 
 ## Phase 1 — Scope the exposure
 
-Goal: quantify *what is shared*, *with whom*, *how broadly*.
+Goal: quantify _what is shared_, _with whom_, _how broadly_.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 1 | Pull the tenant external-sharing baseline | `get-sharepoint-settings` | Tenant-level defaults for external sharing, guest experience, link expiration. Baseline for what *should* be allowed. |
-| 2 | Identify the suspect site(s) | `list-sharepoint-sites`, `get-sharepoint-site` | Filter by owner UPN for an offboarding scenario; filter by URL / title for a reported incident. |
-| 3 | Enumerate site permissions | `list-site-permissions`, `get-site-permission` | Per site: grantee identities, roles (`read` / `write` / `owner`), scope (direct user, group, anonymous link, org-wide share). |
-| 4 | Enumerate site drives and subsites | `list-site-drives`, `get-site-default-drive`, `list-site-subsites` | Establishes the full storage surface to review, not just the root site. |
-| 5 | Measure site activity | `get-site-analytics`, `get-sharepoint-usage-report` | Views, unique viewers, time window. An activity spike aligned with the alert is a strong signal. |
-| 6 | Correlate with sensitivity labels | `list-sensitivity-labels`, `list-sensitivity-sublabels` | Identifies whether the exposed content *should* have been labeled `Confidential` / `Highly Confidential` and was not — a labeling gap is a recurring root cause. |
+| #   | Objective                                 | MCP tool(s)                                                        | Notes                                                                                                                                                            |
+| --- | ----------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Pull the tenant external-sharing baseline | `get-sharepoint-settings`                                          | Tenant-level defaults for external sharing, guest experience, link expiration. Baseline for what _should_ be allowed.                                            |
+| 2   | Identify the suspect site(s)              | `list-sharepoint-sites`, `get-sharepoint-site`                     | Filter by owner UPN for an offboarding scenario; filter by URL / title for a reported incident.                                                                  |
+| 3   | Enumerate site permissions                | `list-site-permissions`, `get-site-permission`                     | Per site: grantee identities, roles (`read` / `write` / `owner`), scope (direct user, group, anonymous link, org-wide share).                                    |
+| 4   | Enumerate site drives and subsites        | `list-site-drives`, `get-site-default-drive`, `list-site-subsites` | Establishes the full storage surface to review, not just the root site.                                                                                          |
+| 5   | Measure site activity                     | `get-site-analytics`, `get-sharepoint-usage-report`                | Views, unique viewers, time window. An activity spike aligned with the alert is a strong signal.                                                                 |
+| 6   | Correlate with sensitivity labels         | `list-sensitivity-labels`, `list-sensitivity-sublabels`            | Identifies whether the exposed content _should_ have been labeled `Confidential` / `Highly Confidential` and was not — a labeling gap is a recurring root cause. |
 
 ### Sample prompt
 
@@ -80,13 +80,13 @@ Goal: quantify *what is shared*, *with whom*, *how broadly*.
 
 Goal: attribute the permission changes and correlate with user activity. For offboarding scenarios, establish what the departing user shared in their final weeks.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 7 | Baseline the actor | `get-user` | Role, department, manager, tenure. Privileged-role members trigger higher severity. |
-| 8 | Sharing events from directory audit | `list-directory-audits` | Filter on `category = SharePoint` and `activityDisplayName` patterns like *Add site collection administrator*, *Update site*, *Share*. Populates the operator-attributed timeline visible to Entra ID. |
-| 9 | Sign-in activity | `list-sign-ins` | Window = last 30 days. Unusual location or anonymous IP during a share-creation window is a strong engagement signal for insider-threat scenarios. |
-| 10 | Related security alerts | `list-security-alerts`, `list-security-incidents` | DLP, insider-risk, or Defender for Cloud Apps alerts on the same user or site. |
-| 11 | *(If file-level forensics required)* | **Handoff to Purview Unified Audit Log** | Per-file `FileDownloaded`, `FileSyncDownloadedFull`, `SharingSet` events are not exposed by Graph. Hand off the user UPN, site URL, and time window. |
+| #   | Objective                            | MCP tool(s)                                       | Notes                                                                                                                                                                                                  |
+| --- | ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 7   | Baseline the actor                   | `get-user`                                        | Role, department, manager, tenure. Privileged-role members trigger higher severity.                                                                                                                    |
+| 8   | Sharing events from directory audit  | `list-directory-audits`                           | Filter on `category = SharePoint` and `activityDisplayName` patterns like _Add site collection administrator_, _Update site_, _Share_. Populates the operator-attributed timeline visible to Entra ID. |
+| 9   | Sign-in activity                     | `list-sign-ins`                                   | Window = last 30 days. Unusual location or anonymous IP during a share-creation window is a strong engagement signal for insider-threat scenarios.                                                     |
+| 10  | Related security alerts              | `list-security-alerts`, `list-security-incidents` | DLP, insider-risk, or Defender for Cloud Apps alerts on the same user or site.                                                                                                                         |
+| 11  | _(If file-level forensics required)_ | **Handoff to Purview Unified Audit Log**          | Per-file `FileDownloaded`, `FileSyncDownloadedFull`, `SharingSet` events are not exposed by Graph. Hand off the user UPN, site URL, and time window.                                                   |
 
 ---
 
@@ -94,14 +94,14 @@ Goal: attribute the permission changes and correlate with user activity. For off
 
 Order: revoke / downgrade at the site first, then tighten the actor's identity if warranted.
 
-| # | Action | MCP tool | Risk | Effect |
-|---|---|---|---|---|
-| 12 | Remove anonymous / excessive share links | `delete-site-permission` | **high** | Revokes a specific permission entry. Use for anonymous links and grantees clearly outside policy. |
-| 13 | Downgrade over-permissive grants | `update-site-permission` | **medium** | Prefer downgrade (`write` → `read`) over delete when collaboration must continue. |
-| 14 | Lock down the site configuration if needed | `update-sharepoint-site` | **medium** | Constrain site-level sharing capabilities while investigation continues. |
-| 15 | If the actor is confirmed malicious or departed | `revoke-user-sessions` | **high** | Per-user session kill. Pair with the [compromised-account](compromised-account.md) playbook if insider compromise is confirmed. |
+| #   | Action                                          | MCP tool                 | Risk       | Effect                                                                                                                          |
+| --- | ----------------------------------------------- | ------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 12  | Remove anonymous / excessive share links        | `delete-site-permission` | **high**   | Revokes a specific permission entry. Use for anonymous links and grantees clearly outside policy.                               |
+| 13  | Downgrade over-permissive grants                | `update-site-permission` | **medium** | Prefer downgrade (`write` → `read`) over delete when collaboration must continue.                                               |
+| 14  | Lock down the site configuration if needed      | `update-sharepoint-site` | **medium** | Constrain site-level sharing capabilities while investigation continues.                                                        |
+| 15  | If the actor is confirmed malicious or departed | `revoke-user-sessions`   | **high**   | Per-user session kill. Pair with the [compromised-account](compromised-account.md) playbook if insider compromise is confirmed. |
 
-> Tenant-level external-sharing policy changes (e.g. disabling *Anyone* links tenant-wide) are **not** exposed as an update tool in this server — that change is made in the SharePoint admin center or via Microsoft Graph beta endpoints not currently mapped. Flag it as a follow-up recommendation in Phase 5.
+> Tenant-level external-sharing policy changes (e.g. disabling _Anyone_ links tenant-wide) are **not** exposed as an update tool in this server — that change is made in the SharePoint admin center or via Microsoft Graph beta endpoints not currently mapped. Flag it as a follow-up recommendation in Phase 5.
 
 ### Sample containment prompt
 
@@ -113,23 +113,23 @@ Order: revoke / downgrade at the site first, then tighten the actor's identity i
 
 Recurring root cause for exfiltration incidents is missing classification. Close the loop so the same event does not happen twice.
 
-| # | Objective | MCP tool(s) | Action |
-|---|---|---|---|
-| 16 | Review sensitivity labels coverage | `list-sensitivity-labels`, `list-sensitivity-sublabels` | Identify whether a suitable label exists for the exposed content type; recommend mandatory labeling. |
-| 17 | Check retention labels | `list-retention-labels`, `list-retention-events`, `list-retention-event-types` | Confirm the content was not under an active retention or hold policy that the revocation could violate. |
-| 18 | Cross-check legal holds | `list-subject-rights-requests` | If an open DSAR or litigation hold covers this content, coordinate with Legal before any further action. |
-| 19 | Recommend tenant hardening | *(advisory — read-only for settings)* | Disable *Anyone* links tenant-wide, enforce link expiration, require guest MFA. Documented in Phase 5 as a follow-up. |
+| #   | Objective                          | MCP tool(s)                                                                    | Action                                                                                                                |
+| --- | ---------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| 16  | Review sensitivity labels coverage | `list-sensitivity-labels`, `list-sensitivity-sublabels`                        | Identify whether a suitable label exists for the exposed content type; recommend mandatory labeling.                  |
+| 17  | Check retention labels             | `list-retention-labels`, `list-retention-events`, `list-retention-event-types` | Confirm the content was not under an active retention or hold policy that the revocation could violate.               |
+| 18  | Cross-check legal holds            | `list-subject-rights-requests`                                                 | If an open DSAR or litigation hold covers this content, coordinate with Legal before any further action.              |
+| 19  | Recommend tenant hardening         | _(advisory — read-only for settings)_                                          | Disable _Anyone_ links tenant-wide, enforce link expiration, require guest MFA. Documented in Phase 5 as a follow-up. |
 
 ---
 
 ## Phase 5 — Documentation and audit
 
-| # | Action | MCP tool | Notes |
-|---|---|---|---|
-| 20 | Update the security incident | `update-security-incident` | Classification (`truePositive / dataExfiltration` or `falsePositive / accidentalShare`), status. |
-| 21 | Narrative comment on the alert | `add-security-alert-comment` | Scope (site + drives), actor, permission changes applied. |
-| 22 | Investigation audit log | `list-directory-audits` | Filter on the responder, window of the response. Attach to the incident. |
-| 23 | Governance follow-ups register | *(output as markdown)* | Tenant hardening, labeling gaps, missing retention — anything the investigation surfaced that is out of scope for the incident itself. |
+| #   | Action                         | MCP tool                     | Notes                                                                                                                                  |
+| --- | ------------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 20  | Update the security incident   | `update-security-incident`   | Classification (`truePositive / dataExfiltration` or `falsePositive / accidentalShare`), status.                                       |
+| 21  | Narrative comment on the alert | `add-security-alert-comment` | Scope (site + drives), actor, permission changes applied.                                                                              |
+| 22  | Investigation audit log        | `list-directory-audits`      | Filter on the responder, window of the response. Attach to the incident.                                                               |
+| 23  | Governance follow-ups register | _(output as markdown)_       | Tenant hardening, labeling gaps, missing retention — anything the investigation surfaced that is out of scope for the incident itself. |
 
 ---
 
@@ -157,7 +157,7 @@ Recurring root cause for exfiltration incidents is missing classification. Close
 ## Related playbooks
 
 - [Compromised Account](compromised-account.md) — triggered when the sharing actor is a confirmed compromise (not a negligent or departing insider).
-- [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) — a phishing lure sometimes drops an OAuth app *or* coerces a user into sharing a OneDrive link externally.
+- [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) — a phishing lure sometimes drops an OAuth app _or_ coerces a user into sharing a OneDrive link externally.
 - [OAuth Illicit Consent](oauth-illicit-consent.md) — apps granted `Files.Read.All` or `Sites.Read.All` through consent phishing show up here as the exfiltration vector.
 
 See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.


### PR DESCRIPTION
## Summary

Fixes the `format:check` CI step that failed on `main` after #42.

- Ran `prettier --write docs/playbooks/*.md` to normalize:
  - emphasis to `_italics_` (prettier default)
  - table column alignment
- No content changes — only whitespace and emphasis style.

## Test plan

- [x] `npx prettier --check "docs/playbooks/**/*.md"` passes locally.
- [ ] CI `verify` job succeeds on all three Node versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)