### PR TITLE
fix(auth): force prompt=select_account on /authorize — v0.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -228,9 +228,16 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     upstream.searchParams.set('code_challenge', serverChallenge);
     upstream.searchParams.set('code_challenge_method', 'S256');
     if (state) upstream.searchParams.set('state', state);
+    // Force Entra's account picker on every sign-in to prevent silent SSO
+    // reuse of a wrong account. Critical for multi-account admin workflows
+    // where a user has both a standard and an admin identity in the tenant.
+    // Note: ineffective against macOS Platform SSO extension in Safari/WebKit
+    // (the extension injects a PRT before Entra sees the prompt param) —
+    // use a non-WebKit browser (Chrome, Firefox) to bypass that layer.
+    upstream.searchParams.set('prompt', 'select_account');
 
     logger.info(
-      `OAuth /authorize → Entra (client=${clientId}, redirect_uri=${redirectUri}, scope=${upstreamScope})`
+      `OAuth /authorize → Entra (client=${clientId}, redirect_uri=${redirectUri}, scope=${upstreamScope}, prompt=select_account)`
     );
     res.redirect(302, upstream.toString());
   });

--- a/test/oauth-proxy.test.ts
+++ b/test/oauth-proxy.test.ts
@@ -160,6 +160,19 @@ describe('SEC-F04b /authorize — unknown client_id rejected', () => {
     const offlineCount = upstreamScope.filter((s) => s === 'offline_access').length;
     expect(offlineCount).toBe(1);
   });
+
+  it('forces prompt=select_account on the upstream authorize URL', async () => {
+    const { clientId } = await register();
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+    const res = await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(302);
+    const upstream = new URL(res.headers.get('location')!);
+    expect(upstream.searchParams.get('prompt')).toBe('select_account');
+  });
 });
 
 describe('SEC-F04b /token — client authentication required', () => {


### PR DESCRIPTION
## Summary

Force Entra's account picker on every OAuth flow by injecting `prompt=select_account` into the `/authorize` → Entra redirect. Prevents silent SSO from reusing a wrong cached account.

### Why

On multi-account tenants (admin personas with separate standard + admin identities), silent SSO can reuse the wrong cached account. This manifests as:
- `AADSTS50105 User not assigned to the application` when the cached account isn't in the Enterprise App assignment list
- Silent sign-in under the wrong UPN with a misleading audit trail (the user thinks they're acting as admin but the Graph calls show standard user identity)

`prompt=select_account` makes Entra always render the account picker, forcing the user to confirm their identity explicitly.

### Limitation — macOS Platform SSO

This patch does NOT bypass the Microsoft Enterprise SSO extension on macOS (Intune-managed Macs using Platform SSO). The extension intercepts OAuth flows at the OS level under Safari/WebKit apps, injects a device-bound PRT, and Entra never sees our `prompt` param. Workaround: admins whose account is not Intune-licensed (e.g., `adm.aad.*@tenant.onmicrosoft.com` at LCI) must use a non-WebKit browser (Chrome, Firefox) as their default for OAuth. Documented inline in the code comment.

## Changes

- [src/oauth-proxy.ts](../blob/claude/prompt-select-account/src/oauth-proxy.ts): +7 lines — `upstream.searchParams.set('prompt', 'select_account')` + inline comment explaining the Platform SSO caveat. Log line updated to surface the forced prompt.
- [test/oauth-proxy.test.ts](../blob/claude/prompt-select-account/test/oauth-proxy.test.ts): +13 lines — new test case asserting the upstream redirect contains `prompt=select_account`. All 12 OAuth-proxy tests pass locally.
- [package.json](../blob/claude/prompt-select-account/package.json): 0.5.1 → 0.5.2.

## Test plan

- [ ] `npm run test` — 12/12 OAuth-proxy tests green (verified locally)
- [ ] `npm run format:check` passes
- [ ] Post-deploy: flow OAuth in Claude Desktop with Chrome as default browser → Entra renders the account picker even when a cached session exists → admin can select their `adm.aad.*` identity
- [ ] Existing users with a single account see no regression (picker just lists one account — 1 click more)

## Follow-ups (not in this PR)

- Tag `v0.5.2` after merge so `release.yml` publishes `ghcr.io/okapi-ca/ms-365-admin-mcp-server:0.5.2`
- Marc re-deploys with `containerImage=ghcr.io/...:0.5.2` via `az deployment group create`
- Consider documenting the browser-choice constraint in [docs/AZURE_DEPLOYMENT_SECURITY.md](../blob/claude/prompt-select-account/docs/AZURE_DEPLOYMENT_SECURITY.md) as a post-deploy operator note

🤖 Generated with [Claude Code](https://claude.com/claude-code)