### PR TITLE
fix(security): sprint 3 — SEC-F05 single-replica, SEC-F07 log scrub, SEC-F08 JWKS SWR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,18 @@ Tool counts in parentheses indicate the cumulative total after the change.
 - **SEC-F02 (breaking)** — `--public-url` is now mandatory when `--oauth-mode` is enabled, validated at startup and again at OAuth-route registration. The header-derived fallback (X-Forwarded-Proto / Host) in `resolveIssuer` and `resourceMetadataUrl` has been removed; the advertised OAuth issuer is deterministic and immune to metadata poisoning via request headers.
 - **SEC-F03** — User tokens must now contain every scope listed in `--required-user-scopes` (default `access_as_user`) in their `scp` claim. Pass `--required-user-scopes ""` to restore the previous no-scope-check behaviour.
 - **SEC-F04 (partial)** — `/token` is now rate-limited at 10 req/min per IP, bounding brute-force throughput against stolen refresh tokens. The architectural residual (single stolen refresh token is still redeemable) is tracked as SEC-F04b for a proof-of-possession follow-up.
+- **SEC-F05 (mitigated)** — [infra/main.bicep](infra/main.bicep) now defaults `maxReplicas = 1` because the PKCE bridge is in-memory per process. Operators scaling beyond one replica must explicitly override the parameter — and should first externalise the bridge. Architectural externalisation tracked as a follow-up under the same SEC-F05 ID.
 - **SEC-F06** — OAuth routes (`/authorize`, `/token`, `/register`) now have dedicated rate limiters: 30 req/min on `/authorize`, 10 req/min on `/token` and `/register`. Previously only `/mcp` was rate-limited.
-- Extracted the post-verification authorization logic into `authorizeUserClaims` and added 16 unit tests covering tenant, audience, oid allowlist, and scope enforcement paths.
+- **SEC-F07** — `/token` upstream error logging extracted into `src/upstream-error.ts`. Only the RFC 6749 fields `error`, `error_description` (clipped, whitespace-normalised), and the Microsoft `error_codes` numeric array (first 5) are logged; non-JSON bodies log `<unparseable N bytes>` and JSON without recognised fields logs a sentinel. Raw correlation IDs and trace fragments no longer leak into logs.
+- **SEC-F08** — Token validators now serve the stale cached JWKS key on fetch failure instead of failing outright. In-library cache TTL bumped from 10 minutes to 24 hours; a new pure module `src/jwks-stale-cache.ts` keeps a per-tenant `Map<kid, PEM>` of previously-fetched keys and falls back to it only when Entra is unreachable. Unknown `kid`s still fail closed.
+- Extracted the post-verification authorization logic into `authorizeUserClaims` and added 28 unit tests across `authorizeUserClaims`, `withStaleKeyFallback`, and `summarizeUpstreamError`.
 
 ### Migration
 
 - Deployments relying on the implicit "any authenticated user" behaviour must add `--allow-any-tenant-user` to their startup command (and review whether that is actually intended).
 - Deployments running `--oauth-mode` without `--public-url` must add `--public-url https://<fqdn>`. This was already documented as "required when behind a reverse proxy"; it is now strictly required.
 - Deployments whose Entra app registration does not expose the `access_as_user` scope — or whose callers request a different scope — must pass `--required-user-scopes <their-scopes>` or `--required-user-scopes ""`.
+- Bicep deployments that previously relied on `maxReplicas = 3` default now scale to a single replica by default. Multi-replica deployments must explicitly set `maxReplicas` and should externalise the PKCE bridge first (follow-up work tracked under SEC-F05).
 
 ## [0.2.4] — 2026-04-20
 

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -157,6 +157,11 @@ The server does not terminate TLS or add caller allowlisting beyond JWT. You mus
 2. **Restrict network exposure** — bind the server to loopback or a private network, front it with the proxy.
 3. **Forward `X-Forwarded-For`** so rate limits attribute correctly.
 4. **Monitor logs** — all auth failures are logged at `warn`/`error` levels.
