### PR TITLE
fix(security): sprint 2 — SEC-F02 public-url, SEC-F06 OAuth rate-limits, SEC-F04 partial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ Tool counts in parentheses indicate the cumulative total after the change.
 ### Security
 
 - **SEC-F01 (breaking)** — OAuth mode now fails closed when no per-user allowlist is configured. Previously an empty `--authorized-users` list silently accepted every authenticated tenant user; now the server refuses to start unless either `--authorized-users <oids>` is provided or the explicit opt-in `--allow-any-tenant-user` is passed.
+- **SEC-F02 (breaking)** — `--public-url` is now mandatory when `--oauth-mode` is enabled, validated at startup and again at OAuth-route registration. The header-derived fallback (X-Forwarded-Proto / Host) in `resolveIssuer` and `resourceMetadataUrl` has been removed; the advertised OAuth issuer is deterministic and immune to metadata poisoning via request headers.
 - **SEC-F03** — User tokens must now contain every scope listed in `--required-user-scopes` (default `access_as_user`) in their `scp` claim. Pass `--required-user-scopes ""` to restore the previous no-scope-check behaviour.
+- **SEC-F04 (partial)** — `/token` is now rate-limited at 10 req/min per IP, bounding brute-force throughput against stolen refresh tokens. The architectural residual (single stolen refresh token is still redeemable) is tracked as SEC-F04b for a proof-of-possession follow-up.
+- **SEC-F06** — OAuth routes (`/authorize`, `/token`, `/register`) now have dedicated rate limiters: 30 req/min on `/authorize`, 10 req/min on `/token` and `/register`. Previously only `/mcp` was rate-limited.
 - Extracted the post-verification authorization logic into `authorizeUserClaims` and added 16 unit tests covering tenant, audience, oid allowlist, and scope enforcement paths.
 
 ### Migration
 
 - Deployments relying on the implicit "any authenticated user" behaviour must add `--allow-any-tenant-user` to their startup command (and review whether that is actually intended).
+- Deployments running `--oauth-mode` without `--public-url` must add `--public-url https://<fqdn>`. This was already documented as "required when behind a reverse proxy"; it is now strictly required.
 - Deployments whose Entra app registration does not expose the `access_as_user` scope — or whose callers request a different scope — must pass `--required-user-scopes <their-scopes>` or `--required-user-scopes ""`.
 
 ## [0.2.4] — 2026-04-20

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -140,14 +140,14 @@ curl -X POST http://localhost:8080/mcp \
 
 The server ships with these defenses enabled by default (see `src/http-server.ts`):
 
