### PR TITLE
fix(security): SEC-F01 fail-closed authz, SEC-F03 scope enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+### Security
+
+- **SEC-F01 (breaking)** — OAuth mode now fails closed when no per-user allowlist is configured. Previously an empty `--authorized-users` list silently accepted every authenticated tenant user; now the server refuses to start unless either `--authorized-users <oids>` is provided or the explicit opt-in `--allow-any-tenant-user` is passed.
+- **SEC-F03** — User tokens must now contain every scope listed in `--required-user-scopes` (default `access_as_user`) in their `scp` claim. Pass `--required-user-scopes ""` to restore the previous no-scope-check behaviour.
+- Extracted the post-verification authorization logic into `authorizeUserClaims` and added 16 unit tests covering tenant, audience, oid allowlist, and scope enforcement paths.
+
+### Migration
+
+- Deployments relying on the implicit "any authenticated user" behaviour must add `--allow-any-tenant-user` to their startup command (and review whether that is actually intended).
+- Deployments whose Entra app registration does not expose the `access_as_user` scope — or whose callers request a different scope — must pass `--required-user-scopes <their-scopes>` or `--required-user-scopes ""`.
+
 ## [0.2.4] — 2026-04-20
 
 Fixes the StreamableHTTP transport so more than one `/mcp` request per process actually works. With the shared `McpServer` instance, the second call to `server.connect(transport)` threw `Already connected to a transport`, which surfaced as repeated 500s after the OAuth flow finally succeeded.

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -23,7 +23,7 @@ Do **not** use HTTP when stdio is sufficient — it's simpler and has a smaller 
 Two auth modes are available, and can be combined:
 
 - **Service-to-service** (machine callers): pre-acquired Entra bearer tokens are validated via `--allowed-clients`.
-- **OAuth proxy** (human users on Claude Desktop/Code/Web): the server exposes `/authorize`, `/token`, DCR, and metadata endpoints, delegating auth to Entra and gating by user object ID via `--authorized-users`.
+- **OAuth proxy** (human users on Claude Desktop/Code/Web): the server exposes `/authorize`, `/token`, DCR, and metadata endpoints, delegating auth to Entra and gating by user object ID via `--authorized-users` (or explicitly `--allow-any-tenant-user` to accept every tenant user).
 
 ```bash
 # Machine-to-machine only
@@ -70,17 +70,18 @@ When `--oauth-mode` is enabled, the following are added:
 
 The server is an OAuth 2.0 proxy to Entra ID, not a full authorization server. User tokens issued by Entra land on `/mcp` and are validated on each call:
 
-| Check                  | Value                                                                                              |
-| ---------------------- | -------------------------------------------------------------------------------------------------- |
-| Algorithm              | `RS256` (only)                                                                                     |
-| Issuer (`iss`)         | `https://login.microsoftonline.com/<tenant>/v2.0` or `https://sts.windows.net/<tenant>/`           |
-| Tenant (`tid`)         | Must match `MS365_ADMIN_MCP_TENANT_ID`                                                             |
-| Audience (`aud`)       | One of: `<server-app-id>`, `api://<server-app-id>`, `00000003-0000-0000-c000-000000000000` (Graph) |
-| User object ID (`oid`) | Must be present and, if `--authorized-users` is set, in the allowlist                              |
-| Signature              | Verified via `https://login.microsoftonline.com/<tenant>/discovery/v2.0/keys`                      |
-| Clock tolerance        | 30 seconds                                                                                         |
+| Check                  | Value                                                                                                                                 |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Algorithm              | `RS256` (only)                                                                                                                        |
+| Issuer (`iss`)         | `https://login.microsoftonline.com/<tenant>/v2.0` or `https://sts.windows.net/<tenant>/`                                              |
+| Tenant (`tid`)         | Must match `MS365_ADMIN_MCP_TENANT_ID`                                                                                                |
+| Audience (`aud`)       | One of: `<server-app-id>`, `api://<server-app-id>`, `00000003-0000-0000-c000-000000000000` (Graph)                                    |
+| User object ID (`oid`) | Must be present. Must be in `--authorized-users` when that flag is set, otherwise `--allow-any-tenant-user` is required (SEC-F01).    |
+| Scopes (`scp`)         | Must contain every scope listed in `--required-user-scopes` (default: `access_as_user`; pass `--required-user-scopes ""` to disable). |
+| Signature              | Verified via `https://login.microsoftonline.com/<tenant>/discovery/v2.0/keys`                                                         |
+| Clock tolerance        | 30 seconds                                                                                                                            |
 
-**Important**: the user's token is used only as an **authN gate**. The server does not call Graph on behalf of the user — it calls Graph with its own client-credentials (application permissions), so tool results are identical regardless of which user authenticated.
+**Important**: the user's token is used only as an **authN gate**. The server does not call Graph on behalf of the user — it calls Graph with its own client-credentials (application permissions), so tool results are identical regardless of which user authenticated. Because of this, the user allowlist and required-scope checks are the **only** layers between an authenticated tenant user and the server's full Graph capability — keep them tight.
 
 #### Entra ID setup for OAuth mode
 

