### PR TITLE
fix(security): sprint 6 — SEC-F04b confidential-client DCR + SEC-F05 Azure Table (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-04-20
+
+Closes the two architectural follow-ups left open by v0.3.0 (SEC-F04b refresh-token proof-of-possession, SEC-F05 PKCE bridge externalisation) by moving OAuth state to Azure Table Storage and turning the MCP DCR layer into a confidential-client issuer. A stolen refresh token is no longer redeemable without the per-client secret issued at `/register`, and the proxy can now run multi-replica.
+
+### Breaking changes
+
+Deployments running HTTP / OAuth mode will need configuration updates — see [Migration](#migration-040) below.
+
+- **MCP clients must re-run Dynamic Client Registration.** Every `/register` call now returns a `client_secret`, and `/token` rejects any call (both `authorization_code` and `refresh_token` grants) missing valid `client_id` + `client_secret`. Existing clients that cached a `client_id` with `token_endpoint_auth_method: none` will get `invalid_client` on the next refresh — they must re-register. The MCP SDK handles this transparently at reconnect.
+- **`--oauth-mode` now requires DCR** and refuses to start with `--no-dynamic-registration`. DCR is the issuance point for per-client credentials; disabling it defeats SEC-F04b.
+- **`--oauth-mode` requires Azure Table Storage** in production (single-replica in-memory fallback still works for local dev/tests). Configure via env: `AZURE_STORAGE_ACCOUNT_NAME` (managed identity, recommended) or `AZURE_STORAGE_CONNECTION_STRING` (Azurite / dev).
+- **Bicep `maxReplicas` default restored to 3** (SEC-F05 resolved). Storage Account + `oauthstate` table provisioned automatically, with `Storage Table Data Contributor` role granted to the UAMI.
+
+### Security — OAuth / token validation (P1 architectural)
+
+- **SEC-F04b** — `/token` now enforces per-client authentication on every grant (both `authorization_code` and `refresh_token`) using `client_secret_post` or `client_secret_basic`. `/register` issues a random 256-bit `client_secret` (stored as SHA-256 hash, compared via `crypto.timingSafeEqual`). `/authorize` rejects unknown `client_id`s and binds the PKCE entry to the `client_id`; `/token authorization_code` verifies the bound `client_id` matches the caller, preventing cross-client code redemption.
+- **SEC-F05 (resolved)** — PKCE bridge + DCR client credentials are persisted in Azure Table Storage (`oauthstate` table, two partitions: `pkce`, `dcr`). Atomic consume via optimistic ETag delete. Managed-identity-only access (`allowSharedKeyAccess: false`).
+
+### Added
+
+- `src/storage/` — new `OAuthStorage` abstraction with `MemoryStorage` (tests/dev) and `TableStorage` (prod) implementations. Resolved by env at startup via `createOAuthStorage()`.
+- 18 new unit tests covering storage behaviour, DCR secret issuance, `/authorize` client validation, `/token` client authentication (body + Basic auth), and cross-client PKCE rejection. Total: 72 tests (up from 54).
+- `@azure/data-tables` ^13.3.2 as optional dependency. `@azure/identity` was already optional.
+- Bicep: Storage Account (Standard_LRS, TLS 1.2, `allowSharedKeyAccess: false`, `defaultToOAuthAuthentication: true`), default table `oauthstate`, `Storage Table Data Contributor` role assignment to UAMI, `AZURE_STORAGE_ACCOUNT_NAME` / `AZURE_STORAGE_TABLE_NAME` env vars injected into the Container App.
+
+### Migration {#migration-040}
+
+- **Existing deployments**: run `az deployment group create` with the updated Bicep to provision the Storage Account + Table + role assignment. No data migration needed — PKCE entries are short-lived (10 min) and DCR re-registration is automatic.
+- **MCP clients**: at next reconnect, the SDK will re-run DCR and receive a `client_secret`. Users may need to re-authorise once.
+- **Local dev / tests**: works out of the box with `MemoryStorage` when neither `AZURE_STORAGE_ACCOUNT_NAME` nor `AZURE_STORAGE_CONNECTION_STRING` is set. For Azurite: set `AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;...;UseDevelopmentStorage=true`.
+- Deployments that explicitly set `--no-dynamic-registration` must remove that flag (or disable `--oauth-mode`).
+
 ## [0.3.0] — 2026-04-20
 
 Substantial security hardening after a two-priority review (P1 OAuth / P2 tool gating) — see [docs/SECURITY_REVIEW_2026-04-20.md](docs/SECURITY_REVIEW_2026-04-20.md) for the full findings register. Nine findings closed across five sprints, two partially mitigated with architectural follow-ups tracked. No critical, high, or medium vulnerabilities remain open across the reviewed surface.

--- a/docs/HTTP_DEPLOYMENT.md
+++ b/docs/HTTP_DEPLOYMENT.md
@@ -60,7 +60,7 @@ When `--oauth-mode` is enabled, the following are added:
 
 - `GET /.well-known/oauth-authorization-server` — AS metadata advertising this server as an OAuth 2.0 authorization server (proxying Entra).
 - `GET /.well-known/oauth-protected-resource` — RS metadata for MCP spec compliance.
-- `POST /register` — Dynamic Client Registration (stub; returns a synthesized `client_id` — all OAuth traffic actually flows through the server's single Entra app).
+- `POST /register` — Dynamic Client Registration. Returns a `client_id` + `client_secret` per MCP client; the plaintext secret is shown once and stored as a SHA-256 hash in the `oauthstate` table. Every `/token` call must authenticate with these credentials (SEC-F04b). All OAuth traffic flows through the server's single Entra app for upstream authentication.
 - `GET /authorize` — 302-redirects to Entra `/oauth2/v2.0/authorize` using a server-side PKCE verifier that bridges to the client's code_challenge.
 - `POST /token` — exchanges authorization codes / refresh tokens against Entra, substituting the server's PKCE verifier.
 
@@ -157,7 +157,28 @@ The server does not terminate TLS or add caller allowlisting beyond JWT. You mus
 2. **Restrict network exposure** — bind the server to loopback or a private network, front it with the proxy.
 3. **Forward `X-Forwarded-For`** so rate limits attribute correctly.
 4. **Monitor logs** — all auth failures are logged at `warn`/`error` levels.
-5. **Keep OAuth mode on a single replica (SEC-F05)** — the PKCE bridge between `/authorize` and `/token` lives in process memory. The shipped Bicep template defaults `maxReplicas = 1`; if you scale up, externalise the bridge first (Redis / Azure Table) or the OAuth flow will fail intermittently.
+5. **Provision the OAuth state table** (SEC-F04b + SEC-F05) — OAuth mode persists the PKCE bridge and DCR client credentials in Azure Table Storage. The shipped Bicep template creates a Storage Account + `oauthstate` table and grants the UAMI `Storage Table Data Contributor`. If you run outside that template, set `AZURE_STORAGE_ACCOUNT_NAME` (managed identity, recommended) or `AZURE_STORAGE_CONNECTION_STRING` (Azurite / dev) and ensure the caller has table data-contributor rights. Without either env var, the server falls back to in-process memory — safe only for single-replica or stdio deployments.
+
+### OAuth state storage (SEC-F04b + SEC-F05)
+
+The OAuth proxy keeps two classes of short-lived state that are now externalised:
+
+- **PKCE bridge** — one row per active `/authorize` call, TTL 10 min, consumed atomically at `/token`.
+- **DCR client credentials** — one row per MCP client registration (`client_id` + SHA-256 hash of `client_secret` + redirect URIs). Long-lived; rotation is manual today.
+
+Storage Account provisioning in the shipped Bicep:
+
+| Property                       | Value                                                 |
+| ------------------------------ | ----------------------------------------------------- |
+| SKU                            | `Standard_LRS`                                        |
+| Kind                           | `StorageV2`                                           |
+| `allowSharedKeyAccess`         | `false` (managed-identity only)                       |
+| `minimumTlsVersion`            | `TLS1_2`                                              |
+| `defaultToOAuthAuthentication` | `true`                                                |
+| Table name                     | `oauthstate` (PartitionKeys: `pkce`, `dcr`)           |
+| RBAC                           | `Storage Table Data Contributor` → Container App UAMI |
+
+Cost: Table Storage at this volume is ~\$0.00/month (storage < 1 MB, transactions well under 10k/month).
 
 ### JWKS resilience (SEC-F08)
 

--- a/docs/SECURITY_REVIEW_2026-04-20.md
+++ b/docs/SECURITY_REVIEW_2026-04-20.md
@@ -3,7 +3,7 @@
 Internal security review covering the highest-value portions of the codebase. Finding IDs are stable (`SEC-Fxx` for Priority 1 / OAuth, `SEC-Gxx` for Priority 2 / tool invocation gating) so remediation PRs and future reviews can reference them cleanly.
 
 **Reviewer:** Marc Bourget (VP IT, LCI Education) with Claude Code assistance.
-**Commit reviewed:** P1 against `main` @ `418ee16`; P2 against `main` @ `e7617c4` (post-sprint-3).
+**Commit reviewed:** P1 against `main` @ `418ee16`; P2 against `main` @ `e7617c4` (post-sprint-3); P1 architectural follow-ups (SEC-F04b, SEC-F05) against `main` @ `879738a` (post-v0.3.0).
 **Scope delivered:**
 
 - **P1** — Auth / OAuth HTTP mode (`oauth-proxy.ts`, `token-validator.ts`, `user-token-validator.ts`, `http-server.ts`, `auth.ts`). SEC-Fxx findings.
@@ -68,23 +68,38 @@ Severity rubric mirrors [RISK_MODEL.md](RISK_MODEL.md) but is calibrated to secu
 ### SEC-F04 — `refresh_token` grant requires no MCP-client authentication
 
 - **Severity:** High
-- **Status:** Partially mitigated — sprint 2. Residual risk tracked.
+- **Status:** Fixed — sprint 6 (v0.4.0, see SEC-F04b below).
 - **Location:** [src/oauth-proxy.ts](../src/oauth-proxy.ts).
 - **Description:** `POST /token` with `grant_type=refresh_token` attaches the server's `client_secret` and forwards the refresh token to Entra. An attacker in possession of a refresh token only needs the public proxy URL to redeem it — the client_secret Entra would normally require is supplied by the proxy on behalf of the caller.
 - **Attack scenario:** Refresh-token exfiltration from an MCP client (local token store, logs, MITM) is directly usable via the proxy, without the additional factor of the client_secret.
-- **Mitigation delivered (sprint 2):** `/token` is now rate-limited at 10 req/min per IP (see SEC-F06), which bounds brute-force throughput and makes scripted abuse visible in logs. This does **not** close the underlying architectural gap — one stolen refresh token used once is still redeemable.
-- **Residual risk:** Stolen-refresh-token reuse remains possible until either (a) the proxy becomes a confidential client to MCP callers (per-client credentials, moving away from `token_endpoint_auth_methods: none`), or (b) the proxy requires a bound proof-of-possession on refresh (DPoP, mTLS, or a session-bound bearer). Both are architectural changes tracked separately as a future SEC-F04b.
-- **Operational compensations:** keep refresh-token lifetimes short in the Entra app registration (default 90 days is too long for an admin surface; consider dropping to 24h via Conditional Access sign-in frequency); monitor the `10 req/min` rate-limit hits on `/token` for anomalous clients.
+- **Mitigation delivered (sprint 2):** `/token` rate-limited at 10 req/min per IP (see SEC-F06) — compensating control, now superseded.
+- **Remediation delivered (sprint 6, v0.4.0):** See SEC-F04b.
+
+### SEC-F04b — Confidential-client enforcement on `/token`
+
+- **Severity:** High (architectural follow-up to SEC-F04)
+- **Status:** Fixed — sprint 6 (v0.4.0)
+- **Location:** [src/oauth-proxy.ts](../src/oauth-proxy.ts), [src/storage/](../src/storage/)
+- **Description:** SEC-F04's residual risk (stolen-refresh-token reuse) required either per-client credentials or a bound proof-of-possession. v0.4.0 ships the first path.
+- **Remediation:**
+  - `/register` now issues a random 256-bit `client_secret` alongside the `client_id`. The plaintext is returned once; the server stores only the SHA-256 hash. Advertised metadata: `token_endpoint_auth_methods_supported: ['client_secret_post', 'client_secret_basic']`.
+  - `/token` rejects both `authorization_code` and `refresh_token` grants with `401 invalid_client` when `client_id` + `client_secret` are missing or do not match the stored hash. Constant-time comparison via `crypto.timingSafeEqual`.
+  - `/authorize` rejects unknown `client_id`s and binds the PKCE entry to the caller's `client_id`. `/token authorization_code` then verifies the stored `client_id` matches the authenticated caller — a compromised client cannot redeem another client's auth code even in a PKCE-race window.
+  - `/register` is mandatory: the proxy refuses to start with `--oauth-mode --no-dynamic-registration`, since DCR is the issuance point for the per-client secret.
+- **Tests:** `test/oauth-proxy.test.ts` — `SEC-F04b /register`, `SEC-F04b /authorize`, `SEC-F04b /token` blocks (9 cases).
+- **Residual risk:** MCP clients that store their `client_secret` on disk remain vulnerable to local token-store theft — but an attacker must now exfiltrate both the refresh_token AND the secret, rather than just the refresh_token. For a fully PoP approach (DPoP), the MCP SDK upstream would need to implement it; out of scope for this cycle.
+- **Operational note:** Existing MCP clients that registered under the old `token_endpoint_auth_method: none` regime will re-DCR automatically on their next reconnect. Users may need to re-authorise once.
 
 ### SEC-F05 — PKCE bridge is in-memory per process
 
 - **Severity:** Medium
-- **Status:** Mitigated — sprint 3 (infra + documentation). Architectural externalisation tracked.
-- **Location:** [src/oauth-proxy.ts](../src/oauth-proxy.ts).
-- **Description:** A process-local `Map<string, PkceEntry>` holds the server-side PKCE verifier between `/authorize` and `/token`. In a multi-replica deployment, the two requests may land on different instances and the bridge lookup fails.
-- **Attack scenario:** No direct exploit, but the availability failure creates pressure for ad-hoc fixes that degrade security (e.g. shortening `PKCE_TTL_MS`, removing PKCE, or relaxing the bridge lookup).
-- **Mitigation delivered (sprint 3):** [infra/main.bicep](../infra/main.bicep) now defaults `maxReplicas = 1` with an inline SEC-F05 note explaining why. Operators who scale past one replica must explicitly override the parameter — forcing them to acknowledge the broken flow before they break it. Documented in [HTTP_DEPLOYMENT.md](HTTP_DEPLOYMENT.md).
-- **Residual risk:** This is an availability/operational constraint, not a remediation. A horizontally-scalable deployment still requires externalising the bridge (Redis / Azure Cosmos / Azure Table with the same 10-minute TTL). Tracked as a follow-up under the same SEC-F05 ID; re-open on this document when the feature is scheduled.
+- **Status:** Fixed — sprint 6 (v0.4.0)
+- **Location:** [src/oauth-proxy.ts](../src/oauth-proxy.ts), [src/storage/table-storage.ts](../src/storage/table-storage.ts), [infra/main.bicep](../infra/main.bicep)
+- **Description:** A process-local `Map<string, PkceEntry>` held the server-side PKCE verifier between `/authorize` and `/token`. In a multi-replica deployment, the two requests could land on different instances and the bridge lookup fails.
+- **Attack scenario:** No direct exploit, but the availability failure created pressure for ad-hoc fixes that degrade security (shortening `PKCE_TTL_MS`, removing PKCE, relaxing the bridge lookup).
+- **Remediation delivered (sprint 6, v0.4.0):** The PKCE bridge and the DCR client credentials (SEC-F04b) now live in Azure Table Storage (`oauthstate` table, two partitions: `pkce` and `dcr`). Atomic consume implemented via `getEntity` + `deleteEntity(ETag)` with 412 Precondition Failed treated as "already consumed". Bicep provisions a Storage Account (Standard_LRS, `allowSharedKeyAccess: false`, `defaultToOAuthAuthentication: true`, TLS 1.2 minimum) and grants the UAMI `Storage Table Data Contributor` on it. Container App receives `AZURE_STORAGE_ACCOUNT_NAME` + `AZURE_STORAGE_TABLE_NAME` via env and authenticates with `DefaultAzureCredential`. `maxReplicas` default restored to 3.
+- **Tests:** `test/storage-memory.test.ts` covers the storage contract; the Table implementation uses the same interface and is smoke-tested via Azurite during local dev (no live-Azure test in CI to keep it hermetic).
+- **Residual risk:** None identified for the reviewed threat. Single-table design keeps PKCE + DCR in the same operational surface; a rogue operator with `Storage Table Data Contributor` on the SA can read DCR hashes (not plaintext secrets — SHA-256), which is the same trust level as the app itself.
 
 ### SEC-F06 — `/token` and `/authorize` have no rate limit
 
@@ -222,15 +237,15 @@ No remediation required — recorded so future reviews do not re-litigate alread
 
 ## Remediation order (recommendation)
 
-| Wave       | Findings                                                                               | Rationale                                                                                                |
-| ---------- | -------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| 1 — PR #44 | SEC-F01 (fixed), SEC-F03 (fixed)                                                       | Critical + High exploitable at the current deployment state.                                             |
-| 2 — PR #46 | SEC-F02 (fixed), SEC-F06 (fixed), SEC-F04 (partial: rate-limited + documented)         | Harden the public OAuth proxy surface before broader exposure.                                           |
-| 3 — PR #47 | SEC-F07 (fixed), SEC-F08 (fixed), SEC-F05 (mitigated via single-replica Bicep default) | Log hygiene, availability robustness, multi-replica guardrail.                                           |
-| 4 — PR #48 | SEC-G02 (fixed)                                                                        | Output-side prompt-injection defence — the only P2 finding exploitable remotely.                         |
-| 5 — PR #49 | SEC-G01 (fixed), SEC-G03 (fixed)                                                       | Granular write cap + sensitive-read risk annotations feeding the cap.                                    |
-| Follow-ups | SEC-F04b (refresh-token PoP), SEC-F05 architectural (externalise PKCE bridge)          | Architectural work — larger PRs with new runtime dependencies. Track separately when scheduling arrives. |
-| Backlog    | SEC-G04, SEC-F09, SEC-F10, SEC-F11                                                     | Documentation / cosmetic; no realistic exploit path.                                                     |
+| Wave       | Findings                                                                               | Rationale                                                                                               |
+| ---------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| 1 — PR #44 | SEC-F01 (fixed), SEC-F03 (fixed)                                                       | Critical + High exploitable at the current deployment state.                                            |
+| 2 — PR #46 | SEC-F02 (fixed), SEC-F06 (fixed), SEC-F04 (partial: rate-limited + documented)         | Harden the public OAuth proxy surface before broader exposure.                                          |
+| 3 — PR #47 | SEC-F07 (fixed), SEC-F08 (fixed), SEC-F05 (mitigated via single-replica Bicep default) | Log hygiene, availability robustness, multi-replica guardrail.                                          |
+| 4 — PR #48 | SEC-G02 (fixed)                                                                        | Output-side prompt-injection defence — the only P2 finding exploitable remotely.                        |
+| 5 — PR #49 | SEC-G01 (fixed), SEC-G03 (fixed)                                                       | Granular write cap + sensitive-read risk annotations feeding the cap.                                   |
+| 6 — v0.4.0 | SEC-F04b (fixed), SEC-F04 (fixed), SEC-F05 (fixed architectural)                       | Confidential-client DCR + Azure Table externalisation of PKCE/DCR state. Closes all architectural debt. |
+| Backlog    | SEC-G04, SEC-F09, SEC-F10, SEC-F11                                                     | Documentation / cosmetic; no realistic exploit path.                                                    |
 
 ---
 
@@ -238,7 +253,7 @@ No remediation required — recorded so future reviews do not re-litigate alread
 
 The broader audit plan identified six priority areas. Status after this cycle:
 
-- **P1 — Auth / OAuth HTTP mode** — substantially remediated. Closed: SEC-F01, SEC-F02, SEC-F03, SEC-F06, SEC-F07, SEC-F08. Partially mitigated: SEC-F04 (rate-limited; architectural PoP fix as SEC-F04b) and SEC-F05 (single-replica default; architectural externalisation still open). Open-backlog: SEC-F09, SEC-F10, SEC-F11.
+- **P1 — Auth / OAuth HTTP mode** — fully remediated. Closed: SEC-F01, SEC-F02, SEC-F03, SEC-F04, SEC-F04b, SEC-F05, SEC-F06, SEC-F07, SEC-F08. Open-backlog: SEC-F09, SEC-F10, SEC-F11.
 - **P2 — Tool invocation gating** — substantially remediated. Closed: SEC-G01 (granular `--max-risk-level`), SEC-G02 (prompt-injection envelope), SEC-G03 (sensitive-read annotations). Open-backlog: SEC-G04 (path-parameter allowlist — hygiene only).
 - **P3 — Secret & token hygiene** — pass-level check done (no logging observed); formal pass pending.
 - **P4 — Transport & deploy hardening** — CORS, HSTS, trust-proxy depth, rate-limit breadth.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -31,9 +31,9 @@ param logRetentionDays int = 30
 @minValue(0)
 param minReplicas int = 0
 
-@description('Container App max replicas. SEC-F05: default is 1 because the OAuth proxy\'s PKCE bridge is in-memory per process — scaling beyond one replica silently breaks the /authorize → /token flow. Override only after externalising the bridge (Redis / Azure Table).')
+@description('Container App max replicas. SEC-F05: PKCE bridge is now externalised to Azure Table Storage (see storageAccount below), so this can safely scale past 1.')
 @minValue(1)
-param maxReplicas int = 1
+param maxReplicas int = 3
 
 @description('Tags applied to every resource (must satisfy org tag policies)')
 param tags object = {}
@@ -59,9 +59,12 @@ var lawName = '${baseName}-law'
 var appInsightsName = '${baseName}-ai'
 var caeName = '${baseName}-cae'
 var appName = '${baseName}-app'
+var storageAccountName = take('${replace(baseName, '-', '')}st${uniqueString(resourceGroup().id)}', 24)
+var oauthTableName = 'oauthstate'
 
 var kvSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
 var kvSecretsOfficerRoleId = 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7'
+var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
 
 var baseArgs = [
   '--transport'
@@ -144,6 +147,52 @@ resource kvAdmins 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   }
 ]
 
+// --- Storage Account (OAuth PKCE bridge + DCR client credentials, SEC-F04b / SEC-F05) ---
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+    defaultToOAuthAuthentication: true
+    networkAcls: {
+      defaultAction: 'Allow'
+      bypass: 'AzureServices'
+    }
+  }
+}
+
+resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource oauthTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
+  parent: tableService
+  name: oauthTableName
+}
+
+resource uamiTableAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: storageAccount
+  name: guid(storageAccount.id, uami.id, storageTableDataContributorRoleId)
+  properties: {
+    principalId: uami.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      storageTableDataContributorRoleId
+    )
+  }
+}
+
 // --- Log Analytics + Application Insights ---
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
@@ -200,6 +249,7 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
   }
   dependsOn: [
     uamiKvAccess
+    uamiTableAccess
   ]
   properties: {
     managedEnvironmentId: containerAppEnv.id
@@ -247,6 +297,14 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
               name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
               value: appInsights.properties.ConnectionString
             }