-| Defense                 | Detail                                                                                                                                          |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| Rate limit              | 100 req/min per source IP on `/mcp`                                                                                                             |
-| Body size limit         | 100 KB                                                                                                                                          |
-| Security headers        | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store`, CSP `default-src 'none'`, `Referrer-Policy: no-referrer` |
-| Default bind            | `127.0.0.1` (loopback)                                                                                                                          |
-| Stateless sessions      | Each request creates a fresh transport; no server-side session state                                                                            |
-| Stack trace suppression | Errors return `500` with generic message; details in logs only                                                                                  |
+| Defense                 | Detail                                                                                                                                                                                          |
+| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Rate limit              | `/mcp`: 100 req/min per source IP. `/authorize`: 30 req/min. `/token` and `/register`: 10 req/min. Limits are process-local — multi-replica deployments scale the effective budget per replica. |
+| Body size limit         | 100 KB                                                                                                                                                                                          |
+| Security headers        | `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Cache-Control: no-store`, CSP `default-src 'none'`, `Referrer-Policy: no-referrer`                                                 |
+| Default bind            | `127.0.0.1` (loopback)                                                                                                                                                                          |
+| Stateless sessions      | Each request creates a fresh transport; no server-side session state                                                                                                                            |
+| Stack trace suppression | Errors return `500` with generic message; details in logs only                                                                                                                                  |
 
 ## Operator-provided hardening (you must do this)
 

--- a/docs/SECURITY_REVIEW_2026-04-20.md
+++ b/docs/SECURITY_REVIEW_2026-04-20.md
@@ -44,11 +44,12 @@ Severity rubric mirrors [RISK_MODEL.md](RISK_MODEL.md) but is calibrated to secu
 ### SEC-F02 — `resolveIssuer` trusts `X-Forwarded-*` in the fallback path
 
 - **Severity:** High
-- **Status:** Open
-- **Location:** [src/oauth-proxy.ts:54-59](../src/oauth-proxy.ts), [src/http-server.ts:34-39](../src/http-server.ts).
-- **Description:** When `publicUrl` is not configured, `resolveIssuer` and `resourceMetadataUrl` derive the advertised OAuth issuer from `X-Forwarded-Proto` / `X-Forwarded-Host` / `Host`. `app.set('trust proxy', 1)` bounds that trust to a single upstream hop, which is appropriate only behind a known-and-trusted reverse proxy.
-- **Attack scenario:** In a direct-exposure deploy (no reverse proxy), a client-supplied `Host` header is echoed into `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`. A victim client performing metadata discovery may be steered to an attacker-controlled issuer and intercepted.
-- **Remediation (proposed):** Make `--public-url` mandatory when `--oauth-mode` is enabled. If a fallback must remain (dev ergonomics), validate the derived host against an allowlist of approved public hostnames.
+- **Status:** Fixed — sprint 2
+- **Location:** [src/oauth-proxy.ts](../src/oauth-proxy.ts), [src/http-server.ts](../src/http-server.ts).
+- **Description:** When `publicUrl` was not configured, the proxy derived the advertised OAuth issuer from `X-Forwarded-Proto` / `X-Forwarded-Host` / `Host`. `app.set('trust proxy', 1)` bounds that trust to a single upstream hop, which is appropriate only behind a known-and-trusted reverse proxy.
+- **Attack scenario:** In a direct-exposure deploy (no reverse proxy), a client-supplied `Host` header was echoed into `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`. A victim client performing metadata discovery could be steered to an attacker-controlled issuer and intercepted.
+- **Remediation:** `--public-url` is now mandatory when `--oauth-mode` is enabled, validated at startup (`server.ts`) and again at OAuth-route registration (`registerOAuthRoutes` throws). The header-derived fallback was removed from both `oauth-proxy.ts` and `http-server.ts` (`resourceMetadataUrl` now takes a non-optional string). The advertised issuer is deterministic and independent of request headers.
+- **Breaking change:** Yes. Deployments that did not pass `--public-url` must add it.
 
 ### SEC-F03 — `scp` claim parsed but never enforced
 
@@ -64,14 +65,13 @@ Severity rubric mirrors [RISK_MODEL.md](RISK_MODEL.md) but is calibrated to secu
 ### SEC-F04 — `refresh_token` grant requires no MCP-client authentication
 
 - **Severity:** High
-- **Status:** Open
-- **Location:** [src/oauth-proxy.ts:197-207](../src/oauth-proxy.ts).
+- **Status:** Partially mitigated — sprint 2. Residual risk tracked.
+- **Location:** [src/oauth-proxy.ts](../src/oauth-proxy.ts).
 - **Description:** `POST /token` with `grant_type=refresh_token` attaches the server's `client_secret` and forwards the refresh token to Entra. An attacker in possession of a refresh token only needs the public proxy URL to redeem it — the client_secret Entra would normally require is supplied by the proxy on behalf of the caller.
-- **Attack scenario:** Refresh-token exfiltration from an MCP client (local token store, logs, MITM) becomes directly usable via the proxy, without the additional factor of the client_secret.
-- **Remediation (proposed):** One of —
-  - require a valid bearer JWT alongside `refresh_token` on `/token` (binds the grant to the same subject) ;
-  - move the proxy away from `token_endpoint_auth_methods: none` and require per-client credentials ;
-  - add a strict per-IP rate limit on `/token` (partial mitigation).
+- **Attack scenario:** Refresh-token exfiltration from an MCP client (local token store, logs, MITM) is directly usable via the proxy, without the additional factor of the client_secret.
+- **Mitigation delivered (sprint 2):** `/token` is now rate-limited at 10 req/min per IP (see SEC-F06), which bounds brute-force throughput and makes scripted abuse visible in logs. This does **not** close the underlying architectural gap — one stolen refresh token used once is still redeemable.
+- **Residual risk:** Stolen-refresh-token reuse remains possible until either (a) the proxy becomes a confidential client to MCP callers (per-client credentials, moving away from `token_endpoint_auth_methods: none`), or (b) the proxy requires a bound proof-of-possession on refresh (DPoP, mTLS, or a session-bound bearer). Both are architectural changes tracked separately as a future SEC-F04b.
+- **Operational compensations:** keep refresh-token lifetimes short in the Entra app registration (default 90 days is too long for an admin surface; consider dropping to 24h via Conditional Access sign-in frequency); monitor the `10 req/min` rate-limit hits on `/token` for anomalous clients.
 
 ### SEC-F05 — PKCE bridge is in-memory per process
 
@@ -85,11 +85,13 @@ Severity rubric mirrors [RISK_MODEL.md](RISK_MODEL.md) but is calibrated to secu
 ### SEC-F06 — `/token` and `/authorize` have no rate limit
 
 - **Severity:** Medium
-- **Status:** Open
-- **Location:** [src/http-server.ts:49-58](../src/http-server.ts).
-- **Description:** The `express-rate-limit` middleware is mounted on `/mcp` only. `/authorize`, `/token`, and `/register` are uncapped.
-- **Attack scenario:** Brute force of authorization codes, enumeration of refresh tokens (pair with SEC-F04), DoS against Entra's `/token` endpoint via the proxy.
-- **Remediation (proposed):** Add a tighter rate limit on `/token` (e.g. 10 req/min per IP) and `/authorize` (e.g. 30 req/min per IP).
+- **Status:** Fixed — sprint 2
+- **Location:** [src/http-server.ts](../src/http-server.ts).
+- **Description:** The `express-rate-limit` middleware was mounted on `/mcp` only. `/authorize`, `/token`, and `/register` were uncapped, enabling brute force of authorization codes and enumeration of refresh tokens (see SEC-F04).
+- **Remediation:** Added two dedicated rate limiters, both active only when `--oauth-mode` is enabled:
+  - `/authorize`: 30 req/min per IP (user-initiated redirect, looser bound).
+  - `/token` and `/register`: 10 req/min per IP (token exchange is the brute-force target).
+- **Note:** Limits are process-local. In a multi-replica deployment the effective budget scales with the replica count; SEC-F05 (externalize transient state) is the follow-up that would restore a single shared budget.
 
 ### SEC-F07 — `/token` logs up to 500 chars of upstream error payload
 
@@ -149,12 +151,12 @@ No remediation required — recorded so future reviews do not re-litigate alread
 
 ## Remediation order (recommendation)
 
-| Wave            | Findings                         | Rationale                                                      |
-| --------------- | -------------------------------- | -------------------------------------------------------------- |
-| 1 — this review | SEC-F01 (fixed), SEC-F03 (fixed) | Critical + High exploitable at the current deployment state.   |
-| 2 — next sprint | SEC-F02, SEC-F04, SEC-F06        | Harden the public OAuth proxy surface before broader exposure. |
-| 3 — hardening   | SEC-F05, SEC-F07, SEC-F08        | Multi-replica readiness, log hygiene, availability robustness. |
-| Backlog         | SEC-F09, SEC-F10, SEC-F11        | Documentation / cosmetic; no realistic exploit path.           |
+| Wave          | Findings                                                                       | Rationale                                                      |
+| ------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| 1 — PR #44    | SEC-F01 (fixed), SEC-F03 (fixed)                                               | Critical + High exploitable at the current deployment state.   |
+| 2 — PR #45    | SEC-F02 (fixed), SEC-F06 (fixed), SEC-F04 (partial: rate-limited + documented) | Harden the public OAuth proxy surface before broader exposure. |
+| 3 — hardening | SEC-F05, SEC-F07, SEC-F08, SEC-F04b (architectural refresh-token PoP)          | Multi-replica readiness, log hygiene, availability robustness. |
+| Backlog       | SEC-F09, SEC-F10, SEC-F11                                                      | Documentation / cosmetic; no realistic exploit path.           |
 
 ---
 
@@ -162,7 +164,7 @@ No remediation required — recorded so future reviews do not re-litigate alread
 
 The broader audit plan identified six priority areas. Status after this cycle:
 
-- **P1 — Auth / OAuth HTTP mode** — partially remediated (SEC-F01 + SEC-F03 closed; SEC-F02/F04/F05/F06/F07/F08/F09/F10/F11 open).
+- **P1 — Auth / OAuth HTTP mode** — majority remediated. Closed: SEC-F01, SEC-F02, SEC-F03, SEC-F06. Partially mitigated: SEC-F04 (rate-limited + documented; architectural PoP fix tracked as SEC-F04b). Open: SEC-F05, SEC-F07, SEC-F08, SEC-F09, SEC-F10, SEC-F11.
 - **P2 — Tool invocation gating** — not yet reviewed. Verify `--allow-writes` enforcement at dispatch, audit risk-level labels, assess prompt-injection via Graph response content.
 - **P3 — Secret & token hygiene** — pass-level check done (no logging observed); formal pass pending.
 - **P4 — Transport & deploy hardening** — CORS, HSTS, trust-proxy depth, rate-limit breadth.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -44,7 +44,7 @@ program
   )
   .option(
     '--public-url <url>',
-    'Public base URL for OAuth metadata (required with --oauth-mode when behind a reverse proxy)'
+    'Public base URL for OAuth metadata, e.g. https://mcp.example.com. Required with --oauth-mode (SEC-F02: no header-based fallback).'
   )
   .option(
     '--authorized-users <oids>',

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -31,11 +31,11 @@ function stripTrailingSlash(s: string): string {
   return s.endsWith('/') ? s.slice(0, -1) : s;
 }
 
-function resourceMetadataUrl(req: Request, publicUrl?: string): string {
-  if (publicUrl) return `${stripTrailingSlash(publicUrl)}/.well-known/oauth-protected-resource`;
-  const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol;
-  const host = (req.headers['x-forwarded-host'] as string) || req.headers.host;
-  return `${proto}://${host}/.well-known/oauth-protected-resource`;
+function resourceMetadataUrl(publicUrl: string): string {
+  // SEC-F02: publicUrl is mandatory and validated by registerOAuthRoutes; no
+  // header-derived fallback here either, to keep the WWW-Authenticate challenge
+  // consistent with the advertised metadata.
+  return `${stripTrailingSlash(publicUrl)}/.well-known/oauth-protected-resource`;
 }
 
 export async function startHttpServer(options: HttpServerOptions): Promise<void> {
@@ -62,8 +62,30 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   });
 
   if (options.oauthProxyOptions) {
+    // SEC-F06: OAuth surface is public and must be rate-limited independently
+    // of /mcp. /token is the tightest (brute-forcing auth codes / refresh tokens
+    // lives here); /authorize is looser because it's a user-initiated redirect.
+    app.use(
+      '/authorize',
+      rateLimit({
+        windowMs: 60_000,
+        max: 30,
+        standardHeaders: true,
+        legacyHeaders: false,
+        message: { error: 'invalid_request', error_description: 'Too many authorize requests' },
+      })
+    );
+    const tokenLimiter = rateLimit({
+      windowMs: 60_000,
+      max: 10,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: { error: 'invalid_request', error_description: 'Too many token requests' },
+    });
+    app.use('/token', tokenLimiter);
+    app.use('/register', tokenLimiter);
     registerOAuthRoutes(app, options.oauthProxyOptions);
-    logger.info('OAuth proxy routes enabled (/authorize, /token, DCR, metadata)');
+    logger.info('OAuth proxy routes enabled (/authorize, /token, DCR, metadata) with rate limits');
   }
 
   const serviceValidator = options.tokenValidatorOptions;
