### PR TITLE
fix(auth): relax /token rate limit for device_code polling (v0.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.6.1] — 2026-04-23
+
+### Fixed — device_code polling hit /token rate limit before MFA could complete
+
+v0.6.0 shipped `/token`, `/register`, and `/devicecode` behind a single tight rate limiter (10 req/min). Observed in prod 2026-04-23T13:29Z during Marc's admin device_code bootstrap: the helper polled `/token` at Entra's advertised 5 s interval, hit the 10/min ceiling after ~50 s with `HTTP 429 invalid_request — Too many token requests`, and aborted before the user could complete Yubikey MFA. This made v0.6.0's device_code flow effectively unusable for interactive admin sign-in.
+
+Fix splits the `/token` limiter by `grant_type`:
+
+- **Tight (10 req/min)** — `authorization_code`, `refresh_token`, unknown / missing grants (safe default). Preserves the existing anti-brute-force posture for stolen codes / refresh tokens.
+- **Loose (60 req/min)** — `urn:ietf:params:oauth:grant-type:device_code`. RFC 8628 §3.5 mandates polling at the server-provided `interval`; Entra returns 5 s → 12 req/min per legitimate bootstrap. 60/min = 1 req/sec average, still bounds brute-force since device codes are high-entropy and `/devicecode` itself stays tight at 10/min.
+
+Limiter setup extracted into `src/oauth-rate-limiters.ts` for isolated testing (no transitive MCP SDK / JWKS imports).
+
+Tests: 6 new (`test/oauth-rate-limit.test.ts`), 100 total.
+
 ## [0.6.0] — 2026-04-23
 
 ### Added — device_code OAuth flow (RFC 8628)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -2,11 +2,12 @@ import express from 'express';
 import type { Request, Response, NextFunction } from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import rateLimit from 'express-rate-limit';
 import logger from './logger.js';
 import { validateEntraToken, type TokenValidatorOptions } from './token-validator.js';
 import { validateUserToken, type UserTokenValidatorOptions } from './user-token-validator.js';
 import { registerOAuthRoutes, type OAuthProxyOptions } from './oauth-proxy.js';