+            {
+              name: 'AZURE_STORAGE_ACCOUNT_NAME'
+              value: storageAccount.name
+            }
+            {
+              name: 'AZURE_STORAGE_TABLE_NAME'
+              value: oauthTableName
+            }
           ]
         }
       ]
@@ -260,5 +318,6 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
 
 output containerAppUrl string = 'https://${containerApp.properties.configuration.ingress.fqdn}'
 output keyVaultName string = keyVault.name
+output storageAccountName string = storageAccount.name
 output uamiPrincipalId string = uami.properties.principalId
 output uamiClientId string = uami.properties.clientId

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
+        "@azure/data-tables": "^13.3.0",
         "@azure/msal-node": "^3.8.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "commander": "^11.1.0",
@@ -43,6 +44,7 @@
         "node": ">=18"
       },
       "optionalDependencies": {
+        "@azure/data-tables": "^13.3.2",
         "@azure/identity": "^4.5.0",
         "@azure/keyvault-secrets": "^4.9.0"
       }
@@ -197,6 +199,41 @@
         "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/data-tables": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-13.3.2.tgz",
+      "integrity": "sha512-PZ8e4SnCpTQEbQ1P+CK6NR7Vhb86Jw1S1qJi2IcF1ij4qiPX2b4vIemwNPkYg/gZGMqKbxkPvGRpRmEbBYdXuA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.4",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1275,6 +1312,19 @@
           "optional": false
         }
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3372,6 +3422,44 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -4694,6 +4782,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -5497,6 +5601,19 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/sucrase": {
       "version": "3.35.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",