@@ -78,9 +100,9 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
   const oauthPublicUrl = options.oauthProxyOptions?.publicUrl;
   const oauthEnabled = Boolean(options.oauthProxyOptions);
 
-  function setChallengeHeader(req: Request, res: Response, errorCode?: string): void {
-    if (!oauthEnabled) return;
-    const metadata = resourceMetadataUrl(req, oauthPublicUrl);
+  function setChallengeHeader(_req: Request, res: Response, errorCode?: string): void {
+    if (!oauthEnabled || !oauthPublicUrl) return;
+    const metadata = resourceMetadataUrl(oauthPublicUrl);
     const parts = [`resource_metadata="${metadata}"`];
     if (errorCode) parts.push(`error="${errorCode}"`);
     res.setHeader('WWW-Authenticate', `Bearer ${parts.join(', ')}`);

--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -3,6 +3,11 @@ import type { Express, Request, Response } from 'express';
 import logger from './logger.js';
 
 export interface OAuthProxyOptions {
+  // SEC-F02: must be a non-empty absolute URL. The proxy advertises this as the
+  // OAuth issuer and resource identifier in `/.well-known/...`. Deriving the
+  // issuer from request headers (X-Forwarded-*, Host) is a metadata-poisoning
+  // vector when the server is not behind a strict reverse proxy, so the
+  // fallback was removed and callers must supply a trusted public URL.
   publicUrl: string;
   tenantId: string;
   clientId: string;
@@ -51,22 +56,24 @@ function stripTrailingSlash(s: string): string {
   return s.endsWith('/') ? s.slice(0, -1) : s;
 }
 
-function resolveIssuer(req: Request, configured: string): string {
-  if (configured) return stripTrailingSlash(configured);
-  const proto = (req.headers['x-forwarded-proto'] as string) || req.protocol;
-  const host = (req.headers['x-forwarded-host'] as string) || req.headers.host;
-  return `${proto}://${host}`;
-}
-
 export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): void {
+  // SEC-F02: refuse to register the OAuth surface without a trusted public URL.
+  // The metadata endpoints would otherwise advertise an attacker-controllable
+  // issuer derived from request headers.
+  if (!options.publicUrl || !/^https?:\/\//.test(options.publicUrl)) {
+    throw new Error(
+      'OAuth proxy requires --public-url to be a non-empty absolute URL (e.g. https://mcp.example.com). ' +
+        'The metadata endpoints advertise this as the OAuth issuer and cannot fall back to request headers.'
+    );
+  }
+  const issuer = stripTrailingSlash(options.publicUrl);
   const authority = `https://login.microsoftonline.com/${options.tenantId}`;
   const fallbackScope =
     options.scopes.length > 0
       ? options.scopes.join(' ')
       : `openid profile email offline_access api://${options.clientId}/access_as_user`;
 
-  app.get('/.well-known/oauth-authorization-server', (req: Request, res: Response) => {
-    const issuer = resolveIssuer(req, options.publicUrl);
+  app.get('/.well-known/oauth-authorization-server', (_req: Request, res: Response) => {
     res.json({
       issuer,
       authorization_endpoint: `${issuer}/authorize`,
@@ -80,8 +87,7 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     });
   });
 
-  app.get('/.well-known/oauth-protected-resource', (req: Request, res: Response) => {
-    const issuer = resolveIssuer(req, options.publicUrl);
+  app.get('/.well-known/oauth-protected-resource', (_req: Request, res: Response) => {
     res.json({
       resource: `${issuer}/mcp`,
       authorization_servers: [issuer],

--- a/src/server.ts
+++ b/src/server.ts
@@ -89,6 +89,19 @@ class AdminGraphServer {
         );
       }
 
+      // SEC-F02: refuse to start if OAuth mode is enabled without a trusted public URL.
+      // The metadata endpoints advertise this as the OAuth issuer; falling back to
+      // request headers would let a client forge the advertised issuer via Host.
+      if (this.options.oauthMode) {
+        const url = this.options.publicUrl;
+        if (!url || !/^https?:\/\//.test(url)) {
+          throw new Error(
+            'OAuth mode requires --public-url to be a non-empty absolute URL (e.g. https://mcp.example.com). ' +
+              'The OAuth metadata endpoints advertise this URL as the issuer.'
+          );
+        }
+      }
+
       // SEC-F03: default to requiring `access_as_user` in scp. An empty string disables the check.
       const requiredScopes =
         this.options.requiredUserScopes === undefined


### PR DESCRIPTION
## Summary

Sprint 2 of the security review register in `docs/SECURITY_REVIEW_2026-04-20.md`. Closes two findings and partially mitigates a third, all in the OAuth HTTP surface.

- **SEC-F02 (High — closed)** — The OAuth issuer is no longer derived from request headers. `--public-url` is strictly required when `--oauth-mode` is enabled, validated both at server startup and at OAuth-route registration. `resolveIssuer` and `resourceMetadataUrl` fallbacks removed.
- **SEC-F06 (Medium — closed)** — Rate limiters mounted on `/authorize` (30/min/IP), `/token` and `/register` (10/min/IP). Previously only `/mcp` had one, leaving the OAuth surface trivially brute-forceable.
- **SEC-F04 (High — partially mitigated)** — The `/token` rate limit from SEC-F06 bounds brute-force against stolen refresh tokens. The architectural residual (one stolen refresh token is still redeemable with nothing but the public URL) is tracked as SEC-F04b for a proof-of-possession follow-up.

## Breaking changes

`--public-url` is now strictly required with `--oauth-mode`. See `CHANGELOG.md [Unreleased]`. Prior deployments that ran OAuth mode without it (or relied on header-derived issuer) must add a trusted `https://...` value.

## Test plan

- [x] `npm run lint` — pass (only pre-existing logger.ts warning).
- [x] `npm run format:check` — clean.
- [x] `npm run build` — clean.
- [x] Local unit tests green (16/16 on `authorizeUserClaims`).
- [ ] Full CI `verify` pipeline across Node 18/20/22.

## Traceability

See `docs/SECURITY_REVIEW_2026-04-20.md` for the updated register. After this merge:

- **Closed:** SEC-F01, SEC-F02, SEC-F03, SEC-F06.
- **Partial:** SEC-F04.
- **Open:** SEC-F05, SEC-F07, SEC-F08, SEC-F04b, SEC-F09, SEC-F10, SEC-F11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)