+import { registerOAuthRateLimiters } from './oauth-rate-limiters.js';
+import rateLimit from 'express-rate-limit';
 
 export interface HttpServerOptions {
   port: number;
@@ -63,33 +64,12 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
 
   if (options.oauthProxyOptions) {
     // SEC-F06: OAuth surface is public and must be rate-limited independently
-    // of /mcp. /token is the tightest (brute-forcing auth codes / refresh tokens
-    // lives here); /authorize is looser because it's a user-initiated redirect.
-    app.use(
-      '/authorize',
-      rateLimit({
-        windowMs: 60_000,
-        max: 30,
-        standardHeaders: true,
-        legacyHeaders: false,
-        message: { error: 'invalid_request', error_description: 'Too many authorize requests' },
-      })
-    );
-    const tokenLimiter = rateLimit({
-      windowMs: 60_000,
-      max: 10,
-      standardHeaders: true,
-      legacyHeaders: false,
-      message: { error: 'invalid_request', error_description: 'Too many token requests' },
-    });
-    app.use('/token', tokenLimiter);
-    app.use('/register', tokenLimiter);
-    // /devicecode issues upstream device_codes on behalf of a DCR client;
-    // same blast radius as /token, so it shares the tight limiter.
-    app.use('/devicecode', tokenLimiter);
+    // of /mcp. Limiter setup lives in registerOAuthRateLimiters for
+    // testability — see that function's docstring for the per-route policy.
+    registerOAuthRateLimiters(app);
     registerOAuthRoutes(app, options.oauthProxyOptions);
     logger.info(
-      'OAuth proxy routes enabled (/authorize, /token, /devicecode, DCR, metadata) with rate limits'
+      'OAuth proxy routes enabled (/authorize, /token [split by grant_type], /devicecode, DCR, metadata) with rate limits'
     );
   }
 

--- a/src/oauth-rate-limiters.ts
+++ b/src/oauth-rate-limiters.ts
@@ -1,0 +1,69 @@
+import type { Express, Request, Response, NextFunction } from 'express';
+import rateLimit from 'express-rate-limit';
+
+const DEVICE_CODE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
+
+/**
+ * Installs the OAuth surface rate limiters on `/authorize`, `/token`,
+ * `/register`, and `/devicecode`. Kept in its own module (no transitive
+ * imports of the MCP SDK or JWKS stack) so tests can exercise the split
+ * without loading the entire server.
+ *
+ * Split policy on /token, by `grant_type`:
+ *  - Tight (10 req/min): `authorization_code` + `refresh_token`.
+ *    One-shot per auth flow, high volume = brute-force suspect.
+ *  - Loose (60 req/min): `urn:ietf:params:oauth:grant-type:device_code`.
+ *    RFC 8628 §3.5 requires clients to poll at the server-provided
+ *    `interval` (Entra returns 5 s → 12 req/min/bootstrap). The tight
+ *    10/min cap broke the flow before MFA could complete — observed in
+ *    prod on v0.6.0 (Marc's admin bootstrap, 2026-04-23T13:29Z).
+ *    60/min = 1 req/sec average, still bounds brute-force: device_codes
+ *    are high-entropy (Entra issues 32+ char random values), /devicecode
+ *    itself stays tight at 10/min, and codes expire in 15 min regardless.
+ *
+ *  Fallback: unknown / missing grant_type → tight limiter (safe default).
+ *
+ *  Must be called AFTER `express.urlencoded()` / `express.json()` so
+ *  req.body is populated when the middleware inspects grant_type.
+ */
+export function registerOAuthRateLimiters(app: Express): void {
+  app.use(
+    '/authorize',
+    rateLimit({
+      windowMs: 60_000,
+      max: 30,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: { error: 'invalid_request', error_description: 'Too many authorize requests' },
+    })
+  );
+  const tokenTightLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'invalid_request', error_description: 'Too many token requests' },
+  });
+  const tokenDevicePollLimiter = rateLimit({
+    windowMs: 60_000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: {
+      error: 'invalid_request',
+      error_description: 'Too many device_code poll requests',
+    },
+  });
+  app.use('/token', (req: Request, res: Response, next: NextFunction) => {
+    const grantType = typeof req.body?.grant_type === 'string' ? req.body.grant_type : '';
+    if (grantType === DEVICE_CODE_GRANT) {
+      tokenDevicePollLimiter(req, res, next);
+      return;
+    }
+    tokenTightLimiter(req, res, next);
+  });
+  app.use('/register', tokenTightLimiter);
+  // /devicecode issues upstream device_codes and is called once per
+  // bootstrap — tight limiter is correct here.
+  app.use('/devicecode', tokenTightLimiter);
+}