@@ -61,6 +61,7 @@
     "zod": "^3.24.2"
   },
   "optionalDependencies": {
+    "@azure/data-tables": "^13.3.2",
     "@azure/identity": "^4.5.0",
     "@azure/keyvault-secrets": "^4.9.0"
   },

--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -1,6 +1,8 @@
 import crypto from 'crypto';
 import type { Express, Request, Response } from 'express';
 import logger from './logger.js';
+import type { OAuthStorage } from './storage/index.js';
+import { hashClientSecret, verifyClientSecret } from './storage/index.js';
 import { summarizeUpstreamError } from './upstream-error.js';
 
 export interface OAuthProxyOptions {
@@ -15,31 +17,14 @@ export interface OAuthProxyOptions {
   clientSecret?: string;
   scopes: string[];
   enableDynamicRegistration: boolean;
-}
-
-interface PkceEntry {
-  serverVerifier: string;
-  redirectUri: string;
-  expiresAt: number;
+  // SEC-F04b + SEC-F05: externalised storage for PKCE bridge + DCR client
+  // credentials. Replaces the previous in-memory Map so a stolen refresh token
+  // cannot be redeemed without the per-client secret, and so the proxy can run
+  // multi-replica without losing PKCE state between /authorize and /token.
+  storage: OAuthStorage;
 }
 
 const PKCE_TTL_MS = 10 * 60 * 1000;
-const PKCE_MAX_ENTRIES = 1000;
-const pkceBridge = new Map<string, PkceEntry>();
-
-function pruneExpired(): void {
-  const now = Date.now();
-  if (pkceBridge.size <= PKCE_MAX_ENTRIES) {
-    for (const [k, v] of pkceBridge) {
-      if (v.expiresAt < now) pkceBridge.delete(k);
-    }
-    return;
-  }
-  const entries = [...pkceBridge.entries()].sort((a, b) => a[1].expiresAt - b[1].expiresAt);
-  for (let i = 0; i < entries.length - PKCE_MAX_ENTRIES; i++) {
-    pkceBridge.delete(entries[i][0]);
-  }
-}
 
 function base64url(buf: Buffer): string {
   return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
@@ -53,8 +38,39 @@ function randomVerifier(): string {
   return base64url(crypto.randomBytes(64));
 }
 
+function randomClientSecret(): string {
+  return base64url(crypto.randomBytes(32));
+}
+
 function stripTrailingSlash(s: string): string {
   return s.endsWith('/') ? s.slice(0, -1) : s;
+}
+
+// RFC 6749 §2.3.1: `client_secret_basic` uses HTTP Basic auth in the
+// Authorization header with form-urlencoded credentials. We also accept
+// `client_secret_post` via the body (advertised as our only supported method).
+function extractClientCredentials(req: Request): { clientId?: string; clientSecret?: string } {
+  const body = req.body ?? {};
+  const bodyId = typeof body.client_id === 'string' ? body.client_id : undefined;
+  const bodySecret = typeof body.client_secret === 'string' ? body.client_secret : undefined;
+  if (bodyId && bodySecret) return { clientId: bodyId, clientSecret: bodySecret };
+
+  const auth = req.headers.authorization;
+  if (auth && auth.startsWith('Basic ')) {
+    try {
+      const decoded = Buffer.from(auth.slice(6), 'base64').toString('utf8');
+      const sep = decoded.indexOf(':');
+      if (sep > 0) {
+        return {
+          clientId: decodeURIComponent(decoded.slice(0, sep)),
+          clientSecret: decodeURIComponent(decoded.slice(sep + 1)),
+        };
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+  return { clientId: bodyId, clientSecret: bodySecret };
 }
 
 export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): void {
@@ -67,6 +83,17 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
         'The metadata endpoints advertise this as the OAuth issuer and cannot fall back to request headers.'
     );
   }
+  // SEC-F04b: DCR must be enabled so that /token can enforce per-client
+  // credentials. An oauth-mode deployment without DCR has no way to bind
+  // refresh-token redemption to a client authentication factor.
+  if (!options.enableDynamicRegistration) {
+    throw new Error(
+      'OAuth proxy requires Dynamic Client Registration to be enabled (SEC-F04b): ' +
+        '/token enforces per-client credentials issued at /register. ' +
+        'Remove --no-dynamic-registration or disable --oauth-mode.'
+    );
+  }
+  const storage = options.storage;
   const issuer = stripTrailingSlash(options.publicUrl);
   const authority = `https://login.microsoftonline.com/${options.tenantId}`;
   const fallbackScope =
@@ -79,11 +106,13 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       issuer,
       authorization_endpoint: `${issuer}/authorize`,
       token_endpoint: `${issuer}/token`,
-      registration_endpoint: options.enableDynamicRegistration ? `${issuer}/register` : undefined,
+      registration_endpoint: `${issuer}/register`,
       response_types_supported: ['code'],
       grant_types_supported: ['authorization_code', 'refresh_token'],
       code_challenge_methods_supported: ['S256'],
-      token_endpoint_auth_methods_supported: ['none'],
+      // SEC-F04b: confidential clients only. MCP clients obtain a secret at
+      // /register and present it on every /token call.
+      token_endpoint_auth_methods_supported: ['client_secret_post', 'client_secret_basic'],
       scopes_supported: options.scopes.length > 0 ? options.scopes : fallbackScope.split(' '),
     });
   });