--- a/docs/SECURITY_REVIEW_2026-04-20.md
+++ b/docs/SECURITY_REVIEW_2026-04-20.md
@@ -1,0 +1,172 @@
+# Security Review — 2026-04-20
+
+Internal security review focused on Priority 1 of the broader audit: **Auth / OAuth HTTP mode** (`src/oauth-proxy.ts`, `src/token-validator.ts`, `src/user-token-validator.ts`, `src/http-server.ts`, `src/auth.ts`).
+
+Purpose of this document: provide a traceable register of findings. Each finding has a stable `SEC-Fxx` identifier so remediation PRs and future reviews can reference it cleanly.
+
+**Reviewer:** Marc Bourget (VP IT, LCI Education) with Claude Code assistance.
+**Commit reviewed:** `main` @ `418ee16` (post-merge of playbooks PR #42).
+**Scope:** Priority 1 only (OAuth flow + token validation + HTTP transport wiring). Priorities 2–6 remain open — see the [next-steps](#next-steps) section.
+
+---
+
+## Architectural premise
+
+Confirmed by inspection of [src/auth.ts:111](../src/auth.ts):
+
+```ts
+const result = await this.msalApp.acquireTokenByClientCredential({
+  scopes: ['https://graph.microsoft.com/.default'],
+});
+```
+
+The server authenticates to Microsoft Graph with **client_credentials** (application permissions), independent of the calling user. A user's JWT is used only as an **authentication gate** on `/mcp`; it is not a delegated authorization token for Graph. As a result, the server's capability ceiling is set by the Entra app registration's consented app-permissions, not by any individual user's scopes.
+
+Implication for this review: any weakness in the user-token authentication gate (e.g. an empty allowlist, a missing scope check) directly elevates an authenticated tenant user to the server's full Graph capability. This makes SEC-F01 and SEC-F03 the highest-priority findings even though each looks innocuous in isolation.
+
+---
+
+## Findings register
+
+Severity rubric mirrors [RISK_MODEL.md](RISK_MODEL.md) but is calibrated to security vulns (CVSS-like): **Critical** = remote unauthenticated/any-user exploit with broad impact; **High** = requires a plausible precondition; **Medium** = operational hardening with realistic exploit chain; **Low** = defence-in-depth / hygiene.
+
+### SEC-F01 — `authorizedUserOids = []` fails open silently
+
+- **Severity:** Critical
+- **Status:** Fixed — this review cycle
+- **Location:** [src/user-token-validator.ts:110](../src/user-token-validator.ts) (pre-fix).
+- **Description:** The guard read `if (options.authorizedUserOids.length > 0 && !includes(oid)) reject`. An empty allowlist skipped the check and accepted every signed token from the tenant.
+- **Attack scenario:** An operator runs `--oauth-mode` without `--authorized-users`. Any Entra user in the tenant who completes the OAuth flow and obtains a token with the expected audience gets app-permission-level Graph access.
+- **Remediation:** Fail-closed. Added `allowAnyTenantUser: boolean` to `UserTokenValidatorOptions`. When the allowlist is empty and the flag is false, every token is rejected with a logged warning. The server refuses to start if OAuth mode is enabled without at least one of `--authorized-users` / `--allow-any-tenant-user`.
+- **Tests:** `test/user-token-validator.test.ts` — _SEC-F01 fail-closed authorization_ block.
+- **Breaking change:** Yes. Deployments relying on the implicit behaviour must now pass `--allow-any-tenant-user` explicitly.
+
+### SEC-F02 — `resolveIssuer` trusts `X-Forwarded-*` in the fallback path
+
+- **Severity:** High
+- **Status:** Open
+- **Location:** [src/oauth-proxy.ts:54-59](../src/oauth-proxy.ts), [src/http-server.ts:34-39](../src/http-server.ts).
+- **Description:** When `publicUrl` is not configured, `resolveIssuer` and `resourceMetadataUrl` derive the advertised OAuth issuer from `X-Forwarded-Proto` / `X-Forwarded-Host` / `Host`. `app.set('trust proxy', 1)` bounds that trust to a single upstream hop, which is appropriate only behind a known-and-trusted reverse proxy.
+- **Attack scenario:** In a direct-exposure deploy (no reverse proxy), a client-supplied `Host` header is echoed into `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`. A victim client performing metadata discovery may be steered to an attacker-controlled issuer and intercepted.
+- **Remediation (proposed):** Make `--public-url` mandatory when `--oauth-mode` is enabled. If a fallback must remain (dev ergonomics), validate the derived host against an allowlist of approved public hostnames.
+
+### SEC-F03 — `scp` claim parsed but never enforced
+
+- **Severity:** High
+- **Status:** Fixed — this review cycle
+- **Location:** [src/user-token-validator.ts](../src/user-token-validator.ts) (pre-fix — `scp` was declared in `UserTokenPayload` but never read).
+- **Description:** A user token whose `scp` claim contains only `openid profile email` (for example) was accepted as though it had consented to the administrative API scope. Combined with the app-permission execution model, this trivially elevated a non-admin consent to admin Graph capability.
+- **Attack scenario:** Consent phishing with a benign-looking scope set → token lands on `/mcp` → full admin-grade Graph operations.
+- **Remediation:** Added `requiredScopes: string[]` to `UserTokenValidatorOptions`, enforced against the space-separated `scp` claim. Default is `['access_as_user']` (matches the scope the proxy itself requests at `/authorize`). Override via `--required-user-scopes <scopes>`; pass `""` to disable.
+- **Tests:** `test/user-token-validator.test.ts` — _SEC-F03 required scope enforcement_ block.
+- **Breaking change:** Yes for any deployment that used a different scope name or relied on no scope check.
+
+### SEC-F04 — `refresh_token` grant requires no MCP-client authentication
+
+- **Severity:** High
+- **Status:** Open
+- **Location:** [src/oauth-proxy.ts:197-207](../src/oauth-proxy.ts).
+- **Description:** `POST /token` with `grant_type=refresh_token` attaches the server's `client_secret` and forwards the refresh token to Entra. An attacker in possession of a refresh token only needs the public proxy URL to redeem it — the client_secret Entra would normally require is supplied by the proxy on behalf of the caller.
+- **Attack scenario:** Refresh-token exfiltration from an MCP client (local token store, logs, MITM) becomes directly usable via the proxy, without the additional factor of the client_secret.
+- **Remediation (proposed):** One of —
+  - require a valid bearer JWT alongside `refresh_token` on `/token` (binds the grant to the same subject) ;
+  - move the proxy away from `token_endpoint_auth_methods: none` and require per-client credentials ;
+  - add a strict per-IP rate limit on `/token` (partial mitigation).
+
+### SEC-F05 — PKCE bridge is in-memory per process
+
+- **Severity:** Medium
+- **Status:** Open
+- **Location:** [src/oauth-proxy.ts:22](../src/oauth-proxy.ts).
+- **Description:** A process-local `Map<string, PkceEntry>` holds the server-side PKCE verifier between `/authorize` and `/token`. In a multi-replica deployment, the two requests may land on different instances and the bridge lookup fails. Operators may be tempted to work around this with sticky sessions or by weakening the bridge.
+- **Attack scenario:** No direct exploit, but the availability failure creates pressure for ad-hoc fixes that degrade security (e.g. shortening `PKCE_TTL_MS`, removing PKCE, or relaxing the bridge lookup).
+- **Remediation (proposed):** Externalise the bridge (Redis, Azure Cosmos, Azure Table) with the same 10-minute TTL; or document and enforce `minReplicas = maxReplicas = 1` in the Container Apps deployment.
+
+### SEC-F06 — `/token` and `/authorize` have no rate limit
+
+- **Severity:** Medium
+- **Status:** Open
+- **Location:** [src/http-server.ts:49-58](../src/http-server.ts).
+- **Description:** The `express-rate-limit` middleware is mounted on `/mcp` only. `/authorize`, `/token`, and `/register` are uncapped.
+- **Attack scenario:** Brute force of authorization codes, enumeration of refresh tokens (pair with SEC-F04), DoS against Entra's `/token` endpoint via the proxy.
+- **Remediation (proposed):** Add a tighter rate limit on `/token` (e.g. 10 req/min per IP) and `/authorize` (e.g. 30 req/min per IP).
+
+### SEC-F07 — `/token` logs up to 500 chars of upstream error payload
+
+- **Severity:** Medium
+- **Status:** Open
+- **Location:** [src/oauth-proxy.ts:221-223](../src/oauth-proxy.ts).
+- **Description:** On upstream HTTP error, `logger.warn` receives `payload.slice(0, 500)`. Entra error bodies may contain correlation IDs, partial trace information, and occasionally snippets that help attackers diagnose flow-level issues.
+- **Remediation (proposed):** Parse as JSON and log only `error` + `error_description` fields; fall back to `<unparseable N bytes>` when the body is not JSON.
+
+### SEC-F08 — No stale-while-revalidate on JWKS cache
+
+- **Severity:** Medium
+- **Status:** Open
+- **Location:** [src/token-validator.ts:22-34](../src/token-validator.ts), [src/user-token-validator.ts:34-46](../src/user-token-validator.ts).
+- **Description:** `jwks-rsa` cache TTL is 10 minutes. If the Entra discovery endpoint is unreachable during a key rotation, token validation fails for up to 10 minutes with no fallback.
+- **Attack scenario:** Self-inflicted DoS during a genuine Entra incident or key rotation; no direct attacker-controlled exploit.
+- **Remediation (proposed):** Extend `cacheMaxAge`, add a background refresh, and serve-stale on fetch failure.
+
+### SEC-F09 — Dynamic Client Registration is decorative
+
+- **Severity:** Low
+- **Status:** Open
+- **Location:** [src/oauth-proxy.ts:93-105](../src/oauth-proxy.ts).
+- **Description:** `/register` returns a synthesised `client_id` but stores nothing. `/token` ignores whatever the client sends and substitutes the server's configured `client_id` when talking to Entra. The endpoint misleads well-behaved clients and alters the advertised RFC 8414 metadata when enabled.
+- **Remediation (proposed):** Either implement genuine DCR (persist, enforce) or remove the endpoint and the `registration_endpoint` line from the AS metadata.
+
+### SEC-F10 — `redirect_uri` forwarded without local allowlist
+
+- **Severity:** Low
+- **Status:** Open
+- **Location:** [src/oauth-proxy.ts:148](../src/oauth-proxy.ts).
+- **Description:** The proxy forwards the client-supplied `redirect_uri` to Entra. Entra enforces its own app-registration allowlist, so a correctly-configured app registration mitigates this. The risk is purely operator hygiene: a wildcard or broadly permissive redirect URI in the app registration extends its laxness through the proxy.
+- **Remediation (proposed):** Document explicitly that the Entra app registration's `redirectUris` are load-bearing; recommend exact-match URIs only (no `localhost:*` patterns, no wildcard).
+
+### SEC-F11 — `/health` leaks the `transport` field
+
+- **Severity:** Low
+- **Status:** Open
+- **Location:** [src/http-server.ts:60-62](../src/http-server.ts).
+- **Description:** The health response includes `transport: "http"`. Trivial information leak.
+- **Remediation (proposed):** Remove the `transport` field, or restrict `/health` to a loopback-bound path if the upstream probe can be configured accordingly.
+
+---
+
+## Observations (positive)
+
+No remediation required — recorded so future reviews do not re-litigate already-correct decisions.
+
+- JWT algorithm pinned to `['RS256']` in both validators; no `none` / `HS*` confusion surface.
+- Both v1 (`sts.windows.net`) and v2 (`login.microsoftonline.com`) issuers accepted on the user-token path, matching Entra's dual-endpoint reality.
+- Global security headers set by [src/http-server.ts:20-28](../src/http-server.ts) (`X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store`, `Content-Security-Policy: default-src 'none'`, `Referrer-Policy: no-referrer`).
+- Request body size capped at `100kb` for both JSON and URL-encoded payloads.
+- Grep across `src/` confirms no secrets or tokens are logged in any scanned code path.
+- `SEC-NN` comment convention already in use (see existing `SEC-02`, `SEC-11`, `SEC-B` markers) — the new findings follow the same pattern.
+
+---
+
+## Remediation order (recommendation)
+
+| Wave            | Findings                         | Rationale                                                      |
+| --------------- | -------------------------------- | -------------------------------------------------------------- |
+| 1 — this review | SEC-F01 (fixed), SEC-F03 (fixed) | Critical + High exploitable at the current deployment state.   |
+| 2 — next sprint | SEC-F02, SEC-F04, SEC-F06        | Harden the public OAuth proxy surface before broader exposure. |
+| 3 — hardening   | SEC-F05, SEC-F07, SEC-F08        | Multi-replica readiness, log hygiene, availability robustness. |
+| Backlog         | SEC-F09, SEC-F10, SEC-F11        | Documentation / cosmetic; no realistic exploit path.           |
+
+---
+
+## Next steps
+
+The broader audit plan identified six priority areas. Status after this cycle:
+
+- **P1 — Auth / OAuth HTTP mode** — partially remediated (SEC-F01 + SEC-F03 closed; SEC-F02/F04/F05/F06/F07/F08/F09/F10/F11 open).
+- **P2 — Tool invocation gating** — not yet reviewed. Verify `--allow-writes` enforcement at dispatch, audit risk-level labels, assess prompt-injection via Graph response content.
+- **P3 — Secret & token hygiene** — pass-level check done (no logging observed); formal pass pending.
+- **P4 — Transport & deploy hardening** — CORS, HSTS, trust-proxy depth, rate-limit breadth.
+- **P5 — Supply chain** — `npm audit`, base-image pinning, generator pipeline integrity.
+- **P6 — Threat-model document** — not yet written; should consolidate this register with `RISK_MODEL.md` into a unified threat model.
+
+This document is the authoritative register for P1 findings. Update in place as findings are closed; add follow-up reviews as `docs/SECURITY_REVIEW_YYYY-MM-DD.md` dated files.

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -7,7 +7,7 @@ Playbooks are the long-form counterpart to [USE_CASES.md](../USE_CASES.md). A us
 Each playbook follows the same structure:
 
 1. **Trigger signals** — how the scenario is detected.
-2. **Scope boundary** (when relevant) — what the server *can* and *cannot* do for this scenario. Forensic or remediation steps that live outside this server are called out and handed off explicitly.
+2. **Scope boundary** (when relevant) — what the server _can_ and _cannot_ do for this scenario. Forensic or remediation steps that live outside this server are called out and handed off explicitly.
 3. **Prerequisites** — presets, delegated permissions, guardrails.
 4. **Phased procedure** — investigation → containment → hardening → documentation. Each step maps to a concrete MCP tool with its risk level.
 5. **Sample prompts** — per phase + a full-run single-shot prompt.
@@ -17,12 +17,12 @@ Each playbook follows the same structure:
 
 ## Catalogue
 
-| # | Playbook | Scope | Tool families | Completeness |
-|---|---|---|---|---|
-| 1 | [Compromised Account](compromised-account.md) | A single user identity is suspected compromised. | `identity`, `audit`, `security`, `response` | End-to-end (investigation → containment → audit). |
-| 2 | [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) | A phishing email reached multiple mailboxes. | `security`, `exchange`, `audit`, `identity` | Scoping + handoff (purge happens outside the server). |
-| 3 | [OAuth Illicit Consent](oauth-illicit-consent.md) | A malicious OAuth application holds delegated or application permissions. | `identity`, `audit`, `security`, `compliance`, `response` | End-to-end + prevention (permission-grant policy review). |
-| 4 | [SharePoint / OneDrive Exfiltration](sharepoint-exfiltration.md) | Anomalous external sharing or mass download on a SharePoint site or OneDrive. | `sharepointadmin`, `audit`, `security`, `identity`, `reports`, `response` | End-to-end at the site level + handoff to Purview for file-level forensics. |
+| #   | Playbook                                                         | Scope                                                                         | Tool families                                                             | Completeness                                                                |
+| --- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 1   | [Compromised Account](compromised-account.md)                    | A single user identity is suspected compromised.                              | `identity`, `audit`, `security`, `response`                               | End-to-end (investigation → containment → audit).                           |
+| 2   | [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md)       | A phishing email reached multiple mailboxes.                                  | `security`, `exchange`, `audit`, `identity`                               | Scoping + handoff (purge happens outside the server).                       |
+| 3   | [OAuth Illicit Consent](oauth-illicit-consent.md)                | A malicious OAuth application holds delegated or application permissions.     | `identity`, `audit`, `security`, `compliance`, `response`                 | End-to-end + prevention (permission-grant policy review).                   |
+| 4   | [SharePoint / OneDrive Exfiltration](sharepoint-exfiltration.md) | Anomalous external sharing or mass download on a SharePoint site or OneDrive. | `sharepointadmin`, `audit`, `security`, `identity`, `reports`, `response` | End-to-end at the site level + handoff to Purview for file-level forensics. |
 
 ---
 
@@ -70,7 +70,7 @@ Selected to showcase distinct capability surfaces of the server in the shortest 
 
 - **#1 Compromised Account** — end-to-end on a single identity. The baseline demo.
 - **#2 Phishing** — shows the server's honesty about scope boundaries. Stops at a handoff package instead of pretending to purge.
-- **#3 OAuth Illicit Consent** — shows sophistication (order of operations matters: disable SP *before* revoking sessions) and closes the prevention loop.
+- **#3 OAuth Illicit Consent** — shows sophistication (order of operations matters: disable SP _before_ revoking sessions) and closes the prevention loop.
 - **#4 SharePoint Exfiltration** — widens the narrative beyond identity into data governance. Exercises a completely different preset family.
 
 Together they exercise 9 of the 15 tool-category presets defined in [src/tool-categories.ts](../../src/tool-categories.ts).
@@ -81,7 +81,7 @@ Together they exercise 9 of the 15 tool-category presets defined in [src/tool-ca
 
 When adding a playbook:
 
-1. Confirm every MCP tool referenced actually exists in [src/endpoints.json](../../src/endpoints.json). Do not include tools that *should* exist — add them to the server first, or handle the gap with an explicit handoff section.
+1. Confirm every MCP tool referenced actually exists in [src/endpoints.json](../../src/endpoints.json). Do not include tools that _should_ exist — add them to the server first, or handle the gap with an explicit handoff section.
 2. Follow the 5-section structure listed at the top of this page. Consistency matters more than length.
 3. Classify each write tool's risk (`low` / `medium` / `high` / `critical`) in line with [docs/RISK_MODEL.md](../RISK_MODEL.md).
-4. Add the playbook to the catalogue table above and to any relevant *Related playbooks* section in existing files.
+4. Add the playbook to the catalogue table above and to any relevant _Related playbooks_ section in existing files.

--- a/docs/playbooks/compromised-account.md
+++ b/docs/playbooks/compromised-account.md
@@ -12,7 +12,7 @@ Any of the following typically opens this playbook:
 
 - A user appears in `list-risky-users` with `riskLevel = high`.
 - A security alert or incident (Microsoft 365 Defender / Identity Protection) targets a user identity.
-- A sign-in flagged *impossible travel*, *atypical location*, or *anonymous IP*.
+- A sign-in flagged _impossible travel_, _atypical location_, or _anonymous IP_.
 - A user self-reports a phishing click or a stolen credential.
 
 ---
@@ -52,13 +52,13 @@ Never run the containment phase against a break-glass account. Confirm the targe
 
 Goal: confirm the compromise, reconstruct the attacker's timeline, and measure the blast radius.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 1 | Confirm the subject and baseline context | `get-user`, `get-risky-user` | Display name, UPN, job title, last interactive sign-in, current risk state. |
-| 2 | Reconstruct the sign-in timeline | `list-sign-ins` | Filter on `userId` and the last 24–72 h. Extract IP, location, client app, conditional access result, risk level per sign-in. |
-| 3 | Correlate with Identity Protection detections | `list-risk-detections`, `list-risky-user-history` | Maps detections (e.g. *malwareInfectedIPAddress*, *unfamiliarFeatures*) to sign-ins from step 2. |
-| 4 | Measure blast radius — what did the attacker do? | `list-directory-audits` | Filter `initiatedBy.user.id = <userId>`. Look for new OAuth consents, new role assignments, password resets, mail rules, group memberships, application registrations. |
-| 5 | Detect MFA persistence added by the attacker | `list-user-auth-methods` | A phone or authenticator app registered during the compromise window is a classic persistence mechanism. |
+| #   | Objective                                        | MCP tool(s)                                       | Notes                                                                                                                                                                  |
+| --- | ------------------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Confirm the subject and baseline context         | `get-user`, `get-risky-user`                      | Display name, UPN, job title, last interactive sign-in, current risk state.                                                                                            |
+| 2   | Reconstruct the sign-in timeline                 | `list-sign-ins`                                   | Filter on `userId` and the last 24–72 h. Extract IP, location, client app, conditional access result, risk level per sign-in.                                          |
+| 3   | Correlate with Identity Protection detections    | `list-risk-detections`, `list-risky-user-history` | Maps detections (e.g. _malwareInfectedIPAddress_, _unfamiliarFeatures_) to sign-ins from step 2.                                                                       |
+| 4   | Measure blast radius — what did the attacker do? | `list-directory-audits`                           | Filter `initiatedBy.user.id = <userId>`. Look for new OAuth consents, new role assignments, password resets, mail rules, group memberships, application registrations. |
+| 5   | Detect MFA persistence added by the attacker     | `list-user-auth-methods`                          | A phone or authenticator app registered during the compromise window is a classic persistence mechanism.                                                               |
 
 ### Sample investigation prompt
 
@@ -72,12 +72,12 @@ Goal: kill active access, remove attacker persistence, and feed the Identity Pro
 
 > Always run every write in dry-run first: have the LLM list the target entity and the exact operation, wait for operator confirmation, then execute.
 
-| # | Action | MCP tool | Risk | Effect |
-|---|---|---|---|---|
-| 6 | Revoke all active sessions (refresh tokens) | `revoke-user-sessions` | **high** | Forces re-authentication on every client within minutes. |
-| 7 | Disable the account if severity warrants it | `disable-user-account` | **critical** | Blocks all sign-ins. Use when the user can be reached through an alternate channel. |
-| 8 | Remove attacker-added phone MFA | `delete-user-phone-auth-method` | **high** | Removes the rogue phone. Repeat with other `delete-user-*-auth-method` tools if authenticator or FIDO was added. |
-| 9 | Confirm compromised in Identity Protection | `confirm-compromised-users` | **high** | Marks `riskState = confirmedCompromised`. Feeds the ML model and triggers dependent Conditional Access policies. |
+| #   | Action                                      | MCP tool                        | Risk         | Effect                                                                                                           |
+| --- | ------------------------------------------- | ------------------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+| 6   | Revoke all active sessions (refresh tokens) | `revoke-user-sessions`          | **high**     | Forces re-authentication on every client within minutes.                                                         |
+| 7   | Disable the account if severity warrants it | `disable-user-account`          | **critical** | Blocks all sign-ins. Use when the user can be reached through an alternate channel.                              |
+| 8   | Remove attacker-added phone MFA             | `delete-user-phone-auth-method` | **high**     | Removes the rogue phone. Repeat with other `delete-user-*-auth-method` tools if authenticator or FIDO was added. |
+| 9   | Confirm compromised in Identity Protection  | `confirm-compromised-users`     | **high**     | Marks `riskState = confirmedCompromised`. Feeds the ML model and triggers dependent Conditional Access policies. |
 
 ### Sample containment prompt
 
@@ -89,11 +89,11 @@ Goal: kill active access, remove attacker persistence, and feed the Identity Pro
 
 Goal: record the response on the incident/alert, and produce a traceability report proving every action taken.
 
-| # | Action | MCP tool | Notes |
-|---|---|---|---|
-| 10 | Update the security incident | `update-security-incident` | Status (e.g. `active` → `inProgress`), classification, assignee. |
-| 11 | Leave a narrative trail on the alert | `add-security-alert-comment` | Short chronology referencing the audit window. |
-| 12 | Generate the post-incident audit report | `list-directory-audits` | Filter on the operator service principal / delegated user, over the response window. Every write from Phase 2 appears there — the loop closes. |
+| #   | Action                                  | MCP tool                     | Notes                                                                                                                                          |
+| --- | --------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| 10  | Update the security incident            | `update-security-incident`   | Status (e.g. `active` → `inProgress`), classification, assignee.                                                                               |
+| 11  | Leave a narrative trail on the alert    | `add-security-alert-comment` | Short chronology referencing the audit window.                                                                                                 |
+| 12  | Generate the post-incident audit report | `list-directory-audits`      | Filter on the operator service principal / delegated user, over the response window. Every write from Phase 2 appears there — the loop closes. |
 
 ### Sample documentation prompt
 
@@ -126,7 +126,7 @@ Use this when demoing the end-to-end flow in one shot. The LLM will chain all th
 
 ## Related playbooks
 
-- Phishing campaign (tenant-wide) — *draft*
-- OAuth illicit consent — *draft*
+- Phishing campaign (tenant-wide) — _draft_
+- OAuth illicit consent — _draft_
 
 See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.

--- a/docs/playbooks/oauth-illicit-consent.md
+++ b/docs/playbooks/oauth-illicit-consent.md
@@ -8,7 +8,7 @@ Scope note: this admin server can perform the **full loop** (scope, contain, har
 
 ## Background
 
-Consent phishing: the attacker sends a link to a Microsoft consent screen for an OAuth application they control. The user clicks *Accept* and grants delegated scopes like `Mail.Read`, `Files.Read.All`, `offline_access`. The attacker receives an access token + refresh token for that user. A tenant admin variant asks for admin consent on `AllPrincipals`, gaining access to every user in one click.
+Consent phishing: the attacker sends a link to a Microsoft consent screen for an OAuth application they control. The user clicks _Accept_ and grants delegated scopes like `Mail.Read`, `Files.Read.All`, `offline_access`. The attacker receives an access token + refresh token for that user. A tenant admin variant asks for admin consent on `AllPrincipals`, gaining access to every user in one click.
 
 Key properties:
 
@@ -23,7 +23,7 @@ Key properties:
 
 - Service principal appears in `list-risky-service-principals` with `riskLevel = high`.
 - Defender / Identity Protection alert referencing a suspicious OAuth application.
-- A user reports they clicked *Accept* on an unexpected consent screen.
+- A user reports they clicked _Accept_ on an unexpected consent screen.
 - Spike of Graph API calls by a newly-created service principal (see `list-sign-ins` filtered on `appDisplayName`).
 - A pending request in `list-app-consent-requests` from an unknown publisher.
 
@@ -58,13 +58,13 @@ See [APP_REGISTRATION.md](../APP_REGISTRATION.md).
 
 Goal: go from the signal to a full profile of the suspect service principal.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 1 | Pull the service principal profile | `get-service-principal` | `appId`, `publisherName`, `verifiedPublisher`, `signInAudience`, `createdDateTime`. Newly created + unverified publisher + multi-tenant = strong signal. |
-| 2 | Check registered credentials | `list-app-federated-credentials` | Federated credentials are a modern persistence vector. Any FIC added recently is suspicious. |
-| 3 | Check ownership | `list-service-principal-owners`, `list-application-owners` | A compromised internal user who owns a suspicious app is a secondary compromise. |
-| 4 | Pull risk detections on the SP | `list-service-principal-risk-detections`, `get-risky-service-principal` | Microsoft-flagged risky behaviours (leaked credentials, anomalous activity). |
-| 5 | Find the home application object | `get-application` | Only present if the app is registered in *this* tenant (single-tenant or multi-tenant publisher = home tenant). |
+| #   | Objective                          | MCP tool(s)                                                             | Notes                                                                                                                                                    |
+| --- | ---------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Pull the service principal profile | `get-service-principal`                                                 | `appId`, `publisherName`, `verifiedPublisher`, `signInAudience`, `createdDateTime`. Newly created + unverified publisher + multi-tenant = strong signal. |
+| 2   | Check registered credentials       | `list-app-federated-credentials`                                        | Federated credentials are a modern persistence vector. Any FIC added recently is suspicious.                                                             |
+| 3   | Check ownership                    | `list-service-principal-owners`, `list-application-owners`              | A compromised internal user who owns a suspicious app is a secondary compromise.                                                                         |
+| 4   | Pull risk detections on the SP     | `list-service-principal-risk-detections`, `get-risky-service-principal` | Microsoft-flagged risky behaviours (leaked credentials, anomalous activity).                                                                             |
+| 5   | Find the home application object   | `get-application`                                                       | Only present if the app is registered in _this_ tenant (single-tenant or multi-tenant publisher = home tenant).                                          |
 
 ### Sample prompt
 
@@ -76,13 +76,13 @@ Goal: go from the signal to a full profile of the suspect service principal.
 
 Goal: enumerate every grant this service principal holds, and every user affected.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 6 | Enumerate delegated permission grants | `list-oauth2-grants` | Filter `clientId eq '<spObjectId>'`. Each result: `principalId` (user who consented), `scope` (space-separated). `consentType = AllPrincipals` means tenant-wide admin consent — blast radius = every user. |
-| 7 | Enumerate application permission grants | `list-sp-app-role-assignments` | App-only permissions (e.g. `Mail.Read` as application) — no user interaction needed, attacker can call Graph on every mailbox. Highest severity. |
-| 8 | List configured delegated permissions | `list-sp-delegated-permissions` | What scopes *could* the SP request — baseline for Phase 4 policy tightening. |
-| 9 | Who actually authenticated to it | `list-sign-ins` | Filter `appDisplayName eq '<malicious app>'` over the window since creation. Gives the real list of active victims, separate from the consented list. |
-| 10 | Consent event timeline | `list-directory-audits` | Filter on `activityDisplayName in ('Consent to application', 'Add app role assignment grant to service principal')` and the SP's `targetResources`. Produces the forensic timeline. |
+| #   | Objective                               | MCP tool(s)                     | Notes                                                                                                                                                                                                       |
+| --- | --------------------------------------- | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 6   | Enumerate delegated permission grants   | `list-oauth2-grants`            | Filter `clientId eq '<spObjectId>'`. Each result: `principalId` (user who consented), `scope` (space-separated). `consentType = AllPrincipals` means tenant-wide admin consent — blast radius = every user. |
+| 7   | Enumerate application permission grants | `list-sp-app-role-assignments`  | App-only permissions (e.g. `Mail.Read` as application) — no user interaction needed, attacker can call Graph on every mailbox. Highest severity.                                                            |
+| 8   | List configured delegated permissions   | `list-sp-delegated-permissions` | What scopes _could_ the SP request — baseline for Phase 4 policy tightening.                                                                                                                                |
+| 9   | Who actually authenticated to it        | `list-sign-ins`                 | Filter `appDisplayName eq '<malicious app>'` over the window since creation. Gives the real list of active victims, separate from the consented list.                                                       |
+| 10  | Consent event timeline                  | `list-directory-audits`         | Filter on `activityDisplayName in ('Consent to application', 'Add app role assignment grant to service principal')` and the SP's `targetResources`. Produces the forensic timeline.                         |
 
 ### Severity classification
 
@@ -97,20 +97,21 @@ Goal: enumerate every grant this service principal holds, and every user affecte
 
 Order matters. Neutralise the SP **before** revoking user sessions — otherwise the attacker uses the remaining refresh-token window to re-consent on fresh sessions or pivot.
 
-| # | Action | MCP tool | Risk | Effect |
-|---|---|---|---|---|
-| 11 | Soft-block the service principal | `update-service-principal` with `accountEnabled = false` | **high** | Prevents all new token issuance. Preserves the audit trail and the grants themselves for forensics. Preferred first step. |
-| 12 | Strip attacker-added credentials | `remove-sp-key`, `remove-sp-password` | **high** | If credentials were added post-compromise, remove them. Do not remove credentials you cannot correlate to the attacker. |
-| 13 | Remove rogue owners | `remove-sp-owner` | **medium** | If an internal user owns the malicious SP and is confirmed complicit / compromised. |
-| 14 | Mark as confirmed compromised | `confirm-compromised-service-principals` | **high** | Feeds Identity Protection, triggers dependent Conditional Access policies for SPs. |
-| 15 | Revoke affected user sessions | `revoke-user-sessions` | **high** | For every user in steps 6 and 9. Kills active access tokens. |
-| 16 | Delete the service principal (optional, after forensics) | `delete-service-principal` | **critical** | Only after evidence preservation. Destroys the SP object and all grants. Irreversible. |
+| #   | Action                                                   | MCP tool                                                 | Risk         | Effect                                                                                                                    |
+| --- | -------------------------------------------------------- | -------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| 11  | Soft-block the service principal                         | `update-service-principal` with `accountEnabled = false` | **high**     | Prevents all new token issuance. Preserves the audit trail and the grants themselves for forensics. Preferred first step. |
+| 12  | Strip attacker-added credentials                         | `remove-sp-key`, `remove-sp-password`                    | **high**     | If credentials were added post-compromise, remove them. Do not remove credentials you cannot correlate to the attacker.   |
+| 13  | Remove rogue owners                                      | `remove-sp-owner`                                        | **medium**   | If an internal user owns the malicious SP and is confirmed complicit / compromised.                                       |
+| 14  | Mark as confirmed compromised                            | `confirm-compromised-service-principals`                 | **high**     | Feeds Identity Protection, triggers dependent Conditional Access policies for SPs.                                        |
+| 15  | Revoke affected user sessions                            | `revoke-user-sessions`                                   | **high**     | For every user in steps 6 and 9. Kills active access tokens.                                                              |
+| 16  | Delete the service principal (optional, after forensics) | `delete-service-principal`                               | **critical** | Only after evidence preservation. Destroys the SP object and all grants. Irreversible.                                    |
 
 > The compromised-account playbook is triggered for each user who consented to sensitive scopes — especially those whose sign-ins in step 9 show attacker-infrastructure IPs.
 
 ### Sample containment prompt
 
 > "Containment for service principal `<spObjectId>`. Dry-run every write first:
+>
 > 1. Set `accountEnabled = false` on the SP.
 > 2. List any secret/key added after `<creation date + 1 day>` and propose removal.
 > 3. Mark the SP as confirmed compromised.
@@ -124,21 +125,21 @@ Order matters. Neutralise the SP **before** revoking user sessions — otherwise
 
 The single highest-leverage control against consent phishing is **restricting user consent**.
 
-| # | Objective | MCP tool(s) | Action |
-|---|---|---|---|
-| 17 | Review the tenant's consent policy | `list-permission-grant-policies` | Confirm which app-role / delegated scopes users can consent to without admin approval. Default is often too permissive. |
-| 18 | Review outstanding consent requests | `list-app-consent-requests`, `list-user-consent-requests` | Clear the queue; look for other suspicious pending requests from the same attacker. |
-| 19 | Recommend the admin-consent workflow if not enabled | *(read-only — configuration change is out of MCP scope)* | Directs any consent for risky scopes to admin review. Biggest prevention win. |
+| #   | Objective                                           | MCP tool(s)                                               | Action                                                                                                                  |
+| --- | --------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 17  | Review the tenant's consent policy                  | `list-permission-grant-policies`                          | Confirm which app-role / delegated scopes users can consent to without admin approval. Default is often too permissive. |
+| 18  | Review outstanding consent requests                 | `list-app-consent-requests`, `list-user-consent-requests` | Clear the queue; look for other suspicious pending requests from the same attacker.                                     |
+| 19  | Recommend the admin-consent workflow if not enabled | _(read-only — configuration change is out of MCP scope)_  | Directs any consent for risky scopes to admin review. Biggest prevention win.                                           |
 
 ---
 
 ## Phase 5 — Documentation and audit
 
-| # | Action | MCP tool | Notes |
-|---|---|---|---|
-| 20 | Update the security incident | `update-security-incident` | Classification `truePositive / maliciousApp`, status `resolved` once Phase 3 complete. |
-| 21 | Narrative on the alert | `add-security-alert-comment` | Chronology + scope summary + containment steps. |
-| 22 | Investigation audit log | `list-directory-audits` | Filter on the responder, response window. Attach to the incident. |
+| #   | Action                       | MCP tool                     | Notes                                                                                  |
+| --- | ---------------------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
+| 20  | Update the security incident | `update-security-incident`   | Classification `truePositive / maliciousApp`, status `resolved` once Phase 3 complete. |
+| 21  | Narrative on the alert       | `add-security-alert-comment` | Chronology + scope summary + containment steps.                                        |
+| 22  | Investigation audit log      | `list-directory-audits`      | Filter on the responder, response window. Attach to the incident.                      |
 
 ---
 
@@ -152,14 +153,14 @@ The single highest-leverage control against consent phishing is **restricting us
 > 4. Hardening — summarize the tenant permission-grant policy and outstanding consent requests; recommend follow-ups.
 > 5. Documentation — update the incident, comment the alert, produce the investigation audit log.
 >
-> Route every user who consented to sensitive scopes (Mail.*, Files.*, User.Read.All) to the compromised-account playbook as a side-output."
+> Route every user who consented to sensitive scopes (Mail._, Files._, User.Read.All) to the compromised-account playbook as a side-output."
 
 ---
 
 ## Demo talking points
 
 - **Full loop inside the server** — contrast with the phishing playbook where purge lives outside. Here investigation → containment → hardening → documentation all chain through the MCP server, no handoff.
-- **Token-economy literacy** — the playbook surfaces *why* revoking sessions before killing the SP is the wrong order. The LLM explains the invariant; the tools enforce it.
+- **Token-economy literacy** — the playbook surfaces _why_ revoking sessions before killing the SP is the wrong order. The LLM explains the invariant; the tools enforce it.
 - **Severity classification** — critical (app permissions) vs high (tenant-wide delegated) vs medium / low. Mechanical but routinely mishandled by human responders under pressure.
 - **Preventive follow-up** — Phase 4 exposes the permission-grant policy as the root cause. Most incident playbooks stop at remediation; this one closes the prevention loop in the same conversation.
 

--- a/docs/playbooks/phishing-tenant-wide.md
+++ b/docs/playbooks/phishing-tenant-wide.md
@@ -19,7 +19,7 @@ This admin-focused server does **not** expose per-message mailbox operations (no
 
 What this server **does** give you for phishing:
 
-- Tenant-wide message-trace visibility — *who received what, when, from where*.
+- Tenant-wide message-trace visibility — _who received what, when, from where_.
 - Victim correlation — sign-ins, risk detections, directory audits post-delivery.
 - Security incident / alert lifecycle — classification, comments, closure.
 - Threat intel enrichment — IOC lookups, article cross-reference.
@@ -45,7 +45,7 @@ The playbook ends with a **handoff package** (list of affected UPNs, message IDs
 
 - `SecurityAlert.ReadWrite.All`, `SecurityIncident.ReadWrite.All`
 - `ThreatIntelligence.Read.All`, `ThreatAssessment.Read.All`
-- `Mail.ReadBasic.All` *(for message trace)* or the Exchange Online `MessageTracking` role
+- `Mail.ReadBasic.All` _(for message trace)_ or the Exchange Online `MessageTracking` role
 - `AuditLog.Read.All`, `Directory.Read.All`
 - `IdentityRiskEvent.Read.All`, `IdentityRiskyUser.Read.All`
 
@@ -57,13 +57,13 @@ See [APP_REGISTRATION.md](../APP_REGISTRATION.md).
 
 Goal: turn a single signal into a list of delivered messages, sender infrastructure, and affected recipients.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 1 | Enumerate related alerts and incidents | `list-security-alerts`, `list-security-incidents`, `get-security-incident` | Filter on `category = Phishing` or keywords from the reported message. |
-| 2 | Pull user-submitted reports | `list-threat-assessment-requests` | Employees using the *Report Phishing* button surface here. |
-| 3 | Match against known campaigns | `list-threat-intel-articles`, `list-threat-intel-article-indicators` | Cross-reference sender domain, URL, IP against Microsoft threat intel articles. |
-| 4 | Measure delivery footprint | `list-message-traces` | Filter by `senderAddress`, `subject`, `fromDateTime`, `toDateTime`. Extract recipient list, delivery status, message IDs. |
-| 5 | Inspect a suspicious delivery in detail | `get-message-trace` | For each high-signal message ID, get the full trace (hops, spam verdict, policy hits). |
+| #   | Objective                               | MCP tool(s)                                                                | Notes                                                                                                                     |
+| --- | --------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Enumerate related alerts and incidents  | `list-security-alerts`, `list-security-incidents`, `get-security-incident` | Filter on `category = Phishing` or keywords from the reported message.                                                    |
+| 2   | Pull user-submitted reports             | `list-threat-assessment-requests`                                          | Employees using the _Report Phishing_ button surface here.                                                                |
+| 3   | Match against known campaigns           | `list-threat-intel-articles`, `list-threat-intel-article-indicators`       | Cross-reference sender domain, URL, IP against Microsoft threat intel articles.                                           |
+| 4   | Measure delivery footprint              | `list-message-traces`                                                      | Filter by `senderAddress`, `subject`, `fromDateTime`, `toDateTime`. Extract recipient list, delivery status, message IDs. |
+| 5   | Inspect a suspicious delivery in detail | `get-message-trace`                                                        | For each high-signal message ID, get the full trace (hops, spam verdict, policy hits).                                    |
 
 ### Sample prompt
 
@@ -77,12 +77,12 @@ A recipient is not yet a victim. Engagement is inferred from sign-in activity, r
 
 For each recipient from Phase 1:
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 6 | Baseline the user | `get-user` | Confirm identity, department, privileged-role membership (privileged targets escalate severity). |
-| 7 | Detect post-delivery suspicious sign-ins | `list-sign-ins` | Window starts at message delivery time. Look for atypical location, anonymous IP, legacy auth, MFA-not-satisfied-but-granted. |
-| 8 | Correlate with Identity Protection | `list-risk-detections`, `list-risky-users` | A detection timestamped just after delivery is a strong engagement signal. |
-| 9 | Spot attacker actions post-click | `list-directory-audits` | Filter `initiatedBy.user.id = <recipientId>` from delivery onward. New OAuth consents and mail rules (visible as audit entries) are the two highest-signal events. |
+| #   | Objective                                | MCP tool(s)                                | Notes                                                                                                                                                              |
+| --- | ---------------------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 6   | Baseline the user                        | `get-user`                                 | Confirm identity, department, privileged-role membership (privileged targets escalate severity).                                                                   |
+| 7   | Detect post-delivery suspicious sign-ins | `list-sign-ins`                            | Window starts at message delivery time. Look for atypical location, anonymous IP, legacy auth, MFA-not-satisfied-but-granted.                                      |
+| 8   | Correlate with Identity Protection       | `list-risk-detections`, `list-risky-users` | A detection timestamped just after delivery is a strong engagement signal.                                                                                         |
+| 9   | Spot attacker actions post-click         | `list-directory-audits`                    | Filter `initiatedBy.user.id = <recipientId>` from delivery onward. New OAuth consents and mail rules (visible as audit entries) are the two highest-signal events. |
 
 ### Classification output
 
@@ -116,11 +116,11 @@ The handoff should include:
 
 ## Phase 4 — Documentation and closure
 
-| # | Action | MCP tool | Notes |
-|---|---|---|---|
-| 10 | Bind related alerts to a single incident | `update-security-incident` | Classification `truePositivePhishing`, assignee, status `inProgress`. |
-| 11 | Narrative on each alert | `add-security-alert-comment` | Timeline bullet points — detection, scope, victims, handoff sent. |
-| 12 | Audit trail of the investigation window | `list-directory-audits` | Capture every operation the responder performed through the server. Attach to the incident record. |
+| #   | Action                                   | MCP tool                     | Notes                                                                                              |
+| --- | ---------------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------- |
+| 10  | Bind related alerts to a single incident | `update-security-incident`   | Classification `truePositivePhishing`, assignee, status `inProgress`.                              |
+| 11  | Narrative on each alert                  | `add-security-alert-comment` | Timeline bullet points — detection, scope, victims, handoff sent.                                  |
+| 12  | Audit trail of the investigation window  | `list-directory-audits`      | Capture every operation the responder performed through the server. Attach to the incident record. |
 
 ---
 
@@ -149,6 +149,6 @@ The handoff should include:
 ## Related playbooks
 
 - [Compromised Account](compromised-account.md) — triggered per confirmed victim.
-- OAuth illicit consent — *draft*. Often a phishing lure leads to consent phishing instead of credential theft — that flow is covered separately.
+- OAuth illicit consent — _draft_. Often a phishing lure leads to consent phishing instead of credential theft — that flow is covered separately.
 
 See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.

--- a/docs/playbooks/sharepoint-exfiltration.md
+++ b/docs/playbooks/sharepoint-exfiltration.md
@@ -8,7 +8,7 @@ Response to suspected data exfiltration through SharePoint Online or OneDrive fo
 
 - A Defender or DLP alert referencing anomalous download volume or mass-sharing.
 - HR notifies of an employee departure; a privileged offboarding review is required.
-- A user reports an accidental *Anyone with the link* share on a sensitive document.
+- A user reports an accidental _Anyone with the link_ share on a sensitive document.
 - A quarterly audit surfaces sites with excessive external guests or anonymous links.
 - Spike in `get-sharepoint-usage-report` external-users metric.
 
@@ -59,16 +59,16 @@ Before revoking or downgrading a permission on a production site, confirm the si
 
 ## Phase 1 — Scope the exposure
 
-Goal: quantify *what is shared*, *with whom*, *how broadly*.
+Goal: quantify _what is shared_, _with whom_, _how broadly_.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 1 | Pull the tenant external-sharing baseline | `get-sharepoint-settings` | Tenant-level defaults for external sharing, guest experience, link expiration. Baseline for what *should* be allowed. |
-| 2 | Identify the suspect site(s) | `list-sharepoint-sites`, `get-sharepoint-site` | Filter by owner UPN for an offboarding scenario; filter by URL / title for a reported incident. |
-| 3 | Enumerate site permissions | `list-site-permissions`, `get-site-permission` | Per site: grantee identities, roles (`read` / `write` / `owner`), scope (direct user, group, anonymous link, org-wide share). |
-| 4 | Enumerate site drives and subsites | `list-site-drives`, `get-site-default-drive`, `list-site-subsites` | Establishes the full storage surface to review, not just the root site. |
-| 5 | Measure site activity | `get-site-analytics`, `get-sharepoint-usage-report` | Views, unique viewers, time window. An activity spike aligned with the alert is a strong signal. |
-| 6 | Correlate with sensitivity labels | `list-sensitivity-labels`, `list-sensitivity-sublabels` | Identifies whether the exposed content *should* have been labeled `Confidential` / `Highly Confidential` and was not — a labeling gap is a recurring root cause. |
+| #   | Objective                                 | MCP tool(s)                                                        | Notes                                                                                                                                                            |
+| --- | ----------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Pull the tenant external-sharing baseline | `get-sharepoint-settings`                                          | Tenant-level defaults for external sharing, guest experience, link expiration. Baseline for what _should_ be allowed.                                            |
+| 2   | Identify the suspect site(s)              | `list-sharepoint-sites`, `get-sharepoint-site`                     | Filter by owner UPN for an offboarding scenario; filter by URL / title for a reported incident.                                                                  |
+| 3   | Enumerate site permissions                | `list-site-permissions`, `get-site-permission`                     | Per site: grantee identities, roles (`read` / `write` / `owner`), scope (direct user, group, anonymous link, org-wide share).                                    |
+| 4   | Enumerate site drives and subsites        | `list-site-drives`, `get-site-default-drive`, `list-site-subsites` | Establishes the full storage surface to review, not just the root site.                                                                                          |
+| 5   | Measure site activity                     | `get-site-analytics`, `get-sharepoint-usage-report`                | Views, unique viewers, time window. An activity spike aligned with the alert is a strong signal.                                                                 |
+| 6   | Correlate with sensitivity labels         | `list-sensitivity-labels`, `list-sensitivity-sublabels`            | Identifies whether the exposed content _should_ have been labeled `Confidential` / `Highly Confidential` and was not — a labeling gap is a recurring root cause. |
 
 ### Sample prompt
 
@@ -80,13 +80,13 @@ Goal: quantify *what is shared*, *with whom*, *how broadly*.
 
 Goal: attribute the permission changes and correlate with user activity. For offboarding scenarios, establish what the departing user shared in their final weeks.
 
-| # | Objective | MCP tool(s) | Notes |
-|---|---|---|---|
-| 7 | Baseline the actor | `get-user` | Role, department, manager, tenure. Privileged-role members trigger higher severity. |
-| 8 | Sharing events from directory audit | `list-directory-audits` | Filter on `category = SharePoint` and `activityDisplayName` patterns like *Add site collection administrator*, *Update site*, *Share*. Populates the operator-attributed timeline visible to Entra ID. |
-| 9 | Sign-in activity | `list-sign-ins` | Window = last 30 days. Unusual location or anonymous IP during a share-creation window is a strong engagement signal for insider-threat scenarios. |
-| 10 | Related security alerts | `list-security-alerts`, `list-security-incidents` | DLP, insider-risk, or Defender for Cloud Apps alerts on the same user or site. |
-| 11 | *(If file-level forensics required)* | **Handoff to Purview Unified Audit Log** | Per-file `FileDownloaded`, `FileSyncDownloadedFull`, `SharingSet` events are not exposed by Graph. Hand off the user UPN, site URL, and time window. |
+| #   | Objective                            | MCP tool(s)                                       | Notes                                                                                                                                                                                                  |
+| --- | ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 7   | Baseline the actor                   | `get-user`                                        | Role, department, manager, tenure. Privileged-role members trigger higher severity.                                                                                                                    |
+| 8   | Sharing events from directory audit  | `list-directory-audits`                           | Filter on `category = SharePoint` and `activityDisplayName` patterns like _Add site collection administrator_, _Update site_, _Share_. Populates the operator-attributed timeline visible to Entra ID. |
+| 9   | Sign-in activity                     | `list-sign-ins`                                   | Window = last 30 days. Unusual location or anonymous IP during a share-creation window is a strong engagement signal for insider-threat scenarios.                                                     |
+| 10  | Related security alerts              | `list-security-alerts`, `list-security-incidents` | DLP, insider-risk, or Defender for Cloud Apps alerts on the same user or site.                                                                                                                         |
+| 11  | _(If file-level forensics required)_ | **Handoff to Purview Unified Audit Log**          | Per-file `FileDownloaded`, `FileSyncDownloadedFull`, `SharingSet` events are not exposed by Graph. Hand off the user UPN, site URL, and time window.                                                   |
 
 ---
 
@@ -94,14 +94,14 @@ Goal: attribute the permission changes and correlate with user activity. For off
 
 Order: revoke / downgrade at the site first, then tighten the actor's identity if warranted.
 
-| # | Action | MCP tool | Risk | Effect |
-|---|---|---|---|---|
-| 12 | Remove anonymous / excessive share links | `delete-site-permission` | **high** | Revokes a specific permission entry. Use for anonymous links and grantees clearly outside policy. |
-| 13 | Downgrade over-permissive grants | `update-site-permission` | **medium** | Prefer downgrade (`write` → `read`) over delete when collaboration must continue. |
-| 14 | Lock down the site configuration if needed | `update-sharepoint-site` | **medium** | Constrain site-level sharing capabilities while investigation continues. |
-| 15 | If the actor is confirmed malicious or departed | `revoke-user-sessions` | **high** | Per-user session kill. Pair with the [compromised-account](compromised-account.md) playbook if insider compromise is confirmed. |
+| #   | Action                                          | MCP tool                 | Risk       | Effect                                                                                                                          |
+| --- | ----------------------------------------------- | ------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 12  | Remove anonymous / excessive share links        | `delete-site-permission` | **high**   | Revokes a specific permission entry. Use for anonymous links and grantees clearly outside policy.                               |
+| 13  | Downgrade over-permissive grants                | `update-site-permission` | **medium** | Prefer downgrade (`write` → `read`) over delete when collaboration must continue.                                               |
+| 14  | Lock down the site configuration if needed      | `update-sharepoint-site` | **medium** | Constrain site-level sharing capabilities while investigation continues.                                                        |
+| 15  | If the actor is confirmed malicious or departed | `revoke-user-sessions`   | **high**   | Per-user session kill. Pair with the [compromised-account](compromised-account.md) playbook if insider compromise is confirmed. |
 
-> Tenant-level external-sharing policy changes (e.g. disabling *Anyone* links tenant-wide) are **not** exposed as an update tool in this server — that change is made in the SharePoint admin center or via Microsoft Graph beta endpoints not currently mapped. Flag it as a follow-up recommendation in Phase 5.
+> Tenant-level external-sharing policy changes (e.g. disabling _Anyone_ links tenant-wide) are **not** exposed as an update tool in this server — that change is made in the SharePoint admin center or via Microsoft Graph beta endpoints not currently mapped. Flag it as a follow-up recommendation in Phase 5.
 
 ### Sample containment prompt
 
@@ -113,23 +113,23 @@ Order: revoke / downgrade at the site first, then tighten the actor's identity i
 
 Recurring root cause for exfiltration incidents is missing classification. Close the loop so the same event does not happen twice.
 
-| # | Objective | MCP tool(s) | Action |
-|---|---|---|---|
-| 16 | Review sensitivity labels coverage | `list-sensitivity-labels`, `list-sensitivity-sublabels` | Identify whether a suitable label exists for the exposed content type; recommend mandatory labeling. |
-| 17 | Check retention labels | `list-retention-labels`, `list-retention-events`, `list-retention-event-types` | Confirm the content was not under an active retention or hold policy that the revocation could violate. |
-| 18 | Cross-check legal holds | `list-subject-rights-requests` | If an open DSAR or litigation hold covers this content, coordinate with Legal before any further action. |
-| 19 | Recommend tenant hardening | *(advisory — read-only for settings)* | Disable *Anyone* links tenant-wide, enforce link expiration, require guest MFA. Documented in Phase 5 as a follow-up. |
+| #   | Objective                          | MCP tool(s)                                                                    | Action                                                                                                                |
+| --- | ---------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| 16  | Review sensitivity labels coverage | `list-sensitivity-labels`, `list-sensitivity-sublabels`                        | Identify whether a suitable label exists for the exposed content type; recommend mandatory labeling.                  |
+| 17  | Check retention labels             | `list-retention-labels`, `list-retention-events`, `list-retention-event-types` | Confirm the content was not under an active retention or hold policy that the revocation could violate.               |
+| 18  | Cross-check legal holds            | `list-subject-rights-requests`                                                 | If an open DSAR or litigation hold covers this content, coordinate with Legal before any further action.              |
+| 19  | Recommend tenant hardening         | _(advisory — read-only for settings)_                                          | Disable _Anyone_ links tenant-wide, enforce link expiration, require guest MFA. Documented in Phase 5 as a follow-up. |
 
 ---
 
 ## Phase 5 — Documentation and audit
 
-| # | Action | MCP tool | Notes |
-|---|---|---|---|
-| 20 | Update the security incident | `update-security-incident` | Classification (`truePositive / dataExfiltration` or `falsePositive / accidentalShare`), status. |
-| 21 | Narrative comment on the alert | `add-security-alert-comment` | Scope (site + drives), actor, permission changes applied. |
-| 22 | Investigation audit log | `list-directory-audits` | Filter on the responder, window of the response. Attach to the incident. |
-| 23 | Governance follow-ups register | *(output as markdown)* | Tenant hardening, labeling gaps, missing retention — anything the investigation surfaced that is out of scope for the incident itself. |
+| #   | Action                         | MCP tool                     | Notes                                                                                                                                  |
+| --- | ------------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 20  | Update the security incident   | `update-security-incident`   | Classification (`truePositive / dataExfiltration` or `falsePositive / accidentalShare`), status.                                       |
+| 21  | Narrative comment on the alert | `add-security-alert-comment` | Scope (site + drives), actor, permission changes applied.                                                                              |
+| 22  | Investigation audit log        | `list-directory-audits`      | Filter on the responder, window of the response. Attach to the incident.                                                               |
+| 23  | Governance follow-ups register | _(output as markdown)_       | Tenant hardening, labeling gaps, missing retention — anything the investigation surfaced that is out of scope for the incident itself. |
 
 ---
 
@@ -157,7 +157,7 @@ Recurring root cause for exfiltration incidents is missing classification. Close
 ## Related playbooks
 
 - [Compromised Account](compromised-account.md) — triggered when the sharing actor is a confirmed compromise (not a negligent or departing insider).
-- [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) — a phishing lure sometimes drops an OAuth app *or* coerces a user into sharing a OneDrive link externally.
+- [Phishing Campaign (Tenant-Wide)](phishing-tenant-wide.md) — a phishing lure sometimes drops an OAuth app _or_ coerces a user into sharing a OneDrive link externally.
 - [OAuth Illicit Consent](oauth-illicit-consent.md) — apps granted `Files.Read.All` or `Sites.Read.All` through consent phishing show up here as the exfiltration vector.
 
 See [USE_CASES.md](../USE_CASES.md) for the broader catalogue of scenarios.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@okapi-ca/ms-365-admin-mcp-server",
-      "version": "0.2.0",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^3.8.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,6 +51,14 @@ program
     'Comma-separated Entra user object IDs (oid) allowed to authenticate via OAuth mode'
   )
   .option(
+    '--allow-any-tenant-user',
+    'Accept any authenticated user in the configured tenant (SEC-F01 opt-in). Required when --oauth-mode is set without --authorized-users.'
+  )
+  .option(
+    '--required-user-scopes <scopes>',
+    'Comma-separated scopes user tokens must contain in their scp claim (SEC-F03). Default: access_as_user. Empty string disables the check.'
+  )
+  .option(
     '--no-dynamic-registration',
     'Disable the OAuth Dynamic Client Registration endpoint (default: enabled with --oauth-mode)'
   );
@@ -73,6 +81,8 @@ export interface CommandOptions {
   oauthMode?: boolean;
   publicUrl?: string;
   authorizedUsers?: string;
+  allowAnyTenantUser?: boolean;
+  requiredUserScopes?: string;
   dynamicRegistration?: boolean;
   [key: string]: unknown;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -73,6 +73,31 @@ class AdminGraphServer {
           }
         : undefined;
 
+      const authorizedUserOids = (this.options.authorizedUsers || '')
+        .split(',')
+        .map((o: string) => o.trim())
+        .filter(Boolean);
+
+      const allowAnyTenantUser = Boolean(this.options.allowAnyTenantUser);
+
+      // SEC-F01: refuse to start if OAuth mode is enabled without any authorization surface.
+      if (this.options.oauthMode && authorizedUserOids.length === 0 && !allowAnyTenantUser) {
+        throw new Error(
+          'OAuth mode requires either --authorized-users <oids> (per-user allowlist) ' +
+            'or --allow-any-tenant-user (accept any tenant user). ' +
+            'Starting without one of these would leave the /mcp endpoint open to every authenticated tenant user.'
+        );
+      }
+
+      // SEC-F03: default to requiring `access_as_user` in scp. An empty string disables the check.
+      const requiredScopes =
+        this.options.requiredUserScopes === undefined
+          ? ['access_as_user']
+          : this.options.requiredUserScopes
+              .split(',')
+              .map((s: string) => s.trim())
+              .filter(Boolean);
+
       const userTokenValidatorOptions = this.options.oauthMode
         ? {
             tenantId: this.secrets!.tenantId,
@@ -81,10 +106,9 @@ class AdminGraphServer {
               `api://${this.secrets!.clientId}`,
               '00000003-0000-0000-c000-000000000000',
             ],
-            authorizedUserOids: (this.options.authorizedUsers || '')
-              .split(',')
-              .map((o: string) => o.trim())
-              .filter(Boolean),
+            authorizedUserOids,
+            allowAnyTenantUser,
+            requiredScopes,
           }
         : undefined;
 

--- a/src/user-token-authorization.ts
+++ b/src/user-token-authorization.ts
@@ -1,0 +1,109 @@
+import logger from './logger.js';
+
+export interface UserTokenValidatorOptions {
+  tenantId: string;
+  expectedAudiences: string[];
+  authorizedUserOids: string[];
+  // SEC-F01: explicit opt-in required when authorizedUserOids is empty.
+  // Without this flag and an empty allowlist, all user tokens are rejected.
+  allowAnyTenantUser: boolean;
+  // SEC-F03: user tokens must contain every scope listed here in their `scp` claim.
+  // Default is enforced at the caller (server.ts); an empty list disables the check.
+  requiredScopes: string[];
+}
+
+export interface UserTokenClaims {
+  oid: string;
+  upn?: string;
+  name?: string;
+  appid?: string;
+}
+
+export interface UserTokenPayload {
+  iss?: string;
+  aud?: string | string[];
+  exp?: number;
+  oid?: string;
+  upn?: string;
+  preferred_username?: string;
+  name?: string;
+  tid?: string;
+  appid?: string;
+  azp?: string;
+  scp?: string;
+}
+
+function audienceMatches(tokenAud: string | string[] | undefined, expected: string[]): boolean {
+  if (!tokenAud || expected.length === 0) return false;
+  const list = Array.isArray(tokenAud) ? tokenAud : [tokenAud];
+  return list.some((a) => expected.includes(a));
+}
+
+function parseTokenScopes(scp: string | undefined): string[] {
+  if (!scp) return [];
+  return scp.split(' ').filter(Boolean);
+}
+
+/**
+ * Post-signature-verification authorization checks on the user token payload.
+ * Pure function — no network, no JWT verification — so it is safe to import
+ * from tests without pulling the JWKS / jose dependency chain.
+ */
+export function authorizeUserClaims(
+  payload: UserTokenPayload,
+  options: UserTokenValidatorOptions
+): UserTokenClaims | null {
+  if (payload.tid && payload.tid !== options.tenantId) {
+    logger.warn(`User token tenant mismatch: tid=${payload.tid}, expected=${options.tenantId}`);
+    return null;
+  }
+
+  if (!audienceMatches(payload.aud, options.expectedAudiences)) {
+    logger.warn(
+      `User token audience not in expected list: aud=${JSON.stringify(payload.aud)}, expected=${JSON.stringify(options.expectedAudiences)}`
+    );
+    return null;
+  }
+
+  const oid = payload.oid;
+  if (!oid) {
+    logger.warn('User token missing oid claim');
+    return null;
+  }
+
+  // SEC-F01: fail-closed when no per-user allowlist is configured.
+  // Without this guard, any tenant user who obtains a token with the expected
+  // audience would gain the server's full app-permission capability.
+  if (options.authorizedUserOids.length === 0) {
+    if (!options.allowAnyTenantUser) {
+      logger.warn(
+        `User ${payload.upn || payload.preferred_username || oid} rejected: no --authorized-users allowlist configured and --allow-any-tenant-user not set`
+      );
+      return null;
+    }
+  } else if (!options.authorizedUserOids.includes(oid)) {
+    logger.warn(
+      `User oid ${oid} (${payload.upn || payload.preferred_username || 'no upn'}) not in authorized-users allowlist`
+    );
+    return null;
+  }
+
+  // SEC-F03: enforce required scopes (e.g. access_as_user) on the `scp` claim.
+  if (options.requiredScopes.length > 0) {
+    const tokenScopes = parseTokenScopes(payload.scp);
+    const missing = options.requiredScopes.filter((s) => !tokenScopes.includes(s));
+    if (missing.length > 0) {
+      logger.warn(
+        `User token missing required scope(s): ${missing.join(', ')}; token scp=${payload.scp ?? '<none>'}`
+      );
+      return null;
+    }
+  }
+
+  return {
+    oid,
+    upn: payload.upn || payload.preferred_username,
+    name: payload.name,
+    appid: payload.appid || payload.azp,
+  };
+}

--- a/src/user-token-validator.ts
+++ b/src/user-token-validator.ts
@@ -1,39 +1,19 @@
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
 import logger from './logger.js';
+import {
+  authorizeUserClaims,
+  type UserTokenClaims,
+  type UserTokenPayload,
+  type UserTokenValidatorOptions,
+} from './user-token-authorization.js';
 
-export interface UserTokenValidatorOptions {
-  tenantId: string;
-  expectedAudiences: string[];
-  authorizedUserOids: string[];
-  // SEC-F01: explicit opt-in required when authorizedUserOids is empty.
-  // Without this flag and an empty allowlist, all user tokens are rejected.
-  allowAnyTenantUser: boolean;
-  // SEC-F03: user tokens must contain every scope listed here in their `scp` claim.
-  // Default is enforced at the caller (server.ts); an empty list disables the check.
-  requiredScopes: string[];
-}
-
-export interface UserTokenClaims {
-  oid: string;
-  upn?: string;
-  name?: string;
-  appid?: string;
-}
-
-interface UserTokenPayload {
-  iss?: string;
-  aud?: string | string[];
-  exp?: number;
-  oid?: string;
-  upn?: string;
-  preferred_username?: string;
-  name?: string;
-  tid?: string;
-  appid?: string;
-  azp?: string;
-  scp?: string;
-}
+export { authorizeUserClaims } from './user-token-authorization.js';
+export type {
+  UserTokenClaims,
+  UserTokenPayload,
+  UserTokenValidatorOptions,
+} from './user-token-authorization.js';
 
 const jwksClients = new Map<string, jwksRsa.JwksClient>();
 
@@ -63,80 +43,6 @@ function getSigningKey(client: jwksRsa.JwksClient, header: jwt.JwtHeader): Promi
       resolve(key.getPublicKey());
     });
   });
-}
-
-function audienceMatches(tokenAud: string | string[] | undefined, expected: string[]): boolean {
-  if (!tokenAud || expected.length === 0) return false;
-  const list = Array.isArray(tokenAud) ? tokenAud : [tokenAud];
-  return list.some((a) => expected.includes(a));
-}
-
-function parseTokenScopes(scp: string | undefined): string[] {
-  if (!scp) return [];
-  return scp.split(' ').filter(Boolean);
-}
-
-/**
- * Post-signature-verification authorization checks on the user token payload.
- * Pure function — no network, no JWT verification. Exposed for unit testing.
- */
-export function authorizeUserClaims(
-  payload: UserTokenPayload,
-  options: UserTokenValidatorOptions
-): UserTokenClaims | null {
-  if (payload.tid && payload.tid !== options.tenantId) {
-    logger.warn(`User token tenant mismatch: tid=${payload.tid}, expected=${options.tenantId}`);
-    return null;
-  }
-
-  if (!audienceMatches(payload.aud, options.expectedAudiences)) {
-    logger.warn(
-      `User token audience not in expected list: aud=${JSON.stringify(payload.aud)}, expected=${JSON.stringify(options.expectedAudiences)}`
-    );
-    return null;
-  }
-
-  const oid = payload.oid;
-  if (!oid) {
-    logger.warn('User token missing oid claim');
-    return null;
-  }
-
-  // SEC-F01: fail-closed when no per-user allowlist is configured.
-  // Without this guard, any tenant user who obtains a token with the expected
-  // audience would gain the server's full app-permission capability.
-  if (options.authorizedUserOids.length === 0) {
-    if (!options.allowAnyTenantUser) {
-      logger.warn(
-        `User ${payload.upn || payload.preferred_username || oid} rejected: no --authorized-users allowlist configured and --allow-any-tenant-user not set`
-      );
-      return null;
-    }
-  } else if (!options.authorizedUserOids.includes(oid)) {
-    logger.warn(
-      `User oid ${oid} (${payload.upn || payload.preferred_username || 'no upn'}) not in authorized-users allowlist`
-    );
-    return null;
-  }
-
-  // SEC-F03: enforce required scopes (e.g. access_as_user) on the `scp` claim.
-  if (options.requiredScopes.length > 0) {
-    const tokenScopes = parseTokenScopes(payload.scp);
-    const missing = options.requiredScopes.filter((s) => !tokenScopes.includes(s));
-    if (missing.length > 0) {
-      logger.warn(
-        `User token missing required scope(s): ${missing.join(', ')}; token scp=${payload.scp ?? '<none>'}`
-      );
-      return null;
-    }
-  }
-
-  return {
-    oid,
-    upn: payload.upn || payload.preferred_username,
-    name: payload.name,
-    appid: payload.appid || payload.azp,
-  };
 }
 
 export async function validateUserToken(

--- a/src/user-token-validator.ts
+++ b/src/user-token-validator.ts
@@ -6,6 +6,12 @@ export interface UserTokenValidatorOptions {
   tenantId: string;
   expectedAudiences: string[];
   authorizedUserOids: string[];
+  // SEC-F01: explicit opt-in required when authorizedUserOids is empty.
+  // Without this flag and an empty allowlist, all user tokens are rejected.
+  allowAnyTenantUser: boolean;
+  // SEC-F03: user tokens must contain every scope listed here in their `scp` claim.
+  // Default is enforced at the caller (server.ts); an empty list disables the check.
+  requiredScopes: string[];
 }
 
 export interface UserTokenClaims {
@@ -65,6 +71,74 @@ function audienceMatches(tokenAud: string | string[] | undefined, expected: stri
   return list.some((a) => expected.includes(a));
 }
 
+function parseTokenScopes(scp: string | undefined): string[] {
+  if (!scp) return [];
+  return scp.split(' ').filter(Boolean);
+}
+
+/**
+ * Post-signature-verification authorization checks on the user token payload.
+ * Pure function — no network, no JWT verification. Exposed for unit testing.
+ */
+export function authorizeUserClaims(
+  payload: UserTokenPayload,
+  options: UserTokenValidatorOptions
+): UserTokenClaims | null {
+  if (payload.tid && payload.tid !== options.tenantId) {
+    logger.warn(`User token tenant mismatch: tid=${payload.tid}, expected=${options.tenantId}`);
+    return null;
+  }
+
+  if (!audienceMatches(payload.aud, options.expectedAudiences)) {
+    logger.warn(
+      `User token audience not in expected list: aud=${JSON.stringify(payload.aud)}, expected=${JSON.stringify(options.expectedAudiences)}`
+    );
+    return null;
+  }
+
+  const oid = payload.oid;
+  if (!oid) {
+    logger.warn('User token missing oid claim');
+    return null;
+  }
+
+  // SEC-F01: fail-closed when no per-user allowlist is configured.
+  // Without this guard, any tenant user who obtains a token with the expected
+  // audience would gain the server's full app-permission capability.
+  if (options.authorizedUserOids.length === 0) {
+    if (!options.allowAnyTenantUser) {
+      logger.warn(
+        `User ${payload.upn || payload.preferred_username || oid} rejected: no --authorized-users allowlist configured and --allow-any-tenant-user not set`
+      );
+      return null;
+    }
+  } else if (!options.authorizedUserOids.includes(oid)) {
+    logger.warn(
+      `User oid ${oid} (${payload.upn || payload.preferred_username || 'no upn'}) not in authorized-users allowlist`
+    );
+    return null;
+  }
+
+  // SEC-F03: enforce required scopes (e.g. access_as_user) on the `scp` claim.
+  if (options.requiredScopes.length > 0) {
+    const tokenScopes = parseTokenScopes(payload.scp);
+    const missing = options.requiredScopes.filter((s) => !tokenScopes.includes(s));
+    if (missing.length > 0) {
+      logger.warn(
+        `User token missing required scope(s): ${missing.join(', ')}; token scp=${payload.scp ?? '<none>'}`
+      );
+      return null;
+    }
+  }
+
+  return {
+    oid,
+    upn: payload.upn || payload.preferred_username,
+    name: payload.name,
+    appid: payload.appid || payload.azp,
+  };
+}
+
 export async function validateUserToken(
   token: string,
   options: UserTokenValidatorOptions
@@ -89,37 +163,7 @@ export async function validateUserToken(
       clockTolerance: 30,
     }) as UserTokenPayload;
 
-    if (payload.tid && payload.tid !== options.tenantId) {
-      logger.warn(`User token tenant mismatch: tid=${payload.tid}, expected=${options.tenantId}`);
-      return null;
-    }
-
-    if (!audienceMatches(payload.aud, options.expectedAudiences)) {
-      logger.warn(
-        `User token audience not in expected list: aud=${JSON.stringify(payload.aud)}, expected=${JSON.stringify(options.expectedAudiences)}`
-      );
-      return null;
-    }
-
-    const oid = payload.oid;
-    if (!oid) {
-      logger.warn('User token missing oid claim');
-      return null;
-    }
-
-    if (options.authorizedUserOids.length > 0 && !options.authorizedUserOids.includes(oid)) {
-      logger.warn(
-        `User oid ${oid} (${payload.upn || payload.preferred_username || 'no upn'}) not in authorized-users allowlist`
-      );
-      return null;
-    }
-
-    return {
-      oid,
-      upn: payload.upn || payload.preferred_username,
-      name: payload.name,
-      appid: payload.appid || payload.azp,
-    };
+    return authorizeUserClaims(payload, options);
   } catch (error) {
     logger.error(`User token validation failed: ${(error as Error).message}`);
     return null;

--- a/test/user-token-validator.test.ts
+++ b/test/user-token-validator.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  authorizeUserClaims,
+  type UserTokenValidatorOptions,
+} from '../src/user-token-validator.js';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const OID_ALICE = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const OID_BOB = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const CLIENT_ID = '22222222-2222-2222-2222-222222222222';
+
+function baseOptions(
+  overrides: Partial<UserTokenValidatorOptions> = {}
+): UserTokenValidatorOptions {
+  return {
+    tenantId: TENANT,
+    expectedAudiences: [CLIENT_ID, `api://${CLIENT_ID}`],
+    authorizedUserOids: [],
+    allowAnyTenantUser: false,
+    requiredScopes: [],
+    ...overrides,
+  };
+}
+
+function basePayload(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    tid: TENANT,
+    aud: `api://${CLIENT_ID}`,
+    oid: OID_ALICE,
+    upn: 'alice@contoso.com',
+    scp: 'access_as_user',
+    ...overrides,
+  };
+}
+
+describe('authorizeUserClaims — tenant and audience', () => {
+  it('rejects when tid does not match the configured tenant', () => {
+    const payload = basePayload({ tid: 'other-tenant-id' });
+    expect(authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }))).toBeNull();
+  });
+
+  it('rejects when audience is not in the expected list', () => {
+    const payload = basePayload({ aud: 'api://some-other-app' });
+    expect(authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }))).toBeNull();
+  });
+
+  it('accepts when audience is an array containing an expected value', () => {
+    const payload = basePayload({ aud: ['api://unrelated', `api://${CLIENT_ID}`] });
+    const claims = authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }));
+    expect(claims?.oid).toBe(OID_ALICE);
+  });
+
+  it('rejects when oid is missing', () => {
+    const payload = basePayload({ oid: undefined });
+    expect(authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }))).toBeNull();
+  });
+});
+
+describe('authorizeUserClaims — SEC-F01 fail-closed authorization', () => {
+  it('rejects every token when authorizedUserOids is empty and allowAnyTenantUser is false', () => {
+    const payload = basePayload();
+    expect(authorizeUserClaims(payload, baseOptions())).toBeNull();
+  });
+
+  it('accepts when authorizedUserOids is empty but allowAnyTenantUser is true', () => {
+    const payload = basePayload();
+    const claims = authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }));
+    expect(claims).not.toBeNull();
+    expect(claims?.oid).toBe(OID_ALICE);
+  });
+
+  it('accepts when oid is in the authorizedUserOids allowlist', () => {
+    const payload = basePayload();
+    const claims = authorizeUserClaims(
+      payload,
+      baseOptions({ authorizedUserOids: [OID_ALICE, OID_BOB] })
+    );
+    expect(claims?.oid).toBe(OID_ALICE);
+  });
+
+  it('rejects when oid is not in a non-empty authorizedUserOids allowlist, even with allowAnyTenantUser=true', () => {
+    const payload = basePayload({ oid: 'cccccccc-cccc-cccc-cccc-cccccccccccc' });
+    expect(
+      authorizeUserClaims(
+        payload,
+        baseOptions({ authorizedUserOids: [OID_ALICE, OID_BOB], allowAnyTenantUser: true })
+      )
+    ).toBeNull();
+  });
+});
+
+describe('authorizeUserClaims — SEC-F03 required scope enforcement', () => {
+  it('accepts when all required scopes are present', () => {
+    const payload = basePayload({ scp: 'profile access_as_user email' });
+    const claims = authorizeUserClaims(
+      payload,
+      baseOptions({ allowAnyTenantUser: true, requiredScopes: ['access_as_user'] })
+    );
+    expect(claims?.oid).toBe(OID_ALICE);
+  });
+
+  it('rejects when a required scope is missing', () => {
+    const payload = basePayload({ scp: 'profile email' });
+    expect(
+      authorizeUserClaims(
+        payload,
+        baseOptions({ allowAnyTenantUser: true, requiredScopes: ['access_as_user'] })
+      )
+    ).toBeNull();
+  });
+
+  it('rejects when the scp claim is missing entirely and scopes are required', () => {
+    const payload = basePayload({ scp: undefined });
+    expect(
+      authorizeUserClaims(
+        payload,
+        baseOptions({ allowAnyTenantUser: true, requiredScopes: ['access_as_user'] })
+      )
+    ).toBeNull();
+  });
+
+  it('skips the scope check when requiredScopes is empty', () => {
+    const payload = basePayload({ scp: undefined });
+    const claims = authorizeUserClaims(
+      payload,
+      baseOptions({ allowAnyTenantUser: true, requiredScopes: [] })
+    );
+    expect(claims?.oid).toBe(OID_ALICE);
+  });
+
+  it('rejects when only one of multiple required scopes is present', () => {
+    const payload = basePayload({ scp: 'access_as_user' });
+    expect(
+      authorizeUserClaims(
+        payload,
+        baseOptions({
+          allowAnyTenantUser: true,
+          requiredScopes: ['access_as_user', 'admin.full'],
+        })
+      )
+    ).toBeNull();
+  });
+});
+
+describe('authorizeUserClaims — claims extraction', () => {
+  it('returns upn when present', () => {
+    const payload = basePayload({ upn: 'alice@contoso.com', preferred_username: 'alice@other' });
+    const claims = authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }));
+    expect(claims?.upn).toBe('alice@contoso.com');
+  });
+
+  it('falls back to preferred_username when upn is missing', () => {
+    const payload = basePayload({ upn: undefined, preferred_username: 'alice@contoso.com' });
+    const claims = authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }));
+    expect(claims?.upn).toBe('alice@contoso.com');
+  });
+
+  it('extracts appid from azp when appid is missing', () => {
+    const payload = basePayload({ appid: undefined, azp: 'client-app-id' });
+    const claims = authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }));
+    expect(claims?.appid).toBe('client-app-id');
+  });
+});