--- a/test/oauth-rate-limit.test.ts
+++ b/test/oauth-rate-limit.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import express from 'express';
+import type { Express, Server } from 'http';
+import { registerOAuthRoutes, type OAuthProxyOptions } from '../src/oauth-proxy.js';
+import { registerOAuthRateLimiters } from '../src/oauth-rate-limiters.js';
+import { MemoryStorage } from '../src/storage/memory-storage.js';
+
+// Regression test for the v0.6.1 fix:
+// v0.6.0 shipped a shared tight rate limiter (10 req/min) on /token that
+// killed RFC 8628 device_code polling before MFA could complete — Marc's
+// admin bootstrap hit 429 at ~50 s on prod 2026-04-23. The fix splits the
+// limiter by grant_type so device_code (60/min) doesn't share the counter
+// with authorization_code / refresh_token (10/min).
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const CLIENT_ID = '22222222-2222-2222-2222-222222222222';
+const DEVICE_CODE_GRANT = 'urn:ietf:params:oauth:grant-type:device_code';
+
+async function buildServer(): Promise<{ url: string; server: Server }> {
+  const app = express();
+  app.use(express.json({ limit: '100kb' }));
+  app.use(express.urlencoded({ extended: true, limit: '100kb' }));
+  // Apply the rate limiters exactly the way startHttpServer does, then
+  // register the OAuth routes on top.
+  registerOAuthRateLimiters(app as Express);
+  const options: OAuthProxyOptions = {
+    publicUrl: 'https://mcp.example.com',
+    tenantId: TENANT,
+    clientId: CLIENT_ID,
+    clientSecret: 'upstream-entra-secret',
+    scopes: ['openid', 'profile', 'email', 'offline_access', `api://${CLIENT_ID}/access_as_user`],
+    enableDynamicRegistration: true,
+    storage: new MemoryStorage(),
+  };
+  registerOAuthRoutes(app as Express, options);
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (addr && typeof addr === 'object') {
+        resolve({ url: `http://127.0.0.1:${addr.port}`, server });
+      }
+    });
+  });
+}
+
+let baseUrl: string;
+let server: Server;
+
+beforeAll(async () => {
+  const built = await buildServer();
+  baseUrl = built.url;
+  server = built.server;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+beforeEach(() => {
+  // Each test gets a fresh window by recreating the server is heavy — we
+  // rely on the fact that express-rate-limit uses an in-process store that
+  // we reset between tests by restarting the server. For most tests the
+  // counters reset naturally because different grant_types land on
+  // different limiters, and the test count stays below each limit's cap.
+});
+
+async function postToken(body: Record<string, string>): Promise<Response> {
+  return fetch(`${baseUrl}/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams(body).toString(),
+  });
+}
+
+describe('v0.6.1 /token rate limiter — split by grant_type', () => {
+  // The key correctness claim: a device_code poll cadence that USED to
+  // fail after 10 requests now succeeds for at least 15. We use a fresh
+  // server for this test to start from an empty limiter window.
+  it('allows 20 device_code polls without hitting 429 (was broken at 11 in v0.6.0)', async () => {
+    // Fresh server so the limiter window starts empty.
+    const { url: freshUrl, server: freshServer } = await buildServer();
+    try {
+      const responses: number[] = [];
+      for (let i = 0; i < 20; i++) {
+        const res = await fetch(`${freshUrl}/token`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: DEVICE_CODE_GRANT,
+            device_code: `poll-${i}`,
+            client_id: 'fake',
+            client_secret: 'fake',
+          }).toString(),
+        });
+        responses.push(res.status);
+        // We don't care about the response body — the limiter decides first.
+        // Expected status is 401 (invalid_client) since we're using fake
+        // credentials; the key is that none should be 429.
+      }
+      const rateLimited = responses.filter((s) => s === 429);
+      expect(rateLimited).toHaveLength(0);
+      // All should be 401 invalid_client — the device_code limiter let them
+      // through and the downstream proxy rejected unknown creds.
+      expect(responses.every((s) => s === 401)).toBe(true);
+    } finally {
+      freshServer.close();
+    }
+  });
+
+  it('still rate-limits refresh_token after 10 requests (existing blast radius preserved)', async () => {
+    const { url: freshUrl, server: freshServer } = await buildServer();
+    try {
+      const responses: number[] = [];
+      for (let i = 0; i < 12; i++) {
+        const res = await fetch(`${freshUrl}/token`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: `stolen-${i}`,
+            client_id: 'fake',
+            client_secret: 'fake',
+          }).toString(),
+        });
+        responses.push(res.status);
+      }
+      // First 10 should get past the limiter (returning 401 invalid_client),
+      // subsequent ones should hit 429.
+      const rateLimited = responses.filter((s) => s === 429);
+      expect(rateLimited.length).toBeGreaterThanOrEqual(1);
+      expect(rateLimited.length).toBeLessThanOrEqual(2);
+      // The first response must not be 429 — the limiter should let the
+      // first request through regardless.
+      expect(responses[0]).toBe(401);
+    } finally {
+      freshServer.close();
+    }
+  });
+
+  it('still rate-limits authorization_code after 10 requests (existing blast radius preserved)', async () => {
+    const { url: freshUrl, server: freshServer } = await buildServer();
+    try {
+      const responses: number[] = [];
+      for (let i = 0; i < 12; i++) {
+        const res = await fetch(`${freshUrl}/token`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'authorization_code',
+            code: `stolen-${i}`,
+            code_verifier: 'x',
+            redirect_uri: 'http://localhost/cb',
+            client_id: 'fake',
+            client_secret: 'fake',
+          }).toString(),
+        });
+        responses.push(res.status);
+      }
+      expect(responses.filter((s) => s === 429).length).toBeGreaterThanOrEqual(1);
+    } finally {
+      freshServer.close();
+    }
+  });
+
+  it('routes mixed grants to independent counters (device_code polls while refresh_token is throttled)', async () => {
+    const { url: freshUrl, server: freshServer } = await buildServer();
+    try {
+      // Burn through the refresh_token limiter: 11 calls, last one should 429.
+      for (let i = 0; i < 11; i++) {
+        await fetch(`${freshUrl}/token`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: 'x',
+            client_id: 'fake',
+            client_secret: 'fake',
+          }).toString(),
+        });
+      }
+      // Confirm refresh_token is now rate-limited.
+      const rtRes = await fetch(`${freshUrl}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: 'refresh_token',
+          refresh_token: 'x',
+          client_id: 'fake',
+          client_secret: 'fake',
+        }).toString(),
+      });
+      expect(rtRes.status).toBe(429);
+
+      // But a device_code poll on the SAME connection (same IP) should
+      // still succeed — independent limiter.
+      const dcRes = await fetch(`${freshUrl}/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          grant_type: DEVICE_CODE_GRANT,
+          device_code: 'x',
+          client_id: 'fake',
+          client_secret: 'fake',
+        }).toString(),
+      });
+      expect(dcRes.status).toBe(401); // invalid_client, NOT 429
+    } finally {
+      freshServer.close();
+    }
+  });
+
+  it('falls back to tight limiter for unknown / missing grant_type (safe default)', async () => {
+    const { url: freshUrl, server: freshServer } = await buildServer();
+    try {
+      const responses: number[] = [];
+      for (let i = 0; i < 12; i++) {
+        // No grant_type at all — must get routed to the tight limiter.
+        const res = await fetch(`${freshUrl}/token`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: '',
+        });
+        responses.push(res.status);
+      }
+      expect(responses.filter((s) => s === 429).length).toBeGreaterThanOrEqual(1);
+    } finally {
+      freshServer.close();
+    }
+  });
+});
+
+describe('v0.6.1 /devicecode rate limiter — unchanged (still tight)', () => {
+  it('rate-limits /devicecode after 10 requests (one-shot per bootstrap)', async () => {
+    const { url: freshUrl, server: freshServer } = await buildServer();
+    try {
+      const responses: number[] = [];
+      for (let i = 0; i < 12; i++) {
+        const res = await fetch(`${freshUrl}/devicecode`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: new URLSearchParams({ client_id: 'fake', client_secret: 'fake' }).toString(),
+        });
+        responses.push(res.status);
+      }
+      expect(responses.filter((s) => s === 429).length).toBeGreaterThanOrEqual(1);
+    } finally {
+      freshServer.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

v0.6.0 shipped an RFC 8628 device_code flow but applied a shared tight rate limiter (10 req/min) on `/token`. Entra returns `interval: 5` in its device authorization response, so clients polling at the advertised cadence hit 12 req/min — the limiter killed every legitimate admin bootstrap before MFA could complete.

**Observed in prod 2026-04-23T13:29Z**: my own admin device_code bootstrap via `ms-365-admin-mcp-auth` aborted with `HTTP 429 invalid_request — Too many token requests` ~50 s after the code was issued, before I could finish Yubikey MFA. v0.6.0's device_code flow was practically unusable for interactive sign-in.

## Fix

Split the `/token` rate limiter by `grant_type`:

| Grant type | Limit | Rationale |
|---|---|---|
| `authorization_code`, `refresh_token`, unknown/missing | 10 req/min | Existing anti-brute-force posture — one-shot per auth flow |
| `urn:ietf:params:oauth:grant-type:device_code` | 60 req/min | RFC 8628 §3.5 polling cadence; 1 req/sec still bounds brute-force given device code entropy + `/devicecode` stays tight at 10/min + 15 min TTL |

`/register` and `/devicecode` stay at tight 10/min (one-shot per bootstrap, not polled).

Rate-limiter setup extracted into `src/oauth-rate-limiters.ts` so the logic can be tested without loading the full MCP SDK + JWKS stack that transitively imports from `http-server.ts`.

## Tests

**6 new / 100 total**, all passing:

- 20 device_code polls succeed (was failing at 11 in v0.6.0)
- `refresh_token` still rate-limits at 10/min
- `authorization_code` still rate-limits at 10/min
- Independent counters: device_code succeeds even when `refresh_token` is already throttled from the same IP
- Unknown/missing `grant_type` falls through to tight limiter (safe default)
- `/devicecode` itself remains tight

## Test plan

- [x] `npm run verify` green locally (100/100 tests)
- [ ] CI `verify` green on PR
- [ ] After merge + release: `az containerapp update --name ca-cc-mcpms365admin-p --resource-group RG_CanadaCentral_MCPms365admin_Load --image ghcr.io/okapi-ca/ms-365-admin-mcp-server:0.6.1`
- [ ] End-to-end smoke: Jihane runs `ms-365-admin-mcp-auth` bootstrap from her Windows laptop (WAM-backed Edge blocks the browser flow, so device_code is her primary path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)