### PR TITLE
docs(setup): Windows device code setup guides (EN + FR)

### DIFF
--- a/docs/SETUP_WINDOWS_EN.md
+++ b/docs/SETUP_WINDOWS_EN.md
@@ -1,0 +1,198 @@
+# MS 365 Admin MCP — Windows setup guide (device code flow)
+
+Connect Claude Desktop on your Windows admin laptop to the LCI `ms-365-admin` MCP server so you can query M365 security, audit, users, groups, Intune, and Defender data through natural-language prompts.
+
+**Who this is for:** LCI tenant admins with an `adm.aad.*@lcieducation.onmicrosoft.com` account. If your admin account isn't in the allowlist (`--authorized-users` oids configured by Marc), ask him before starting.
+
+**Why device code:** on Windows, Edge / Chrome / Firefox all get intercepted by Microsoft's WAM broker (Web Account Manager). The standard browser-based OAuth flow won't complete. Device code flow bypasses the browser entirely — you authenticate on your phone or another device.
+
+---
+
+## Prerequisites
+
+| Item                                 | How to verify                                            | If missing                                                                      |
+| ------------------------------------ | -------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Claude Desktop                       | `Start > Claude` opens                                   | Install from https://claude.ai/download                                         |
+| Node.js 18+                          | `node --version` in PowerShell                           | Install from https://nodejs.org (LTS) or via `winget install OpenJS.NodeJS.LTS` |
+| Microsoft Authenticator (or Yubikey) | Your admin account MFA is already enrolled               | Ask IT if MFA setup is incomplete                                               |
+| Your admin account credentials       | `adm.aad.<your-name>@lcieducation.onmicrosoft.com` + MFA | —                                                                               |
+
+---
+
+## Step 1 — Configure Claude Desktop
+
+Open PowerShell and run:
+
+```powershell
+notepad "$env:APPDATA\Claude\claude_desktop_config.json"
+```
+
+If the file doesn't exist yet, Notepad asks to create it — say yes. Paste this content (replace anything already there):
+
+```json
+{
+  "mcpServers": {
+    "ms-365-admin": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp"
+      ]
+    }
+  }
+}
+```
+
+Save (Ctrl+S) and close Notepad.
+
+---
+
+## Step 2 — Run the device code bootstrap
+
+In PowerShell, run:
+
+```powershell
+# Make sure you're NOT inside a Node project folder (avoid local node_modules interference)
+cd $env:USERPROFILE
+
+npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth `
+  --server https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp
+```
+
+(The backtick `` ` `` is PowerShell's line-continuation character. If you prefer a single line, remove the `` ` `` and put everything on one line.)
+
+You'll see output similar to:
+
+```
+Discovering OAuth metadata at https://ca-cc-mcpms365admin-p…
+Registering a fresh DCR client…
+Requesting a device code…
+
+────────────────────────────────────────────────────────────
+ Microsoft 365 Admin MCP — device code authentication
+────────────────────────────────────────────────────────────
+ 1. Open https://microsoft.com/devicelogin
+ 2. Enter code: XXXX-XXXX   (copied to clipboard)
+ Waiting for authentication… (timeout 15 min)
+────────────────────────────────────────────────────────────
+```
+
+The user code is **copied to your clipboard automatically**.
+
+---
+
+## Step 3 — Authenticate on your phone
+
+1. On your phone (or any device with a working browser), go to **https://microsoft.com/devicelogin**
+2. Enter the code shown in your PowerShell window (it's already in your clipboard — paste with Ctrl+V on a laptop, or the paste action on your phone).
+3. Sign in with your admin account: **adm.aad.\<your-name\>@lcieducation.onmicrosoft.com**
+4. Complete MFA (Authenticator app push or Yubikey).
+5. Confirm the consent screen if shown.
+
+Back in PowerShell, you'll see:
+
+```
+Authentication complete.
+  cache dir:   C:\Users\<you>\.mcp-auth\mcp-remote-0.1.38
+  client info: …_client_info.json
+  tokens:      …_tokens.json
+
+Restart Claude Desktop / Claude Code — mcp-remote will reuse these tokens.
+```
+
+---
+
+## Step 4 — Restart Claude Desktop and test
+
+1. Quit Claude Desktop completely (right-click the tray icon → Quit, or kill it via Task Manager).
+2. Launch Claude Desktop from the Start menu.
+3. In a new conversation, try a test prompt:
+
+   > List the 5 most recent Defender security alerts.
+
+   Claude should answer using the `list-security-alerts` tool from the `ms-365-admin` MCP.
+
+---
+
+## Reset / re-authenticate (first thing to try when something breaks)
+
+If Claude Desktop shows "Server disconnected", tool calls fail with auth errors, or you changed account and want to re-authenticate, wipe the token cache and re-run the bootstrap:
+
+```powershell
+# 1. Quit Claude Desktop completely (tray icon → Quit, or Task Manager)
+
+# 2. Delete the authentication cache
+Remove-Item -Recurse -Force "$env:USERPROFILE\.mcp-auth\mcp-remote-*"
+
+# 3. (Only if npx itself misbehaves — e.g. "command not found" errors)
+Remove-Item -Recurse -Force "$env:USERPROFILE\.npm\_npx"
+
+# 4. Re-run the bootstrap (Step 2 above)
+cd $env:USERPROFILE
+npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth `
+  --server https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp
+
+# 5. Re-launch Claude Desktop
+```
+
+This is safe — no data is lost. The cache only holds OAuth tokens; deleting it just forces a fresh authentication on next startup.
+
+Common situations that require a reset:
+
+- You see old data or get errors after a server upgrade
+- You changed your admin password or re-registered MFA
+- Your refresh token expired (Entra rotates them periodically)
+- Claude Desktop was closed while in the middle of an auth flow
+
+---
+
+## Troubleshooting
+
+**`ms-365-admin-mcp-auth: command not found`**
+You're running from a folder that has its own `node_modules`. Go to your home directory first (`cd $env:USERPROFILE`) and retry.
+
+**The bootstrap prints `429 Too many token requests`**
+This was a bug in v0.6.0 — if you see it, confirm you're using v0.6.1 or later: `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@0.6.1" …`
+
+**Claude Desktop shows "Server disconnected" after restart**
+Check that tokens were actually written:
+
+```powershell
+dir $env:USERPROFILE\.mcp-auth\mcp-remote-*\
+```
+
+If there's no `*_tokens.json` file, the bootstrap didn't complete. Run it again.
+
+**`AADSTS50105: Your account is not assigned to a role for the application`**
+Your admin oid isn't in the server's `--authorized-users` list. Contact Marc to add it.
+
+**Everything else**
+Collect:
+
+- `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth --help` output
+- Contents of `%USERPROFILE%\.mcp-auth\mcp-remote-*\` (redact token values)
+- Recent Claude Desktop log: `%APPDATA%\Claude\Logs\mcp-server-ms-365-admin.log`
+
+Ping Marc with the above.
+
+---
+
+## What this MCP can do
+
+Read-only by default. Covers:
+
+- **Security**: Defender alerts and incidents, Identity Protection risky users, Secure Score, attack simulations, threat intelligence.
+- **Audit**: directory audits, sign-ins, provisioning logs, deleted items.
+- **Identity**: users, groups, directory roles, PIM eligible/active assignments, Conditional Access policies.
+- **Intune**: managed devices, compliance policies, device configurations, app protection.
+- **Organization**: subscribed SKUs (licenses), service health, usage reports.
+
+Full tool list: `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-server --list-tools` — but you'll typically just ask Claude natural-language questions.
+
+## Security notes
+
+- Tokens are cached in `%USERPROFILE%\.mcp-auth\` and only readable by your Windows user.
+- The MCP runs in read-only mode by default — no mutations possible from Claude.
+- Your admin actions are audited in Entra + Purview as if you made them yourself (OBO delegated flow).
+- If you leave LCI or change roles, Marc revokes your oid from `--authorized-users` server-side.

--- a/docs/SETUP_WINDOWS_FR.md
+++ b/docs/SETUP_WINDOWS_FR.md
@@ -1,0 +1,198 @@
+# MS 365 Admin MCP — Guide d'installation Windows (flux device code)
+
+Connecte Claude Desktop sur ton laptop admin Windows au serveur MCP `ms-365-admin` LCI pour interroger les données M365 sécurité, audit, utilisateurs, groupes, Intune et Defender en langage naturel.
+
+**À qui ce guide s'adresse :** admins du tenant LCI avec un compte `adm.aad.*@lcieducation.onmicrosoft.com`. Si ton compte admin n'est pas dans la liste d'autorisation (oids `--authorized-users` configurés par Marc), demande-lui avant de commencer.
+
+**Pourquoi device code :** sur Windows, Edge / Chrome / Firefox se font tous intercepter par le broker WAM (Web Account Manager) de Microsoft. Le flux OAuth standard via navigateur n'aboutit pas. Le device code contourne complètement le navigateur — tu t'authentifies sur ton téléphone ou un autre appareil.
+
+---
+
+## Prérequis
+
+| Élément                              | Comment vérifier                                       | Si absent                                                                           |
+| ------------------------------------ | ------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| Claude Desktop                       | `Démarrer > Claude` l'ouvre                            | Installer depuis https://claude.ai/download                                         |
+| Node.js 18+                          | `node --version` dans PowerShell                       | Installer depuis https://nodejs.org (LTS) ou via `winget install OpenJS.NodeJS.LTS` |
+| Microsoft Authenticator (ou Yubikey) | Ton compte admin a déjà MFA activée                    | Voir avec IT si MFA pas encore configurée                                           |
+| Identifiants admin                   | `adm.aad.<ton-nom>@lcieducation.onmicrosoft.com` + MFA | —                                                                                   |
+
+---
+
+## Étape 1 — Configurer Claude Desktop
+
+Ouvre PowerShell et lance :
+
+```powershell
+notepad "$env:APPDATA\Claude\claude_desktop_config.json"
+```
+
+Si le fichier n'existe pas, Notepad propose de le créer — accepte. Colle ce contenu (remplace tout ce qui s'y trouve déjà) :
+
+```json
+{
+  "mcpServers": {
+    "ms-365-admin": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp"
+      ]
+    }
+  }
+}
+```
+
+Sauvegarde (Ctrl+S) et ferme Notepad.
+
+---
+
+## Étape 2 — Lancer le bootstrap device code
+
+Dans PowerShell :
+
+```powershell
+# Sortir de tout dossier projet Node pour éviter les conflits avec un node_modules local
+cd $env:USERPROFILE
+
+npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth `
+  --server https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp
+```
+
+(Le backtick `` ` `` est le caractère de continuation de ligne PowerShell. Si tu préfères une seule ligne, supprime le `` ` `` et mets tout sur une ligne.)
+
+Tu verras une sortie du style :
+
+```
+Discovering OAuth metadata at https://ca-cc-mcpms365admin-p…
+Registering a fresh DCR client…
+Requesting a device code…
+
+────────────────────────────────────────────────────────────
+ Microsoft 365 Admin MCP — device code authentication
+────────────────────────────────────────────────────────────
+ 1. Open https://microsoft.com/devicelogin
+ 2. Enter code: XXXX-XXXX   (copied to clipboard)
+ Waiting for authentication… (timeout 15 min)
+────────────────────────────────────────────────────────────
+```
+
+Le code utilisateur est **automatiquement copié dans ton presse-papier**.
+
+---
+
+## Étape 3 — T'authentifier sur ton téléphone
+
+1. Sur ton téléphone (ou tout appareil avec un navigateur fonctionnel), va sur **https://microsoft.com/devicelogin**
+2. Saisis le code affiché dans PowerShell (il est déjà dans ton presse-papier — colle avec Ctrl+V sur laptop, ou l'action coller sur mobile).
+3. Connecte-toi avec ton compte admin : **adm.aad.\<ton-nom\>@lcieducation.onmicrosoft.com**
+4. Complète MFA (notification Authenticator app ou Yubikey).
+5. Confirme l'écran de consentement si affiché.
+
+De retour dans PowerShell, tu verras :
+
+```
+Authentication complete.
+  cache dir:   C:\Users\<toi>\.mcp-auth\mcp-remote-0.1.38
+  client info: …_client_info.json
+  tokens:      …_tokens.json
+
+Restart Claude Desktop / Claude Code — mcp-remote will reuse these tokens.
+```
+
+---
+
+## Étape 4 — Redémarrer Claude Desktop et tester
+
+1. Quitte Claude Desktop complètement (clic droit sur l'icône de la zone de notifications → Quitter, ou via le gestionnaire de tâches).
+2. Relance Claude Desktop depuis le menu Démarrer.
+3. Dans une nouvelle conversation, essaie ce prompt test :
+
+   > Liste-moi les 5 dernières alertes de sécurité Defender.
+
+   Claude devrait répondre en utilisant l'outil `list-security-alerts` du MCP `ms-365-admin`.
+
+---
+
+## Réinitialiser / ré-authentifier (premier réflexe en cas de problème)
+
+Si Claude Desktop affiche "Server disconnected", si les appels d'outils échouent avec des erreurs d'authentification, ou si tu as changé de compte et veux te ré-authentifier, efface le cache de tokens et relance le bootstrap :
+
+```powershell
+# 1. Quitte Claude Desktop complètement (icône systray → Quitter, ou gestionnaire de tâches)
+
+# 2. Supprime le cache d'authentification
+Remove-Item -Recurse -Force "$env:USERPROFILE\.mcp-auth\mcp-remote-*"
+
+# 3. (Seulement si npx lui-même pose problème — ex. erreurs "command not found")
+Remove-Item -Recurse -Force "$env:USERPROFILE\.npm\_npx"
+
+# 4. Relance le bootstrap (Étape 2 ci-dessus)
+cd $env:USERPROFILE
+npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth `
+  --server https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp
+
+# 5. Relance Claude Desktop
+```
+
+C'est sans danger — aucune donnée n'est perdue. Le cache ne contient que des tokens OAuth ; l'effacer force simplement une ré-authentification au prochain démarrage.
+
+Situations courantes nécessitant une réinitialisation :
+
+- Données anciennes ou erreurs après une mise à jour du serveur
+- Tu as changé ton mot de passe admin ou re-enregistré MFA
+- Ton refresh token a expiré (Entra les fait tourner périodiquement)
+- Claude Desktop a été fermé en plein milieu d'un flux d'authentification
+
+---
+
+## Dépannage
+
+**`ms-365-admin-mcp-auth: command not found`**
+Tu es dans un dossier qui a son propre `node_modules`. Va d'abord dans ton dossier personnel (`cd $env:USERPROFILE`) et réessaie.
+
+**Le bootstrap affiche `429 Too many token requests`**
+C'était un bug en v0.6.0 — si tu vois ça, vérifie que tu utilises bien v0.6.1 ou plus récent : `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@0.6.1" …`
+
+**Claude Desktop affiche "Server disconnected" après redémarrage**
+Vérifie que les tokens ont bien été écrits :
+
+```powershell
+dir $env:USERPROFILE\.mcp-auth\mcp-remote-*\
+```
+
+S'il n'y a pas de fichier `*_tokens.json`, le bootstrap n'a pas abouti. Relance-le.
+
+**`AADSTS50105: Your account is not assigned to a role for the application`**
+Ton oid admin n'est pas dans la liste `--authorized-users` du serveur. Contacte Marc pour l'ajouter.
+
+**Autre problème**
+Récupère :
+
+- La sortie de `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth --help`
+- Le contenu de `%USERPROFILE%\.mcp-auth\mcp-remote-*\` (masque les valeurs des tokens)
+- Le log récent de Claude Desktop : `%APPDATA%\Claude\Logs\mcp-server-ms-365-admin.log`
+
+Et envoie à Marc.
+
+---
+
+## Ce que le MCP peut faire
+
+Lecture seule par défaut. Couvre :
+
+- **Sécurité** : alertes et incidents Defender, utilisateurs à risque Identity Protection, Secure Score, simulations d'attaque, threat intelligence.
+- **Audit** : journaux d'audit du répertoire, connexions, journaux de provisionnement, éléments supprimés.
+- **Identité** : utilisateurs, groupes, rôles du répertoire, assignations PIM éligibles/actives, stratégies d'accès conditionnel.
+- **Intune** : appareils gérés, stratégies de conformité, configurations d'appareils, protection des applications.
+- **Organisation** : SKUs souscrits (licences), intégrité des services, rapports d'utilisation.
+
+Liste complète des outils : `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-server --list-tools` — mais en pratique tu vas juste poser des questions en langage naturel à Claude.
+
+## Notes de sécurité
+
+- Les tokens sont en cache dans `%USERPROFILE%\.mcp-auth\` et lisibles uniquement par ton utilisateur Windows.
+- Le MCP tourne en mode lecture seule par défaut — aucune modification possible depuis Claude.
+- Tes actions admin sont auditées dans Entra + Purview comme si tu les avais faites toi-même (flux OBO délégué).
+- Si tu quittes LCI ou changes de rôle, Marc révoque ton oid de `--authorized-users` côté serveur.


### PR DESCRIPTION
## Summary

Step-by-step install guides for LCI tenant admins to set up Claude Desktop + `ms-365-admin` MCP on Windows. Targeted audience: **Saad Tariq (EN)** and **Jihane Lahmar (FR)** initially; extensible to any new admin added to `--authorized-users`.

**Why these guides exist:** on Windows, the standard authorization_code + PKCE flow is intercepted by Microsoft's WAM broker regardless of browser (Edge, Chrome, Firefox all affected). Device code flow — shipped in v0.6.0 and fixed in v0.6.1 (rate limiter) — is the reliable path. Users authenticate on their phone or another device, and `mcp-remote` picks up the cached tokens on next Claude Desktop launch.

## Files

- `docs/SETUP_WINDOWS_EN.md` — for Saad
- `docs/SETUP_WINDOWS_FR.md` — for Jihane

Both files share an identical 9-section structure for easy side-by-side translation review:

1. Who this is for + why device code (not browser flow)
2. Prerequisites (Claude Desktop, Node 18+, MFA enrolled, admin creds)
3. Step 1 — Claude Desktop config (`%APPDATA%\Claude\claude_desktop_config.json`)
4. Step 2 — Device code bootstrap (PowerShell with backtick line continuation)
5. Step 3 — Authenticate on phone via `microsoft.com/devicelogin`
6. Step 4 — Restart Claude Desktop + test prompt (`list security alerts`)
7. **Reset / re-authenticate** — first reflex when anything breaks (purge `~\.mcp-auth\`)
8. Troubleshooting — 4 common errors mapped to solutions, plus what to collect for Marc
9. What the MCP can do + security notes (read-only default, OBO audit trail, revocation)

## Requires v0.6.1 on npm + ACA

The guides use `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth` which pulls v0.6.1. v0.6.0's rate limiter bug would kill any bootstrap at ~50 s with HTTP 429. Release is in flight (PR #60 merged, tag v0.6.1 pushed, workflow in progress as of this PR creation).

**Don't share the guides with Saad / Jihane until ACA is on `:0.6.1`** — they'd hit the same 429 Marc saw this morning.

## Test plan

- [x] Prettier formatting clean
- [x] Markdown renders correctly on GitHub
- [ ] Marc reads the FR version for translation accuracy / LCI-specific phrasing
- [ ] Once v0.6.1 is deployed to ACA, Saad follows EN guide end-to-end from a Windows laptop
- [ ] Jihane follows FR guide end-to-end — Windows WAM is the real test target (macOS can't fully reproduce WAM behavior)
- [ ] Both can successfully query `list-security-alerts` from Claude Desktop after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)