+5. **Keep OAuth mode on a single replica (SEC-F05)** — the PKCE bridge between `/authorize` and `/token` lives in process memory. The shipped Bicep template defaults `maxReplicas = 1`; if you scale up, externalise the bridge first (Redis / Azure Table) or the OAuth flow will fail intermittently.
+
+### JWKS resilience (SEC-F08)
+
+The server caches Entra signing keys for 24 hours and keeps a per-tenant stale-key map. If Microsoft's JWKS endpoint is temporarily unreachable, previously-validated `kid`s continue to verify tokens (with a `warn`-level log entry) instead of the server returning `403` on every request. Unknown `kid`s still fail closed.
 
 ## Docker
 

--- a/docs/SECURITY_REVIEW_2026-04-20.md
+++ b/docs/SECURITY_REVIEW_2026-04-20.md
@@ -76,11 +76,12 @@ Severity rubric mirrors [RISK_MODEL.md](RISK_MODEL.md) but is calibrated to secu
 ### SEC-F05 — PKCE bridge is in-memory per process
 
 - **Severity:** Medium
-- **Status:** Open
-- **Location:** [src/oauth-proxy.ts:22](../src/oauth-proxy.ts).
-- **Description:** A process-local `Map<string, PkceEntry>` holds the server-side PKCE verifier between `/authorize` and `/token`. In a multi-replica deployment, the two requests may land on different instances and the bridge lookup fails. Operators may be tempted to work around this with sticky sessions or by weakening the bridge.
+- **Status:** Mitigated — sprint 3 (infra + documentation). Architectural externalisation tracked.
+- **Location:** [src/oauth-proxy.ts](../src/oauth-proxy.ts).
+- **Description:** A process-local `Map<string, PkceEntry>` holds the server-side PKCE verifier between `/authorize` and `/token`. In a multi-replica deployment, the two requests may land on different instances and the bridge lookup fails.
 - **Attack scenario:** No direct exploit, but the availability failure creates pressure for ad-hoc fixes that degrade security (e.g. shortening `PKCE_TTL_MS`, removing PKCE, or relaxing the bridge lookup).
-- **Remediation (proposed):** Externalise the bridge (Redis, Azure Cosmos, Azure Table) with the same 10-minute TTL; or document and enforce `minReplicas = maxReplicas = 1` in the Container Apps deployment.
+- **Mitigation delivered (sprint 3):** [infra/main.bicep](../infra/main.bicep) now defaults `maxReplicas = 1` with an inline SEC-F05 note explaining why. Operators who scale past one replica must explicitly override the parameter — forcing them to acknowledge the broken flow before they break it. Documented in [HTTP_DEPLOYMENT.md](HTTP_DEPLOYMENT.md).
+- **Residual risk:** This is an availability/operational constraint, not a remediation. A horizontally-scalable deployment still requires externalising the bridge (Redis / Azure Cosmos / Azure Table with the same 10-minute TTL). Tracked as a follow-up under the same SEC-F05 ID; re-open on this document when the feature is scheduled.
 
 ### SEC-F06 — `/token` and `/authorize` have no rate limit
 
@@ -96,19 +97,20 @@ Severity rubric mirrors [RISK_MODEL.md](RISK_MODEL.md) but is calibrated to secu
 ### SEC-F07 — `/token` logs up to 500 chars of upstream error payload
 
 - **Severity:** Medium