@@ -96,24 +125,43 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     });
   });
 
-  if (options.enableDynamicRegistration) {
-    app.post('/register', (req: Request, res: Response) => {
-      const body = req.body ?? {};
-      const clientId = `mcp-client-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
-      res.status(201).json({
-        client_id: clientId,
-        client_id_issued_at: Math.floor(Date.now() / 1000),
-        redirect_uris: body.redirect_uris ?? [],
-        grant_types: body.grant_types ?? ['authorization_code', 'refresh_token'],
-        response_types: body.response_types ?? ['code'],
-        token_endpoint_auth_method: 'none',
-        scope: body.scope ?? fallbackScope,
-      });
-    });
-  }
+  app.post('/register', async (req: Request, res: Response) => {
+    const body = req.body ?? {};
+    const clientId = `mcp-client-${Date.now()}-${crypto.randomBytes(4).toString('hex')}`;
+    const clientSecret = randomClientSecret();
+    const redirectUris = Array.isArray(body.redirect_uris) ? body.redirect_uris : [];
 
-  app.get('/authorize', (req: Request, res: Response) => {
+    try {
+      await storage.saveClient({
+        clientId,
+        clientSecretHash: hashClientSecret(clientSecret),
+        redirectUris,
+        createdAt: Date.now(),
+      });
+    } catch (error) {
+      logger.error(`DCR saveClient failed: ${(error as Error).message}`);
+      res.status(500).json({ error: 'server_error', error_description: 'Registration failed' });
+      return;
+    }
+
+    logger.info(`DCR registered ${clientId}`);
+    res.status(201).json({
+      client_id: clientId,
+      client_secret: clientSecret,
+      // 0 means "does not expire" per RFC 7591 §3.2.1. Rotation is manual.
+      client_secret_expires_at: 0,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      redirect_uris: redirectUris,
+      grant_types: body.grant_types ?? ['authorization_code', 'refresh_token'],
+      response_types: body.response_types ?? ['code'],
+      token_endpoint_auth_method: 'client_secret_post',
+      scope: body.scope ?? fallbackScope,
+    });
+  });
+
+  app.get('/authorize', async (req: Request, res: Response) => {
     const {
+      client_id: clientId,
       redirect_uri: redirectUri,
       state,
       code_challenge: clientChallenge,
@@ -121,11 +169,11 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       scope,
     } = req.query as Record<string, string | undefined>;
 
-    if (!redirectUri || !clientChallenge) {
-      logger.warn('OAuth /authorize rejected: missing redirect_uri or code_challenge');
+    if (!clientId || !redirectUri || !clientChallenge) {
+      logger.warn('OAuth /authorize rejected: missing client_id, redirect_uri or code_challenge');
       res.status(400).json({
         error: 'invalid_request',
-        error_description: 'Missing redirect_uri or code_challenge',
+        error_description: 'Missing client_id, redirect_uri or code_challenge',
       });
       return;
     }
@@ -140,12 +188,23 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       return;
     }
 
-    pruneExpired();
+    // SEC-F04b: /authorize must only accept DCR-issued client_ids. An unknown
+    // client_id would let a caller who doesn't possess the secret still funnel
+    // an auth code through the proxy.
+    const known = await storage.getClient(clientId);
+    if (!known) {
+      logger.warn(`OAuth /authorize rejected: unknown client_id ${clientId}`);
+      res.status(400).json({ error: 'invalid_client', error_description: 'Unknown client_id' });
+      return;
+    }
+
     const serverVerifier = randomVerifier();
     const serverChallenge = sha256Base64url(serverVerifier);
-    pkceBridge.set(clientChallenge, {
+    await storage.savePkce({
+      clientChallenge,
       serverVerifier,
       redirectUri,
+      clientId,
       expiresAt: Date.now() + PKCE_TTL_MS,
     });
 
@@ -160,7 +219,7 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     if (state) upstream.searchParams.set('state', state);
 
     logger.info(
-      `OAuth /authorize → Entra (redirect_uri=${redirectUri}, scope=${scope || fallbackScope})`
+      `OAuth /authorize → Entra (client=${clientId}, redirect_uri=${redirectUri}, scope=${scope || fallbackScope})`
     );
     res.redirect(302, upstream.toString());
   });
@@ -168,6 +227,26 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
   app.post('/token', async (req: Request, res: Response) => {
     const body = req.body ?? {};
     const grantType = body.grant_type;
+
+    // SEC-F04b: require client authentication on every /token call. A stolen
+    // authorization_code or refresh_token is useless without the client_secret
+    // issued at /register.
+    const { clientId: reqClientId, clientSecret: reqClientSecret } = extractClientCredentials(req);
+    if (!reqClientId || !reqClientSecret) {
+      res.status(401).json({
+        error: 'invalid_client',
+        error_description: 'Missing client_id or client_secret',
+      });
+      return;
+    }
+    const registered = await storage.getClient(reqClientId);
+    if (!registered || !verifyClientSecret(reqClientSecret, registered.clientSecretHash)) {
+      logger.warn(`OAuth /token rejected: invalid client credentials for ${reqClientId}`);
+      res
+        .status(401)
+        .json({ error: 'invalid_client', error_description: 'Invalid client credentials' });
+      return;
+    }
 
     const form = new URLSearchParams();
     form.set('client_id', options.clientId);
@@ -187,15 +266,27 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       }
 
       const clientChallenge = sha256Base64url(clientVerifier);
-      const bridge = pkceBridge.get(clientChallenge);
-      if (!bridge || bridge.expiresAt < Date.now()) {
+      const bridge = await storage.consumePkce(clientChallenge);
+      if (!bridge) {
         res.status(400).json({
           error: 'invalid_grant',
           error_description: 'PKCE bridge entry missing or expired',
         });
         return;
       }
-      pkceBridge.delete(clientChallenge);
+      // SEC-F04b: a client cannot redeem a code obtained under a different
+      // client_id. This prevents a compromised client from redeeming another
+      // client's auth code even if it races the PKCE consumption.
+      if (bridge.clientId !== reqClientId) {
+        logger.warn(
+          `OAuth /token rejected: client_id mismatch (bridge=${bridge.clientId}, req=${reqClientId})`
+        );
+        res.status(400).json({
+          error: 'invalid_grant',
+          error_description: 'client_id does not match the one used at /authorize',
+        });
+        return;
+      }
 
       form.set('grant_type', 'authorization_code');
       form.set('code', code);
@@ -230,7 +321,7 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
           `Entra /token returned ${upstream.status} for grant_type=${grantType}: ${summarizeUpstreamError(payload)}`
         );
       } else {
-        logger.info(`Entra /token exchange ok (grant_type=${grantType})`);
+        logger.info(`Entra /token exchange ok (grant_type=${grantType}, client=${reqClientId})`);
       }
       res.status(upstream.status).type('application/json').send(payload);
     } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -131,22 +131,26 @@ class AdminGraphServer {
           }
         : undefined;
 
-      const oauthProxyOptions = this.options.oauthMode
-        ? {
-            publicUrl: this.options.publicUrl || '',
-            tenantId: this.secrets!.tenantId,
-            clientId: this.secrets!.clientId,
-            clientSecret: this.secrets!.clientSecret,
-            scopes: [
-              'openid',
-              'profile',
-              'email',
-              'offline_access',
-              `api://${this.secrets!.clientId}/access_as_user`,
-            ],
-            enableDynamicRegistration: this.options.dynamicRegistration !== false,
-          }
-        : undefined;
+      let oauthProxyOptions: import('./oauth-proxy.js').OAuthProxyOptions | undefined;
+      if (this.options.oauthMode) {
+        const { createOAuthStorage } = await import('./storage/index.js');
+        const storage = await createOAuthStorage();
+        oauthProxyOptions = {
+          publicUrl: this.options.publicUrl || '',
+          tenantId: this.secrets!.tenantId,
+          clientId: this.secrets!.clientId,
+          clientSecret: this.secrets!.clientSecret,
+          scopes: [
+            'openid',
+            'profile',
+            'email',
+            'offline_access',
+            `api://${this.secrets!.clientId}/access_as_user`,
+          ],
+          enableDynamicRegistration: this.options.dynamicRegistration !== false,
+          storage,
+        };
+      }
 
       await startHttpServer({
         port,

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,0 +1,31 @@
+import logger from '../logger.js';
+import { MemoryStorage } from './memory-storage.js';
+import type { OAuthStorage } from './oauth-storage.js';
+
+export type { OAuthStorage, PkceEntry, RegisteredClient } from './oauth-storage.js';
+export { hashClientSecret, verifyClientSecret } from './oauth-storage.js';
+export { MemoryStorage } from './memory-storage.js';
+
+export interface StorageFactoryOptions {
+  tableName?: string;
+}
+
+// Resolves an OAuthStorage from environment:
+// - AZURE_STORAGE_ACCOUNT_NAME → TableStorage via DefaultAzureCredential (prod / Container Apps)
+// - AZURE_STORAGE_CONNECTION_STRING → TableStorage via connection string (local dev / Azurite)
+// - neither → MemoryStorage (stdio, tests, non-OAuth deployments)
+export async function createOAuthStorage(
+  options: StorageFactoryOptions = {}
+): Promise<OAuthStorage> {
+  const tableName = options.tableName ?? process.env.AZURE_STORAGE_TABLE_NAME ?? 'oauthstate';
+  const accountName = process.env.AZURE_STORAGE_ACCOUNT_NAME;
+  const connectionString = process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+  if (accountName || connectionString) {
+    const { TableStorage } = await import('./table-storage.js');
+    return TableStorage.create({ accountName, connectionString, tableName });
+  }
+
+  logger.info('OAuth state backed by in-process memory (single-replica only)');
+  return new MemoryStorage();
+}

--- a/src/storage/memory-storage.ts
+++ b/src/storage/memory-storage.ts
@@ -1,0 +1,43 @@
+import type { OAuthStorage, PkceEntry, RegisteredClient } from './oauth-storage.js';
+
+const PKCE_MAX_ENTRIES = 1000;
+
+export class MemoryStorage implements OAuthStorage {
+  private pkce = new Map<string, PkceEntry>();
+  private clients = new Map<string, RegisteredClient>();
+
+  async savePkce(entry: PkceEntry): Promise<void> {
+    this.prunePkce();
+    this.pkce.set(entry.clientChallenge, entry);
+  }
+
+  async consumePkce(clientChallenge: string): Promise<PkceEntry | null> {
+    const entry = this.pkce.get(clientChallenge);
+    if (!entry) return null;
+    this.pkce.delete(clientChallenge);
+    if (entry.expiresAt < Date.now()) return null;
+    return entry;
+  }
+
+  async saveClient(client: RegisteredClient): Promise<void> {
+    this.clients.set(client.clientId, client);
+  }
+
+  async getClient(clientId: string): Promise<RegisteredClient | null> {
+    return this.clients.get(clientId) ?? null;
+  }
+
+  private prunePkce(): void {
+    const now = Date.now();
+    if (this.pkce.size <= PKCE_MAX_ENTRIES) {
+      for (const [k, v] of this.pkce) {
+        if (v.expiresAt < now) this.pkce.delete(k);
+      }
+      return;
+    }
+    const entries = [...this.pkce.entries()].sort((a, b) => a[1].expiresAt - b[1].expiresAt);
+    for (let i = 0; i < entries.length - PKCE_MAX_ENTRIES; i++) {
+      this.pkce.delete(entries[i][0]);
+    }
+  }
+}

--- a/src/storage/oauth-storage.ts
+++ b/src/storage/oauth-storage.ts
@@ -1,0 +1,39 @@
+import crypto from 'crypto';
+
+export interface PkceEntry {
+  clientChallenge: string;
+  serverVerifier: string;
+  redirectUri: string;
+  // SEC-F04b: bind the PKCE entry to the DCR client_id that initiated the
+  // /authorize call. /token then rejects any attempt to redeem a code under a
+  // different client_id.
+  clientId: string;
+  expiresAt: number;
+}
+
+export interface RegisteredClient {
+  clientId: string;
+  clientSecretHash: string;
+  redirectUris: string[];
+  createdAt: number;
+}
+
+export interface OAuthStorage {
+  savePkce(entry: PkceEntry): Promise<void>;
+  // Atomic fetch-and-delete. Returns null if the entry is missing, expired, or
+  // was consumed by a concurrent caller. One-shot semantics prevent replay.
+  consumePkce(clientChallenge: string): Promise<PkceEntry | null>;
+  saveClient(client: RegisteredClient): Promise<void>;
+  getClient(clientId: string): Promise<RegisteredClient | null>;
+}
+
+export function hashClientSecret(secret: string): string {
+  return crypto.createHash('sha256').update(secret, 'utf8').digest('hex');
+}
+
+export function verifyClientSecret(plaintext: string, hash: string): boolean {
+  const computed = Buffer.from(hashClientSecret(plaintext), 'utf8');
+  const expected = Buffer.from(hash, 'utf8');
+  if (computed.length !== expected.length) return false;
+  return crypto.timingSafeEqual(computed, expected);
+}

--- a/src/storage/table-storage.ts
+++ b/src/storage/table-storage.ts
@@ -1,0 +1,139 @@
+import type { TableClient, TableServiceClient } from '@azure/data-tables';
+import logger from '../logger.js';
+import type { OAuthStorage, PkceEntry, RegisteredClient } from './oauth-storage.js';
+
+const PKCE_PARTITION = 'pkce';
+const DCR_PARTITION = 'dcr';
+
+interface PkceEntity {
+  partitionKey: string;
+  rowKey: string;
+  serverVerifier: string;
+  redirectUri: string;
+  clientId: string;
+  expiresAt: number;
+}
+
+interface ClientEntity {
+  partitionKey: string;
+  rowKey: string;
+  clientSecretHash: string;
+  redirectUrisJson: string;
+  createdAt: number;
+}
+
+export class TableStorage implements OAuthStorage {
+  constructor(private client: TableClient) {}
+
+  static async create(options: {
+    accountName?: string;
+    connectionString?: string;
+    tableName: string;
+  }): Promise<TableStorage> {
+    const { TableClient, TableServiceClient } = await import('@azure/data-tables');
+    const { DefaultAzureCredential } = await import('@azure/identity');
+
+    let client: TableClient;
+    let service: TableServiceClient;
+
+    if (options.connectionString) {
+      client = TableClient.fromConnectionString(options.connectionString, options.tableName, {
+        allowInsecureConnection: options.connectionString.includes('UseDevelopmentStorage=true'),
+      });
+      service = TableServiceClient.fromConnectionString(options.connectionString, {
+        allowInsecureConnection: options.connectionString.includes('UseDevelopmentStorage=true'),
+      });
+    } else if (options.accountName) {
+      const credential = new DefaultAzureCredential();
+      const endpoint = `https://${options.accountName}.table.core.windows.net`;
+      client = new TableClient(endpoint, options.tableName, credential);
+      service = new TableServiceClient(endpoint, credential);
+    } else {
+      throw new Error(
+        'TableStorage requires either connectionString or accountName (for managed identity)'
+      );
+    }
+
+    await service.createTable(options.tableName).catch((err: { statusCode?: number }) => {
+      if (err.statusCode !== 409) throw err;
+    });
+
+    logger.info(`OAuth state backed by Azure Table "${options.tableName}"`);
+    return new TableStorage(client);
+  }
+
+  async savePkce(entry: PkceEntry): Promise<void> {
+    const entity: PkceEntity = {
+      partitionKey: PKCE_PARTITION,
+      rowKey: entry.clientChallenge,
+      serverVerifier: entry.serverVerifier,
+      redirectUri: entry.redirectUri,
+      clientId: entry.clientId,
+      expiresAt: entry.expiresAt,
+    };
+    await this.client.upsertEntity(entity, 'Replace');
+  }
+
+  async consumePkce(clientChallenge: string): Promise<PkceEntry | null> {
+    let entity: PkceEntity & { etag: string };
+    try {
+      entity = (await this.client.getEntity<PkceEntity>(
+        PKCE_PARTITION,
+        clientChallenge
+      )) as PkceEntity & { etag: string };
+    } catch (err) {
+      if ((err as { statusCode?: number }).statusCode === 404) return null;
+      throw err;
+    }
+
+    try {
+      await this.client.deleteEntity(PKCE_PARTITION, clientChallenge, { etag: entity.etag });
+    } catch (err) {
+      // 412: another caller consumed it between get and delete. 404: already gone.
+      const status = (err as { statusCode?: number }).statusCode;
+      if (status === 412 || status === 404) return null;
+      throw err;
+    }
+
+    if (entity.expiresAt < Date.now()) return null;
+    return {
+      clientChallenge,
+      serverVerifier: entity.serverVerifier,
+      redirectUri: entity.redirectUri,
+      clientId: entity.clientId,
+      expiresAt: entity.expiresAt,
+    };
+  }
+
+  async saveClient(client: RegisteredClient): Promise<void> {
+    const entity: ClientEntity = {
+      partitionKey: DCR_PARTITION,
+      rowKey: client.clientId,
+      clientSecretHash: client.clientSecretHash,
+      redirectUrisJson: JSON.stringify(client.redirectUris),
+      createdAt: client.createdAt,
+    };
+    await this.client.createEntity(entity);
+  }
+
+  async getClient(clientId: string): Promise<RegisteredClient | null> {
+    try {
+      const entity = await this.client.getEntity<ClientEntity>(DCR_PARTITION, clientId);
+      let redirectUris: string[] = [];
+      try {
+        redirectUris = JSON.parse(entity.redirectUrisJson);
+      } catch {
+        redirectUris = [];
+      }
+      return {
+        clientId,
+        clientSecretHash: entity.clientSecretHash,
+        redirectUris,
+        createdAt: entity.createdAt,
+      };
+    } catch (err) {
+      if ((err as { statusCode?: number }).statusCode === 404) return null;
+      throw err;
+    }
+  }
+}

--- a/test/oauth-proxy.test.ts
+++ b/test/oauth-proxy.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, vi } from 'vitest';
+import express from 'express';
+import type { Express, Server } from 'http';
+import crypto from 'crypto';
+import { registerOAuthRoutes, type OAuthProxyOptions } from '../src/oauth-proxy.js';
+import { MemoryStorage } from '../src/storage/memory-storage.js';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const CLIENT_ID = '22222222-2222-2222-2222-222222222222';
+
+function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function sha256(input: string): string {
+  return base64url(crypto.createHash('sha256').update(input).digest());
+}
+
+async function buildServer(storage: MemoryStorage): Promise<{ url: string; server: Server }> {
+  const app = express();
+  app.use(express.json({ limit: '100kb' }));
+  app.use(express.urlencoded({ extended: true, limit: '100kb' }));
+  const options: OAuthProxyOptions = {
+    publicUrl: 'https://mcp.example.com',
+    tenantId: TENANT,
+    clientId: CLIENT_ID,
+    clientSecret: 'upstream-entra-secret',
+    scopes: ['openid', 'profile', 'email', 'offline_access', `api://${CLIENT_ID}/access_as_user`],
+    enableDynamicRegistration: true,
+    storage,
+  };
+  registerOAuthRoutes(app as Express, options);
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (addr && typeof addr === 'object') {
+        resolve({ url: `http://127.0.0.1:${addr.port}`, server });
+      }
+    });
+  });
+}
+
+let storage: MemoryStorage;
+let baseUrl: string;
+let server: Server;
+let fetchMock: ReturnType<typeof vi.fn>;
+let realFetch: typeof fetch;
+
+beforeAll(async () => {
+  storage = new MemoryStorage();
+  const built = await buildServer(storage);
+  baseUrl = built.url;
+  server = built.server;
+  realFetch = globalThis.fetch;
+});
+
+afterAll(() => {
+  globalThis.fetch = realFetch;
+  server.close();
+});
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  // SEC-F04b test harness: stub only the upstream Entra endpoint; route
+  // traffic back to our test server hits the real fetch.
+  globalThis.fetch = (async (...args: Parameters<typeof fetch>) => {
+    const [input] = args;
+    const url = typeof input === 'string' ? input : input.toString();
+    if (url.includes('login.microsoftonline.com')) {
+      return fetchMock(...args);
+    }
+    return realFetch(...args);
+  }) as typeof fetch;
+});
+
+async function register(): Promise<{ clientId: string; clientSecret: string }> {
+  const res = await realFetch(`${baseUrl}/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ redirect_uris: ['http://localhost:3000/cb'] }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as {
+    client_id: string;
+    client_secret: string;
+    token_endpoint_auth_method: string;
+  };
+  expect(body.token_endpoint_auth_method).toBe('client_secret_post');
+  return { clientId: body.client_id, clientSecret: body.client_secret };
+}
+
+describe('SEC-F04b /register (DCR) — confidential client issuance', () => {
+  it('returns a client_id and a client_secret, and stores a hash', async () => {
+    const { clientId, clientSecret } = await register();
+    expect(clientId).toMatch(/^mcp-client-/);
+    expect(clientSecret.length).toBeGreaterThan(20);
+
+    const stored = await storage.getClient(clientId);
+    expect(stored).not.toBeNull();
+    expect(stored?.clientSecretHash).not.toBe(clientSecret);
+    expect(stored?.clientSecretHash).toHaveLength(64);
+  });
+});
+
+describe('SEC-F04b /authorize — unknown client_id rejected', () => {
+  it('rejects client_id that was not registered via DCR', async () => {
+    const res = await realFetch(
+      `${baseUrl}/authorize?client_id=unknown&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=xyz`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid_client');
+  });
+
+  it('accepts a DCR-registered client and redirects to Entra', async () => {
+    const { clientId } = await register();
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+    const res = await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toContain('login.microsoftonline.com');
+  });
+});
+
+describe('SEC-F04b /token — client authentication required', () => {
+  it('rejects refresh_token grant with no client credentials', async () => {
+    const res = await realFetch(`${baseUrl}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: 'stolen-rt' }),
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid_client');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects refresh_token grant with wrong client_secret', async () => {
+    const { clientId } = await register();
+    const res = await realFetch(`${baseUrl}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: 'stolen-rt',
+        client_id: clientId,
+        client_secret: 'wrong-secret',
+      }),
+    });
+    expect(res.status).toBe(401);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts refresh_token grant with valid credentials and forwards to Entra', async () => {
+    const { clientId, clientSecret } = await register();
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ access_token: 'new-at', refresh_token: 'new-rt' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const res = await realFetch(`${baseUrl}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: 'legit-rt',
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = (await res.json()) as { access_token: string };
+    expect(body.access_token).toBe('new-at');
+  });
+
+  it('accepts Basic auth (client_secret_basic) as an alternative to body auth', async () => {
+    const { clientId, clientSecret } = await register();
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ access_token: 'at' }), { status: 200 })
+    );
+    const basic = Buffer.from(
+      `${encodeURIComponent(clientId)}:${encodeURIComponent(clientSecret)}`
+    ).toString('base64');
+    const res = await realFetch(`${baseUrl}/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        Authorization: `Basic ${basic}`,
+      },
+      body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: 'rt' }),
+    });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SEC-F04b /token authorization_code — PKCE client_id binding', () => {
+  it('rejects code redemption under a different client_id than /authorize used', async () => {
+    const clientA = await register();
+    const clientB = await register();
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+
+    // Client A starts the flow
+    await realFetch(
+      `${baseUrl}/authorize?client_id=${clientA.clientId}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+
+    // Client B tries to redeem a code with A's PKCE verifier
+    const res = await realFetch(`${baseUrl}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: 'stolen-code',
+        code_verifier: verifier,
+        redirect_uri: 'http://localhost/cb',
+        client_id: clientB.clientId,
+        client_secret: clientB.clientSecret,
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid_grant');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('SEC-F04b oauth-mode startup — refuses when DCR is disabled', () => {
+  it('throws when enableDynamicRegistration is false', () => {
+    const app = express();
+    expect(() =>
+      registerOAuthRoutes(app as Express, {
+        publicUrl: 'https://mcp.example.com',
+        tenantId: TENANT,
+        clientId: CLIENT_ID,
+        clientSecret: 'x',
+        scopes: [],
+        enableDynamicRegistration: false,
+        storage: new MemoryStorage(),
+      })
+    ).toThrow(/Dynamic Client Registration/);
+  });
+});

--- a/test/storage-memory.test.ts
+++ b/test/storage-memory.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { MemoryStorage } from '../src/storage/memory-storage.js';
+import { hashClientSecret, verifyClientSecret } from '../src/storage/oauth-storage.js';
+
+describe('MemoryStorage — PKCE bridge', () => {
+  it('stores and consumes a PKCE entry (one-shot)', async () => {
+    const store = new MemoryStorage();
+    await store.savePkce({
+      clientChallenge: 'abc',
+      serverVerifier: 'verifier',
+      redirectUri: 'http://localhost:3000/cb',
+      clientId: 'mcp-client-1',
+      expiresAt: Date.now() + 60_000,
+    });
+
+    const first = await store.consumePkce('abc');
+    expect(first?.serverVerifier).toBe('verifier');
+
+    const second = await store.consumePkce('abc');
+    expect(second).toBeNull();
+  });
+
+  it('returns null for expired entries and removes them on consume', async () => {
+    const store = new MemoryStorage();
+    await store.savePkce({
+      clientChallenge: 'stale',
+      serverVerifier: 'v',
+      redirectUri: 'http://localhost/cb',
+      clientId: 'c',
+      expiresAt: Date.now() - 1,
+    });
+    expect(await store.consumePkce('stale')).toBeNull();
+  });
+
+  it('returns null for unknown challenges', async () => {
+    const store = new MemoryStorage();
+    expect(await store.consumePkce('unknown')).toBeNull();
+  });
+});
+
+describe('MemoryStorage — DCR clients', () => {
+  it('round-trips a registered client', async () => {
+    const store = new MemoryStorage();
+    await store.saveClient({
+      clientId: 'mcp-client-42',
+      clientSecretHash: hashClientSecret('super-secret'),
+      redirectUris: ['http://localhost:3000/cb'],
+      createdAt: Date.now(),
+    });
+    const got = await store.getClient('mcp-client-42');
+    expect(got?.clientId).toBe('mcp-client-42');
+    expect(got?.redirectUris).toEqual(['http://localhost:3000/cb']);
+  });
+
+  it('returns null for unknown client_id', async () => {
+    const store = new MemoryStorage();
+    expect(await store.getClient('ghost')).toBeNull();
+  });
+});
+
+describe('client_secret hashing', () => {
+  it('produces a stable SHA-256 hex digest', () => {
+    const h1 = hashClientSecret('abc');
+    const h2 = hashClientSecret('abc');
+    expect(h1).toBe(h2);
+    expect(h1).toHaveLength(64);
+  });
+
+  it('verifyClientSecret accepts the correct secret', () => {
+    const secret = 'my-random-32-byte-secret-value';
+    const hash = hashClientSecret(secret);
+    expect(verifyClientSecret(secret, hash)).toBe(true);
+  });
+
+  it('verifyClientSecret rejects the wrong secret', () => {
+    const hash = hashClientSecret('correct');
+    expect(verifyClientSecret('wrong', hash)).toBe(false);
+  });
+
+  it('verifyClientSecret rejects malformed hashes without throwing', () => {
+    expect(verifyClientSecret('anything', 'tooshort')).toBe(false);
+    expect(verifyClientSecret('anything', '')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two architectural follow-ups left open by v0.3.0. Ships as **v0.4.0** — security hardening release.

- **SEC-F04b** (High, architectural follow-up to SEC-F04) — `/token` enforces per-client authentication (`client_secret_post` / `client_secret_basic`) on both `authorization_code` and `refresh_token` grants. `/register` issues a random 256-bit `client_secret` (SHA-256 hashed, `crypto.timingSafeEqual` compare). `/authorize` rejects unknown `client_id`s and binds the PKCE entry to the caller — cross-client code redemption blocked. A stolen refresh_token is no longer redeemable without the per-client secret.
- **SEC-F05** (Medium, architectural) — PKCE bridge + DCR credentials externalised to Azure Table Storage via `DefaultAzureCredential` (managed identity). Bicep provisions a hardened Storage Account + `oauthstate` table + role assignment. `maxReplicas` default restored to 3.

After this PR, **P1 is fully remediated** across the 2026-04-20 security review.

## Breaking changes

- MCP clients must re-run Dynamic Client Registration. The MCP SDK does this transparently at reconnect; users may need to re-authorise once.
- `--oauth-mode --no-dynamic-registration` now refuses to start (DCR is the issuance point for the per-client secret).
- Bicep `maxReplicas` default 1 → 3. Deployments running outside the shipped Bicep must provide `AZURE_STORAGE_ACCOUNT_NAME` or `AZURE_STORAGE_CONNECTION_STRING` (local dev / Azurite), otherwise the server falls back to in-process memory (safe only for stdio or single replica).

See [CHANGELOG.md](CHANGELOG.md) v0.4.0 for the full migration guide.

## What changed

- `src/storage/` — new `OAuthStorage` abstraction (`MemoryStorage` for tests/dev, `TableStorage` for prod). Atomic PKCE consume via `getEntity + deleteEntity(ETag)` with 412 handling.
- `src/oauth-proxy.ts` — confidential-client DCR, per-grant client auth, PKCE `client_id` binding, cross-client rejection, startup refusal when DCR disabled in oauth-mode.
- `infra/main.bicep` — Storage Account (Standard_LRS, `allowSharedKeyAccess:false`, `defaultToOAuthAuthentication:true`, TLS 1.2), `oauthstate` table, `Storage Table Data Contributor` → UAMI, env vars injected into the Container App.
- `docs/SECURITY_REVIEW_2026-04-20.md` — SEC-F04 → Fixed, new SEC-F04b Fixed entry, SEC-F05 → Fixed. P1 declared fully remediated.
- `docs/HTTP_DEPLOYMENT.md` — OAuth state storage section, `/register` description updated.
- `package.json` — 0.3.0 → 0.4.0, `@azure/data-tables ^13.3.2` added to `optionalDependencies`.

## Test plan

- [x] `npm run verify` clean (0 errors, 1 pre-existing warning on `src/logger.ts`)
- [x] 72/72 tests pass (18 new: storage contract, DCR issuance, `/authorize` client validation, `/token` body + Basic auth, cross-client PKCE rejection, oauth-mode startup refusal without DCR)
- [x] `az bicep build` clean
- [ ] Deploy to LCI tenant productive RG `rg-ms365admin-prod` via `az deployment group create` — expected: Storage Account provisioned, table created, UAMI role assignment, Container App revision bumped with new env vars
- [ ] End-to-end auth flow via Claude Web (DCR → `/authorize` → Entra → `/token` with `client_secret_post` → `/mcp` call)
- [ ] Verify stolen-refresh-token reuse: attempt `/token refresh_token` without `client_secret` → expect `401 invalid_client` (no upstream call to Entra)
- [ ] Verify multi-replica: bump `maxReplicas` to 3, confirm OAuth flow still works across instances (PKCE state in Azure Table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)