### PR TITLE
ci(release): add workflow_dispatch fallback for missed tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,14 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual dispatch as a fallback when GitHub misses a tag push event.
+  # Observed 2026-04-23 with v0.6.1: `git push origin v0.6.1` succeeded,
+  # tag present on remote, but no CreateEvent / workflow trigger fired
+  # even after delete+re-push. Dispatch from a tag ref with:
+  #   gh workflow run release.yml --ref v0.6.1
+  # GITHUB_REF_NAME resolves to the tag name, so the existing release-body
+  # logic (`TAG="${GITHUB_REF_NAME}"`) keeps working unchanged.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Observed 2026-04-23 pushing v0.6.1: the tag push event never reached the GitHub Actions dispatcher. \`git push origin v0.6.1\` returned success, the tag is visible via \`git ls-remote\` and in the commit graph, yet no CreateEvent / workflow trigger fired in the repo's events feed — even after a delete + re-push. The release workflow never started, leaving v0.6.1 unpublished on npm and GHCR despite the tag existing.

Adding \`workflow_dispatch\` gives a manual fallback without changing the happy path:

\`\`\`bash
gh workflow run release.yml --ref v0.6.1
\`\`\`

When dispatched with \`--ref <tag>\`, \`GITHUB_REF_NAME\` resolves to the tag name, so the existing \`TAG=\"\${GITHUB_REF_NAME}\"\` line in the github-release job produces the right release title and body unchanged.

## Test plan

- [x] YAML syntax valid (GHA schema-compliant)
- [ ] After merge: dispatch v0.6.1 via \`gh workflow run release.yml --ref v0.6.1\`
- [ ] Future tag pushes continue to auto-trigger via the push:tags filter

Additional value: this pattern is useful any time a workflow needs to be re-run for a specific tag (e.g. flaky publish-docker step that needs a clean retry without cutting a new version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)