-- **Status:** Open
-- **Location:** [src/oauth-proxy.ts:221-223](../src/oauth-proxy.ts).
-- **Description:** On upstream HTTP error, `logger.warn` receives `payload.slice(0, 500)`. Entra error bodies may contain correlation IDs, partial trace information, and occasionally snippets that help attackers diagnose flow-level issues.
-- **Remediation (proposed):** Parse as JSON and log only `error` + `error_description` fields; fall back to `<unparseable N bytes>` when the body is not JSON.
+- **Status:** Fixed — sprint 3
+- **Location:** [src/oauth-proxy.ts](../src/oauth-proxy.ts), [src/upstream-error.ts](../src/upstream-error.ts).
+- **Description:** On upstream HTTP error, the proxy used to log `payload.slice(0, 500)`. Entra error bodies contain `correlation_id`, `trace_id`, server-generated prose, and occasionally diagnostic hints that have no place in our logs.
+- **Remediation:** Extracted `summarizeUpstreamError` into a pure module and delegated logging to it. Only the RFC 6749 fields `error`, `error_description` (clipped to 200 chars, whitespace-collapsed), and the Microsoft `error_codes` numeric array (first 5) are emitted. Non-JSON payloads log `<unparseable N bytes>`; JSON without recognised fields logs `<no recognised oauth error fields>`. 7 unit tests in [test/upstream-error.test.ts](../test/upstream-error.test.ts) cover the extraction, clipping, whitespace normalisation, and both fallback paths.
 
 ### SEC-F08 — No stale-while-revalidate on JWKS cache
 
 - **Severity:** Medium
-- **Status:** Open
-- **Location:** [src/token-validator.ts:22-34](../src/token-validator.ts), [src/user-token-validator.ts:34-46](../src/user-token-validator.ts).
-- **Description:** `jwks-rsa` cache TTL is 10 minutes. If the Entra discovery endpoint is unreachable during a key rotation, token validation fails for up to 10 minutes with no fallback.
-- **Attack scenario:** Self-inflicted DoS during a genuine Entra incident or key rotation; no direct attacker-controlled exploit.
-- **Remediation (proposed):** Extend `cacheMaxAge`, add a background refresh, and serve-stale on fetch failure.
+- **Status:** Fixed — sprint 3
+- **Location:** [src/token-validator.ts](../src/token-validator.ts), [src/user-token-validator.ts](../src/user-token-validator.ts), [src/jwks-stale-cache.ts](../src/jwks-stale-cache.ts).
+- **Description:** `jwks-rsa` cache TTL was 10 minutes. A JWKS outage outlasting the cache window caused token validation to fail outright.
+- **Remediation:** Two layers:
+  - `cacheMaxAge` raised from 10 minutes to 24 hours on the in-library cache in both validators. Entra advertises new keys well before activation, so a longer TTL is safe.
+  - New pure module `jwks-stale-cache.ts` keeps a per-tenant `Map<kid, PEM>` of successfully-fetched keys. On a fetch failure, if a PEM for the same `kid` is cached, the wrapper serves it with a warning log. Truly unknown keys still fail closed (rethrow). This survives multi-hour JWKS outages without broadening trust — stale keys were already trusted when first fetched, and signatures remain valid until the key itself is rotated out. 5 unit tests in [test/jwks-stale-cache.test.ts](../test/jwks-stale-cache.test.ts) cover cache population, stale fallback, rethrow on unknown kid, and overwrite on refresh.
 
 ### SEC-F09 — Dynamic Client Registration is decorative
 
@@ -151,12 +153,13 @@ No remediation required — recorded so future reviews do not re-litigate alread
 
 ## Remediation order (recommendation)
 
-| Wave          | Findings                                                                       | Rationale                                                      |
-| ------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------- |
-| 1 — PR #44    | SEC-F01 (fixed), SEC-F03 (fixed)                                               | Critical + High exploitable at the current deployment state.   |
-| 2 — PR #45    | SEC-F02 (fixed), SEC-F06 (fixed), SEC-F04 (partial: rate-limited + documented) | Harden the public OAuth proxy surface before broader exposure. |
-| 3 — hardening | SEC-F05, SEC-F07, SEC-F08, SEC-F04b (architectural refresh-token PoP)          | Multi-replica readiness, log hygiene, availability robustness. |
-| Backlog       | SEC-F09, SEC-F10, SEC-F11                                                      | Documentation / cosmetic; no realistic exploit path.           |
+| Wave       | Findings                                                                               | Rationale                                                                                                |
+| ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 1 — PR #44 | SEC-F01 (fixed), SEC-F03 (fixed)                                                       | Critical + High exploitable at the current deployment state.                                             |
+| 2 — PR #46 | SEC-F02 (fixed), SEC-F06 (fixed), SEC-F04 (partial: rate-limited + documented)         | Harden the public OAuth proxy surface before broader exposure.                                           |
+| 3 — PR #47 | SEC-F07 (fixed), SEC-F08 (fixed), SEC-F05 (mitigated via single-replica Bicep default) | Log hygiene, availability robustness, multi-replica guardrail.                                           |
+| Follow-ups | SEC-F04b (refresh-token PoP), SEC-F05 architectural (externalise PKCE bridge)          | Architectural work — larger PRs with new runtime dependencies. Track separately when scheduling arrives. |
+| Backlog    | SEC-F09, SEC-F10, SEC-F11                                                              | Documentation / cosmetic; no realistic exploit path.                                                     |
 
 ---
 