--- a/test/user-token-validator.test.ts
+++ b/test/user-token-validator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   authorizeUserClaims,
   type UserTokenValidatorOptions,
-} from '../src/user-token-validator.js';
+} from '../src/user-token-authorization.js';
 
 const TENANT = '11111111-1111-1111-1111-111111111111';
 const OID_ALICE = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';


### PR DESCRIPTION
## Summary

Closes the two exploitable findings identified in the Priority 1 security review (`docs/SECURITY_REVIEW_2026-04-20.md`). Both were latent in the OAuth HTTP mode introduced in v0.2.0.

- **SEC-F01 (Critical)** — empty `authorizedUserOids` silently accepted every authenticated tenant user. Combined with the client-credentials Graph auth model ([src/auth.ts:111](https://github.com/okapi-ca/ms-365-admin-mcp-server/blob/main/src/auth.ts#L111)), any such user gained the server's full app-permission capability. Fixed by failing closed unless `--authorized-users` or the explicit `--allow-any-tenant-user` flag is passed. Server refuses to start at config time without one of them.
- **SEC-F03 (High)** — `scp` claim was parsed but never enforced. A token whose scopes were `openid profile email` was accepted and drove admin-grade Graph operations. Fixed by enforcing a required-scopes list (default `access_as_user`) via the new `--required-user-scopes` flag.

Post-verification authorization logic extracted into the pure function `authorizeUserClaims(payload, options)` so the policy layer is testable without JWT/JWKS plumbing. 16 new unit tests cover tenant, audience, oid allowlist, scope enforcement, and claims extraction.

## Breaking changes

See `CHANGELOG.md [Unreleased]`. Two migration cases:

1. Deployments that relied on the implicit "any authenticated tenant user" behaviour must now pass `--allow-any-tenant-user` explicitly (and review whether that is actually intended — this is the SEC-F01 fix).
2. Deployments whose Entra app registration does not expose `access_as_user`, or whose callers request a different scope, must pass `--required-user-scopes <scopes>` or `--required-user-scopes ""` (SEC-F03).

## Traceability

Full findings register, architectural premise, and remediation plan:

- `docs/SECURITY_REVIEW_2026-04-20.md` — stable `SEC-Fxx` identifiers for this and future review cycles.
- Remaining priority-1 findings (SEC-F02, F04, F05, F06, F07, F08, F09, F10, F11) tracked there for future PRs.

## Test plan

- [x] `npm run lint` — pass (only pre-existing logger.ts warning, unrelated).
- [x] `npm run format:check` — clean.
- [x] `npm run build` — clean.
- [x] `npm test` for `test/user-token-validator.test.ts` — 16/16 green locally.
- [ ] Full CI `verify` pipeline (generate + lint + format + build + test) across Node 18/20/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)