@@ -164,7 +167,7 @@ No remediation required — recorded so future reviews do not re-litigate alread
 
 The broader audit plan identified six priority areas. Status after this cycle:
 
-- **P1 — Auth / OAuth HTTP mode** — majority remediated. Closed: SEC-F01, SEC-F02, SEC-F03, SEC-F06. Partially mitigated: SEC-F04 (rate-limited + documented; architectural PoP fix tracked as SEC-F04b). Open: SEC-F05, SEC-F07, SEC-F08, SEC-F09, SEC-F10, SEC-F11.
+- **P1 — Auth / OAuth HTTP mode** — substantially remediated. Closed: SEC-F01, SEC-F02, SEC-F03, SEC-F06, SEC-F07, SEC-F08. Partially mitigated: SEC-F04 (rate-limited; architectural PoP fix as SEC-F04b) and SEC-F05 (single-replica default; architectural externalisation still open). Open-backlog: SEC-F09, SEC-F10, SEC-F11.
 - **P2 — Tool invocation gating** — not yet reviewed. Verify `--allow-writes` enforcement at dispatch, audit risk-level labels, assess prompt-injection via Graph response content.
 - **P3 — Secret & token hygiene** — pass-level check done (no logging observed); formal pass pending.
 - **P4 — Transport & deploy hardening** — CORS, HSTS, trust-proxy depth, rate-limit breadth.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -31,9 +31,9 @@ param logRetentionDays int = 30
 @minValue(0)
 param minReplicas int = 0
 
-@description('Container App max replicas')
+@description('Container App max replicas. SEC-F05: default is 1 because the OAuth proxy\'s PKCE bridge is in-memory per process — scaling beyond one replica silently breaks the /authorize → /token flow. Override only after externalising the bridge (Redis / Azure Table).')
 @minValue(1)
-param maxReplicas int = 3
+param maxReplicas int = 1
 
 @description('Tags applied to every resource (must satisfy org tag policies)')
 param tags object = {}

--- a/src/jwks-stale-cache.ts
+++ b/src/jwks-stale-cache.ts
@@ -1,0 +1,35 @@
+import logger from './logger.js';
+
+/**
+ * SEC-F08: stale-while-revalidate wrapper around JWKS key retrieval.
+ *
+ * On a successful fetch, the PEM is stored under its `kid`. On a failed fetch,
+ * if we have previously cached a key for the same `kid`, we return it and log
+ * a warning instead of failing token validation outright. This survives brief
+ * Entra JWKS outages without opening any new attack surface — the stale key
+ * was already trusted, its signatures are still valid, and only its freshness
+ * is at issue. Truly rotated keys fail at the fetch AND have no stale entry,
+ * so validation fails closed.
+ *
+ * Exposed as a pure function for unit testing. Each validator keeps its own
+ * cache `Map` so eviction policies can differ per caller if needed.
+ */
+export async function withStaleKeyFallback(
+  kid: string | undefined,
+  fetchKey: () => Promise<string>,
+  staleCache: Map<string, string>
+): Promise<string> {
+  try {
+    const key = await fetchKey();
+    if (kid) staleCache.set(kid, key);
+    return key;
+  } catch (err) {
+    if (kid && staleCache.has(kid)) {
+      logger.warn(
+        `JWKS fetch failed for kid=${kid}; serving stale cached key (${(err as Error).message})`
+      );
+      return staleCache.get(kid) as string;
+    }
+    throw err;
+  }
+}

--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import type { Express, Request, Response } from 'express';
 import logger from './logger.js';
+import { summarizeUpstreamError } from './upstream-error.js';
 
 export interface OAuthProxyOptions {
   // SEC-F02: must be a non-empty absolute URL. The proxy advertises this as the
@@ -224,8 +225,9 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       });
       const payload = await upstream.text();
       if (upstream.status >= 400) {
+        // SEC-F07: scrub upstream error — log only parsed OAuth-standard fields.
         logger.warn(
-          `Entra /token returned ${upstream.status} for grant_type=${grantType}: ${payload.slice(0, 500)}`
+          `Entra /token returned ${upstream.status} for grant_type=${grantType}: ${summarizeUpstreamError(payload)}`
         );
       } else {
         logger.info(`Entra /token exchange ok (grant_type=${grantType})`);

--- a/src/token-validator.ts
+++ b/src/token-validator.ts
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
 import logger from './logger.js';
+import { withStaleKeyFallback } from './jwks-stale-cache.js';
 
 export interface TokenValidatorOptions {
   tenantId: string;
@@ -18,6 +19,8 @@ interface EntraTokenPayload {
 }
 
 const jwksClients = new Map<string, jwksRsa.JwksClient>();
+// SEC-F08: per-tenant stale-while-revalidate cache of PEM public keys.
+const staleKeyCaches = new Map<string, Map<string, string>>();
 
 function getJwksClient(tenantId: string): jwksRsa.JwksClient {
   let client = jwksClients.get(tenantId);
@@ -25,7 +28,10 @@ function getJwksClient(tenantId: string): jwksRsa.JwksClient {
     client = jwksRsa({
       jwksUri: `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`,
       cache: true,
-      cacheMaxAge: 600_000,
+      // SEC-F08: 24h in-library cache; the stale-key fallback below catches
+      // outages that outlast it. Entra only activates newly-published keys
+      // after advertising them well in advance, so a longer TTL is safe.
+      cacheMaxAge: 24 * 60 * 60 * 1000,
       rateLimit: true,
     });
     jwksClients.set(tenantId, client);
@@ -33,13 +39,18 @@ function getJwksClient(tenantId: string): jwksRsa.JwksClient {
   return client;
 }
 
-function getSigningKey(client: jwksRsa.JwksClient, header: jwt.JwtHeader): Promise<string> {
+function getStaleKeyCache(tenantId: string): Map<string, string> {
+  let cache = staleKeyCaches.get(tenantId);
+  if (!cache) {
+    cache = new Map<string, string>();
+    staleKeyCaches.set(tenantId, cache);
+  }
+  return cache;
+}
+
+function fetchSigningKey(client: jwksRsa.JwksClient, kid: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    if (!header.kid) {
-      reject(new Error('JWT header missing kid'));
-      return;
-    }
-    client.getSigningKey(header.kid, (err, key) => {
+    client.getSigningKey(kid, (err, key) => {
       if (err) {
         reject(err);
         return;
@@ -51,6 +62,16 @@ function getSigningKey(client: jwksRsa.JwksClient, header: jwt.JwtHeader): Promi
       resolve(key.getPublicKey());
     });
   });
+}
+
+function getSigningKey(
+  tenantId: string,
+  client: jwksRsa.JwksClient,
+  header: jwt.JwtHeader
+): Promise<string> {
+  if (!header.kid) return Promise.reject(new Error('JWT header missing kid'));
+  const kid = header.kid;
+  return withStaleKeyFallback(kid, () => fetchSigningKey(client, kid), getStaleKeyCache(tenantId));
 }
 
 export async function validateEntraToken(
@@ -66,7 +87,7 @@ export async function validateEntraToken(
       return false;
     }
 
-    const publicKey = await getSigningKey(client, decoded.header);
+    const publicKey = await getSigningKey(options.tenantId, client, decoded.header);
 
     const payload = jwt.verify(token, publicKey, {
       algorithms: ['RS256'],

--- a/src/upstream-error.ts
+++ b/src/upstream-error.ts
@@ -1,0 +1,34 @@
+/**
+ * SEC-F07: extract only the OAuth-standard safe fields from an upstream error
+ * body. Logging the raw payload would echo correlation IDs, trace fragments,
+ * or unexpected server-generated content that has no place in our logs.
+ *
+ * Pure function so it can be unit-tested without pulling the Express / OAuth
+ * proxy module. Kept deliberately small: `error`, `error_description`, and
+ * `error_codes` are the only fields defined by RFC 6749 §5.2 plus the Microsoft
+ * `error_codes` extension that help operators debug legitimate issues.
+ */
+export function summarizeUpstreamError(body: string): string {
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: unknown;
+      error_description?: unknown;
+      error_codes?: unknown;
+    };
+    const parts: string[] = [];
+    if (typeof parsed.error === 'string') parts.push(`error=${parsed.error}`);
+    if (typeof parsed.error_description === 'string') {
+      // Trim whitespace and clip — error_description can be a short sentence
+      // but should never be an essay in our logs.
+      const clipped = parsed.error_description.replace(/\s+/g, ' ').slice(0, 200);
+      parts.push(`error_description="${clipped}"`);
+    }
+    if (Array.isArray(parsed.error_codes)) {
+      const codes = parsed.error_codes.filter((c) => typeof c === 'number').slice(0, 5);
+      if (codes.length > 0) parts.push(`error_codes=[${codes.join(',')}]`);
+    }
+    return parts.length > 0 ? parts.join(' ') : '<no recognised oauth error fields>';
+  } catch {
+    return `<unparseable ${body.length} bytes>`;
+  }
+}

--- a/src/user-token-validator.ts
+++ b/src/user-token-validator.ts
@@ -1,6 +1,7 @@
 import jwt from 'jsonwebtoken';
 import jwksRsa from 'jwks-rsa';
 import logger from './logger.js';
+import { withStaleKeyFallback } from './jwks-stale-cache.js';
 import {
   authorizeUserClaims,
   type UserTokenClaims,
@@ -16,6 +17,8 @@ export type {
 } from './user-token-authorization.js';
 
 const jwksClients = new Map<string, jwksRsa.JwksClient>();
+// SEC-F08: per-tenant stale-while-revalidate cache of PEM public keys.
+const staleKeyCaches = new Map<string, Map<string, string>>();
 
 function getJwksClient(tenantId: string): jwksRsa.JwksClient {
   let client = jwksClients.get(tenantId);
@@ -23,7 +26,8 @@ function getJwksClient(tenantId: string): jwksRsa.JwksClient {
     client = jwksRsa({
       jwksUri: `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`,
       cache: true,
-      cacheMaxAge: 600_000,
+      // SEC-F08: 24h in-library cache; stale-key fallback catches longer outages.
+      cacheMaxAge: 24 * 60 * 60 * 1000,
       rateLimit: true,
     });
     jwksClients.set(tenantId, client);
@@ -31,18 +35,33 @@ function getJwksClient(tenantId: string): jwksRsa.JwksClient {
   return client;
 }
 
-function getSigningKey(client: jwksRsa.JwksClient, header: jwt.JwtHeader): Promise<string> {
+function getStaleKeyCache(tenantId: string): Map<string, string> {
+  let cache = staleKeyCaches.get(tenantId);
+  if (!cache) {
+    cache = new Map<string, string>();
+    staleKeyCaches.set(tenantId, cache);
+  }
+  return cache;
+}
+
+function fetchSigningKey(client: jwksRsa.JwksClient, kid: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    if (!header.kid) {
-      reject(new Error('JWT header missing kid'));
-      return;
-    }
-    client.getSigningKey(header.kid, (err, key) => {
+    client.getSigningKey(kid, (err, key) => {
       if (err) return reject(err);
       if (!key) return reject(new Error('No signing key found'));
       resolve(key.getPublicKey());
     });
   });
+}
+
+function getSigningKey(
+  tenantId: string,
+  client: jwksRsa.JwksClient,
+  header: jwt.JwtHeader
+): Promise<string> {
+  if (!header.kid) return Promise.reject(new Error('JWT header missing kid'));
+  const kid = header.kid;
+  return withStaleKeyFallback(kid, () => fetchSigningKey(client, kid), getStaleKeyCache(tenantId));
 }
 
 export async function validateUserToken(
@@ -58,7 +77,7 @@ export async function validateUserToken(
       return null;
     }
 
-    const publicKey = await getSigningKey(client, decoded.header);
+    const publicKey = await getSigningKey(options.tenantId, client, decoded.header);
 
     const payload = jwt.verify(token, publicKey, {
       algorithms: ['RS256'],

--- a/test/jwks-stale-cache.test.ts
+++ b/test/jwks-stale-cache.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { withStaleKeyFallback } from '../src/jwks-stale-cache.js';
+
+describe('withStaleKeyFallback', () => {
+  it('stores the key under kid on success and returns it', async () => {
+    const cache = new Map<string, string>();
+    const key = await withStaleKeyFallback('kid-1', async () => 'PEM-FRESH', cache);
+    expect(key).toBe('PEM-FRESH');
+    expect(cache.get('kid-1')).toBe('PEM-FRESH');
+  });
+
+  it('serves the stale cached key when the fetch fails', async () => {
+    const cache = new Map<string, string>([['kid-1', 'PEM-STALE']]);
+    const key = await withStaleKeyFallback(
+      'kid-1',
+      async () => {
+        throw new Error('JWKS endpoint unreachable');
+      },
+      cache
+    );
+    expect(key).toBe('PEM-STALE');
+  });
+
+  it('rethrows when the fetch fails and no stale entry is cached for the kid', async () => {
+    const cache = new Map<string, string>();
+    await expect(
+      withStaleKeyFallback(
+        'kid-unknown',
+        async () => {
+          throw new Error('JWKS endpoint unreachable');
+        },
+        cache
+      )
+    ).rejects.toThrow('JWKS endpoint unreachable');
+  });
+
+  it('rethrows when kid is undefined even if the cache has entries', async () => {
+    const cache = new Map<string, string>([['kid-1', 'PEM-STALE']]);
+    await expect(
+      withStaleKeyFallback(
+        undefined,
+        async () => {
+          throw new Error('JWKS endpoint unreachable');
+        },
+        cache
+      )
+    ).rejects.toThrow('JWKS endpoint unreachable');
+  });
+
+  it('overwrites stale cache when a newer successful fetch returns a different PEM', async () => {
+    const cache = new Map<string, string>([['kid-1', 'PEM-OLD']]);
+    const key = await withStaleKeyFallback('kid-1', async () => 'PEM-NEW', cache);
+    expect(key).toBe('PEM-NEW');
+    expect(cache.get('kid-1')).toBe('PEM-NEW');
+  });
+});

--- a/test/upstream-error.test.ts
+++ b/test/upstream-error.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeUpstreamError } from '../src/upstream-error.js';
+
+describe('summarizeUpstreamError', () => {
+  it('extracts error and error_description from a well-formed OAuth error JSON', () => {
+    const body = JSON.stringify({
+      error: 'invalid_grant',
+      error_description: 'AADSTS70008: The provided authorization code has expired.',
+      correlation_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+      trace_id: '11111111-2222-3333-4444-555555555555',
+    });
+    const out = summarizeUpstreamError(body);
+    expect(out).toContain('error=invalid_grant');
+    expect(out).toContain('error_description="AADSTS70008');
+    expect(out).not.toContain('correlation_id');
+    expect(out).not.toContain('trace_id');
+  });
+
+  it('includes up to five numeric error_codes', () => {
+    const body = JSON.stringify({
+      error: 'invalid_request',
+      error_codes: [70008, 70011, 'not-a-number', 90014, 70044, 12345, 67890],
+    });
+    const out = summarizeUpstreamError(body);
+    expect(out).toContain('error_codes=[70008,70011,90014,70044,12345]');
+  });
+
+  it('clips a long error_description to 200 characters and collapses whitespace', () => {
+    const longDescription = 'A'.repeat(250);
+    const body = JSON.stringify({ error: 'invalid_grant', error_description: longDescription });
+    const out = summarizeUpstreamError(body);
+    const match = out.match(/error_description="([^"]+)"/);
+    expect(match).not.toBeNull();
+    expect(match![1].length).toBe(200);
+  });
+
+  it('collapses embedded newlines and tabs in error_description', () => {
+    const body = JSON.stringify({
+      error: 'invalid_grant',
+      error_description: 'line one\n\tline two\r\n  line three',
+    });
+    const out = summarizeUpstreamError(body);
+    expect(out).toContain('error_description="line one line two line three"');
+  });
+
+  it('returns an unparseable marker with byte length for non-JSON bodies', () => {
+    const out = summarizeUpstreamError('<html><body>502 Bad Gateway</body></html>');
+    expect(out).toMatch(/^<unparseable \d+ bytes>$/);
+  });
+
+  it('returns a sentinel when the JSON parses but has no recognised fields', () => {
+    const out = summarizeUpstreamError(JSON.stringify({ something_else: 'value' }));
+    expect(out).toBe('<no recognised oauth error fields>');
+  });
+
+  it('ignores non-string error and error_description values', () => {
+    const out = summarizeUpstreamError(
+      JSON.stringify({ error: { nested: 'object' }, error_description: 42 })
+    );
+    expect(out).toBe('<no recognised oauth error fields>');
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 3 of the security review register in `docs/SECURITY_REVIEW_2026-04-20.md`. Closes two medium findings outright and mitigates a third at the infra layer.

- **SEC-F07 (Medium — closed)** — `/token` upstream error logs extracted into `src/upstream-error.ts` and restricted to OAuth-standard fields only (`error`, `error_description` clipped to 200 chars, `error_codes` first 5 numeric). Non-JSON and no-recognised-field bodies fall back to sentinels. No more raw `correlation_id` or trace leakage.
- **SEC-F08 (Medium — closed)** — JWKS cache TTL bumped from 10 minutes to 24 hours, and a new pure module `src/jwks-stale-cache.ts` implements stale-while-revalidate per-tenant. A brief Entra outage no longer cascades into blanket 403s; unknown `kid`s still fail closed. Both validators use the wrapper.
- **SEC-F05 (Medium — mitigated)** — `infra/main.bicep` now defaults `maxReplicas = 1` with an inline note pointing at the finding. Operators must consciously override to scale up — and should externalise the PKCE bridge first. The architectural externalisation (Redis / Azure Table) is tracked as a follow-up under the same SEC-F05 ID.

## Tests

12 new unit tests in `test/jwks-stale-cache.test.ts` (5) and `test/upstream-error.test.ts` (7). Total suite after this PR: 28 unit tests across 3 pure modules (`authorizeUserClaims`, `withStaleKeyFallback`, `summarizeUpstreamError`).

## Breaking changes

Bicep deployments that relied on the `maxReplicas = 3` default now scale to a single replica. Multi-replica deployments must set the parameter explicitly (and really should externalise the PKCE bridge first). Documented in `CHANGELOG.md [Unreleased]`.

## Traceability

After this merge the P1 register stands at:

- **Closed:** SEC-F01, SEC-F02, SEC-F03, SEC-F06, SEC-F07, SEC-F08.
- **Partial:** SEC-F04 (rate-limited; architectural PoP tracked as SEC-F04b), SEC-F05 (single-replica default; architectural externalisation tracked separately).
- **Backlog:** SEC-F09, SEC-F10, SEC-F11 (cosmetic / documentation).

## Test plan

- [x] `npm run lint` — clean (only pre-existing logger.ts warning).
- [x] `npm run format:check` — clean.
- [x] `npm run build` — clean.
- [x] Local `npm test` — 28/28 unit tests pass.
- [ ] Full CI `verify` pipeline across Node 18/20/22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)