### PR TITLE
docs(setup): macOS device code / browser setup guides (EN + FR)

### DIFF
--- a/docs/SETUP_MACOS_EN.md
+++ b/docs/SETUP_MACOS_EN.md
@@ -1,0 +1,193 @@
+# MS 365 Admin MCP — macOS setup guide
+
+Connect Claude Desktop on your Mac to the LCI `ms-365-admin` MCP server so you can query M365 security, audit, users, groups, Intune, and Defender data through natural-language prompts.
+
+**Who this is for:** LCI tenant admins with an `adm.aad.*@lcieducation.onmicrosoft.com` account. If your admin account isn't in the allowlist (`--authorized-users` oids configured by Marc), ask him before starting.
+
+**Two authentication paths — pick one:**
+
+- **Browser flow (default, easiest)** — Claude Desktop opens an OAuth tab in your default browser, you sign in, done. Works for admin accounts that aren't enrolled in Platform SSO (the common case at LCI since `adm.aad.*` accounts have no Intune license).
+- **Device code flow (fallback)** — If browser flow fails (Safari intercepted by a Microsoft Enterprise SSO extension, or headless Mac), you authenticate on your phone or another device.
+
+---
+
+## Prerequisites
+
+| Item                                 | How to verify                                            | If missing                                                 |
+| ------------------------------------ | -------------------------------------------------------- | ---------------------------------------------------------- |
+| Claude Desktop                       | `open -a Claude` in Terminal works                       | Install from https://claude.ai/download                    |
+| Node.js 18+                          | `node --version` in Terminal                             | `brew install node` (Homebrew) or https://nodejs.org (LTS) |
+| Microsoft Authenticator (or Yubikey) | Your admin account MFA is already enrolled               | Ask IT if MFA setup is incomplete                          |
+| Your admin account credentials       | `adm.aad.<your-name>@lcieducation.onmicrosoft.com` + MFA | —                                                          |
+
+---
+
+## Step 1 — Configure Claude Desktop
+
+Open Terminal and run:
+
+```bash
+mkdir -p ~/Library/Application\ Support/Claude
+open -e ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+If the file doesn't exist, TextEdit creates an empty one. Paste this content (replace anything already there):
+
+```json
+{
+  "mcpServers": {
+    "ms-365-admin": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp"
+      ]
+    }
+  }
+}
+```
+
+Save (⌘S) and close TextEdit.
+
+---
+
+## Step 2 — Launch Claude Desktop (browser flow)
+
+1. **Quit Claude Desktop** if already running (⌘Q).
+2. **Relaunch** from Spotlight (⌘Space, type "Claude") or the Dock.
+3. A browser tab opens automatically on `login.microsoftonline.com/...` — your default browser handles it.
+4. Sign in with your admin account: **adm.aad.\<your-name\>@lcieducation.onmicrosoft.com**
+5. Complete MFA (Authenticator app push or Yubikey).
+6. The page redirects to `localhost:14543/oauth/callback` and shows "Authentication successful — you can close this tab."
+
+Back in Claude Desktop, the MCP `ms-365-admin` is now connected.
+
+**If you see "Server disconnected" or the browser tab loops on a Microsoft broker page** — Platform SSO is likely intercepting via the _Microsoft Enterprise SSO_ browser extension. Jump to the device code fallback below.
+
+---
+
+## Step 3 — Test
+
+In a new conversation:
+
+> List the 5 most recent Defender security alerts.
+
+Claude should answer using the `list-security-alerts` tool from the `ms-365-admin` MCP.
+
+---
+
+## Alternative: device code flow (fallback)
+
+Use this if Step 2 fails with "Server disconnected" or the browser tab redirects through a broker endlessly.
+
+```bash
+# 1. Quit Claude Desktop (⌘Q)
+
+# 2. Purge the OAuth cache
+rm -rf ~/.mcp-auth/mcp-remote-*
+
+# 3. Run the device code bootstrap
+cd ~
+npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth \
+  --server https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp
+```
+
+You'll see:
+
+```
+────────────────────────────────────────────────────────────
+ Microsoft 365 Admin MCP — device code authentication
+────────────────────────────────────────────────────────────
+ 1. Open https://microsoft.com/devicelogin
+ 2. Enter code: XXXX-XXXX   (copied to clipboard)
+ Waiting for authentication… (timeout 15 min)
+────────────────────────────────────────────────────────────
+```
+
+The user code is copied to your clipboard automatically.
+
+On your phone (or any device with a working browser), go to **https://microsoft.com/devicelogin**, paste the code, sign in with your admin account, complete MFA. Terminal prints "Authentication complete" and writes the tokens.
+
+Relaunch Claude Desktop — `mcp-remote` picks up the cached tokens, no browser tab opens.
+
+---
+
+## Reset / re-authenticate (first thing to try when something breaks)
+
+If Claude Desktop shows "Server disconnected", tool calls fail with auth errors, or you changed account and want to re-authenticate:
+
+```bash
+# 1. Quit Claude Desktop (⌘Q)
+
+# 2. Delete the authentication cache
+rm -rf ~/.mcp-auth/mcp-remote-*
+
+# 3. (Only if npx itself misbehaves — e.g. "command not found" errors)
+rm -rf ~/.npm/_npx
+
+# 4. Relaunch Claude Desktop — the browser flow triggers fresh.
+#    (If browser flow still fails, fall back to the device code steps above.)
+```
+
+This is safe — no data is lost. The cache only holds OAuth tokens; deleting it forces a fresh authentication on next startup.
+
+Common situations that require a reset:
+
+- You see old data or get errors after a server upgrade
+- You changed your admin password or re-registered MFA
+- Your refresh token expired (Entra rotates them periodically)
+- Claude Desktop was closed during an in-progress auth flow
+
+---
+
+## Troubleshooting
+
+**`ms-365-admin-mcp-auth: command not found` (when running device code bootstrap)**
+You're in a folder that has its own `node_modules`. `cd ~` first and retry.
+
+**Browser tab opens but redirects silently through a Microsoft broker page**
+_Microsoft Enterprise SSO_ extension is installed in Safari/Chrome/Firefox. Either: disable it temporarily (`Safari > Settings > Extensions`), use a private/incognito window (extensions are disabled there by default), switch to Brave/Arc for this flow, or use the device code fallback.
+
+**Claude Desktop shows "Server disconnected" after restart**
+Check that tokens were written:
+
+```bash
+ls -la ~/.mcp-auth/mcp-remote-*/
+```
+
+If there's no `*_tokens.json` file, auth didn't complete. Run the reset + try again (device code if browser keeps failing).
+
+**`AADSTS50105: Your account is not assigned to a role for the application`**
+Your admin oid isn't in the server's `--authorized-users` list. Contact Marc.
+
+**Everything else**
+Collect:
+
+- Recent Claude Desktop log: `~/Library/Logs/Claude/mcp-server-ms-365-admin.log`
+- Contents of `~/.mcp-auth/mcp-remote-*/` (redact token values)
+- Exact error text or screenshot
+
+Ping Marc.
+
+---
+
+## What this MCP can do
+
+Covers:
+
+- **Security**: Defender alerts and incidents, Identity Protection risky users, Secure Score, attack simulations, threat intelligence.
+- **Audit**: directory audits, sign-ins, provisioning logs, deleted items.
+- **Identity**: users, groups, directory roles, PIM eligible/active assignments, Conditional Access policies.
+- **Intune**: managed devices, compliance policies, device configurations, app protection.
+- **Organization**: subscribed SKUs (licenses), service health, usage reports.
+- **Write actions** (currently enabled on the pilot): `update-security-alert`, `dismiss-risky-user`, `revoke-user-sessions`, etc. Claude uses your permissions via OBO, so nothing escalates beyond what your account can already do. Sensitive roles stay gated behind PIM.
+
+Full tool list: `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-server --list-tools` — but you'll typically just ask Claude natural-language questions.
+
+## Security notes
+
+- Tokens are cached in `~/.mcp-auth/` with `0600` permissions (user-readable only).
+- Your admin actions are audited in Entra + Purview under your UPN as if you made them yourself (OBO delegated flow).
+- High-risk roles (Global Admin, User Access Admin, Privileged Role Admin) stay PIM-protected — tool availability in Claude doesn't bypass role activation requirements.
+- If you leave LCI or change roles, Marc revokes your oid from `--authorized-users` server-side.

--- a/docs/SETUP_MACOS_FR.md
+++ b/docs/SETUP_MACOS_FR.md
@@ -1,0 +1,193 @@
+# MS 365 Admin MCP — Guide d'installation macOS
+
+Connecte Claude Desktop sur ton Mac au serveur MCP `ms-365-admin` LCI pour interroger les données M365 sécurité, audit, utilisateurs, groupes, Intune et Defender en langage naturel.
+
+**À qui ce guide s'adresse :** admins du tenant LCI avec un compte `adm.aad.*@lcieducation.onmicrosoft.com`. Si ton compte admin n'est pas dans la liste d'autorisation (oids `--authorized-users` configurés par Marc), demande-lui avant de commencer.
+
+**Deux chemins d'authentification — tu choisis :**
+
+- **Flux navigateur (par défaut, le plus simple)** — Claude Desktop ouvre un onglet OAuth dans ton navigateur par défaut, tu te connectes, c'est fait. Fonctionne pour les comptes admin qui ne sont pas enrôlés dans Platform SSO (le cas commun chez LCI puisque les comptes `adm.aad.*` n'ont pas de licence Intune).
+- **Flux device code (fallback)** — Si le flux navigateur échoue (Safari intercepté par une extension Microsoft Enterprise SSO, ou Mac headless), tu t'authentifies sur ton téléphone ou un autre appareil.
+
+---
+
+## Prérequis
+
+| Élément                              | Comment vérifier                                       | Si absent                                                  |
+| ------------------------------------ | ------------------------------------------------------ | ---------------------------------------------------------- |
+| Claude Desktop                       | `open -a Claude` dans Terminal fonctionne              | Installer depuis https://claude.ai/download                |
+| Node.js 18+                          | `node --version` dans Terminal                         | `brew install node` (Homebrew) ou https://nodejs.org (LTS) |
+| Microsoft Authenticator (ou Yubikey) | Ton compte admin a déjà MFA activée                    | Voir avec IT si MFA pas encore configurée                  |
+| Identifiants admin                   | `adm.aad.<ton-nom>@lcieducation.onmicrosoft.com` + MFA | —                                                          |
+
+---
+
+## Étape 1 — Configurer Claude Desktop
+
+Ouvre Terminal et lance :
+
+```bash
+mkdir -p ~/Library/Application\ Support/Claude
+open -e ~/Library/Application\ Support/Claude/claude_desktop_config.json
+```
+
+Si le fichier n'existe pas, TextEdit en crée un vide. Colle ce contenu (remplace tout ce qui s'y trouve déjà) :
+
+```json
+{
+  "mcpServers": {
+    "ms-365-admin": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp"
+      ]
+    }
+  }
+}
+```
+
+Sauvegarde (⌘S) et ferme TextEdit.
+
+---
+
+## Étape 2 — Lancer Claude Desktop (flux navigateur)
+
+1. **Quitte Claude Desktop** s'il tourne déjà (⌘Q).
+2. **Relance** depuis Spotlight (⌘Espace, tape "Claude") ou le Dock.
+3. Un onglet navigateur s'ouvre automatiquement sur `login.microsoftonline.com/...` — ton navigateur par défaut s'en charge.
+4. Connecte-toi avec ton compte admin : **adm.aad.\<ton-nom\>@lcieducation.onmicrosoft.com**
+5. Complète MFA (notification Authenticator app ou Yubikey).
+6. La page redirige vers `localhost:14543/oauth/callback` et affiche "Authentication successful — you can close this tab."
+
+De retour dans Claude Desktop, le MCP `ms-365-admin` est maintenant connecté.
+
+**Si tu vois "Server disconnected" ou l'onglet boucle sur une page broker Microsoft** — Platform SSO intercepte probablement via l'extension navigateur _Microsoft Enterprise SSO_. Passe au fallback device code ci-dessous.
+
+---
+
+## Étape 3 — Tester
+
+Dans une nouvelle conversation :
+
+> Liste-moi les 5 dernières alertes de sécurité Defender.
+
+Claude devrait répondre en utilisant l'outil `list-security-alerts` du MCP `ms-365-admin`.
+
+---
+
+## Alternative : flux device code (fallback)
+
+À utiliser si l'Étape 2 échoue avec "Server disconnected" ou si l'onglet navigateur boucle indéfiniment via un broker.
+
+```bash
+# 1. Quitte Claude Desktop (⌘Q)
+
+# 2. Purge le cache OAuth
+rm -rf ~/.mcp-auth/mcp-remote-*
+
+# 3. Lance le bootstrap device code
+cd ~
+npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-auth \
+  --server https://ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io/mcp
+```
+
+Tu verras :
+
+```
+────────────────────────────────────────────────────────────
+ Microsoft 365 Admin MCP — device code authentication
+────────────────────────────────────────────────────────────
+ 1. Open https://microsoft.com/devicelogin
+ 2. Enter code: XXXX-XXXX   (copied to clipboard)
+ Waiting for authentication… (timeout 15 min)
+────────────────────────────────────────────────────────────
+```
+
+Le code utilisateur est automatiquement copié dans ton presse-papier.
+
+Sur ton téléphone (ou tout appareil avec un navigateur fonctionnel), va sur **https://microsoft.com/devicelogin**, colle le code, connecte-toi avec ton compte admin, complète MFA. Terminal affiche "Authentication complete" et écrit les tokens.
+
+Relance Claude Desktop — `mcp-remote` récupère les tokens en cache, aucun onglet navigateur ne s'ouvre.
+
+---
+
+## Réinitialiser / ré-authentifier (premier réflexe en cas de problème)
+
+Si Claude Desktop affiche "Server disconnected", si les appels d'outils échouent avec des erreurs d'authentification, ou si tu as changé de compte et veux te ré-authentifier :
+
+```bash
+# 1. Quitte Claude Desktop (⌘Q)
+
+# 2. Supprime le cache d'authentification
+rm -rf ~/.mcp-auth/mcp-remote-*
+
+# 3. (Seulement si npx lui-même pose problème — ex. erreurs "command not found")
+rm -rf ~/.npm/_npx
+
+# 4. Relance Claude Desktop — le flux navigateur se déclenche à neuf.
+#    (Si le navigateur échoue toujours, passe aux étapes device code ci-dessus.)
+```
+
+C'est sans danger — aucune donnée n'est perdue. Le cache ne contient que des tokens OAuth ; l'effacer force simplement une ré-authentification au prochain démarrage.
+
+Situations courantes nécessitant une réinitialisation :
+
+- Données anciennes ou erreurs après une mise à jour du serveur
+- Tu as changé ton mot de passe admin ou re-enregistré MFA
+- Ton refresh token a expiré (Entra les fait tourner périodiquement)
+- Claude Desktop a été fermé en plein milieu d'un flux d'authentification
+
+---
+
+## Dépannage
+
+**`ms-365-admin-mcp-auth: command not found` (lors du bootstrap device code)**
+Tu es dans un dossier qui a son propre `node_modules`. Fais `cd ~` d'abord et réessaie.
+
+**L'onglet navigateur s'ouvre mais redirige silencieusement via une page broker Microsoft**
+L'extension _Microsoft Enterprise SSO_ est installée dans Safari/Chrome/Firefox. Options : désactive-la temporairement (`Safari > Réglages > Extensions`), utilise une fenêtre privée/incognito (les extensions sont désactivées par défaut en mode privé), passe à Brave/Arc pour ce flow, ou utilise le fallback device code.
+
+**Claude Desktop affiche "Server disconnected" après redémarrage**
+Vérifie que les tokens ont bien été écrits :
+
+```bash
+ls -la ~/.mcp-auth/mcp-remote-*/
+```
+
+S'il n'y a pas de fichier `*_tokens.json`, l'auth n'a pas abouti. Fais le reset puis réessaie (device code si le navigateur continue d'échouer).
+
+**`AADSTS50105: Your account is not assigned to a role for the application`**
+Ton oid admin n'est pas dans la liste `--authorized-users` du serveur. Contacte Marc.
+
+**Autre problème**
+Récupère :
+
+- Le log récent de Claude Desktop : `~/Library/Logs/Claude/mcp-server-ms-365-admin.log`
+- Le contenu de `~/.mcp-auth/mcp-remote-*/` (masque les valeurs des tokens)
+- Le texte exact de l'erreur ou une capture d'écran
+
+Envoie à Marc.
+
+---
+
+## Ce que le MCP peut faire
+
+Couvre :
+
+- **Sécurité** : alertes et incidents Defender, utilisateurs à risque Identity Protection, Secure Score, simulations d'attaque, threat intelligence.
+- **Audit** : journaux d'audit du répertoire, connexions, journaux de provisionnement, éléments supprimés.
+- **Identité** : utilisateurs, groupes, rôles du répertoire, assignations PIM éligibles/actives, stratégies d'accès conditionnel.
+- **Intune** : appareils gérés, stratégies de conformité, configurations d'appareils, protection des applications.
+- **Organisation** : SKUs souscrits (licences), intégrité des services, rapports d'utilisation.
+- **Actions d'écriture** (actuellement activées sur le pilote) : `update-security-alert`, `dismiss-risky-user`, `revoke-user-sessions`, etc. Claude utilise tes permissions via OBO, donc aucune escalade au-delà de ce que ton compte peut déjà faire. Les rôles sensibles restent gated par PIM.
+
+Liste complète des outils : `npx -y -p "@okapi-ca/ms-365-admin-mcp-server@latest" ms-365-admin-mcp-server --list-tools` — mais en pratique tu vas juste poser des questions en langage naturel à Claude.
+
+## Notes de sécurité
+
+- Les tokens sont en cache dans `~/.mcp-auth/` avec les permissions `0600` (lisibles uniquement par toi).
+- Tes actions admin sont auditées dans Entra + Purview sous ton UPN comme si tu les avais faites toi-même (flux OBO délégué).
+- Les rôles à haut risque (Global Admin, User Access Admin, Privileged Role Admin) restent protégés par PIM — la disponibilité d'un outil dans Claude ne contourne pas les exigences d'activation de rôle.
+- Si tu quittes LCI ou changes de rôle, Marc révoque ton oid de `--authorized-users` côté serveur.


### PR DESCRIPTION
## Summary

Companion to the Windows guides merged in #62. Covers the macOS path for LCI admins on Mac — primarily **Alexis Michaud (FR, infra tech lead, Mac-first)** plus Marc and any future admin who joins `--authorized-users` from macOS.

## Key difference from Windows guides

macOS guides put **browser OAuth as the primary path** and **device code as the fallback**. Rationale:

LCI admin accounts (`adm.aad.*@lcieducation.onmicrosoft.com`) don't have Intune licenses → not enrolled in Platform SSO → Microsoft Enterprise SSO extension isn't pushed → `authorization_code + PKCE + localhost:14543/oauth/callback` completes cleanly.

The Windows guide made device code primary because WAM broker intercepts browser OAuth regardless of admin status. That concern doesn't apply to LCI Mac admins in their default setup.

Device code is still documented as fallback for the cases where:
- User installed the Microsoft Enterprise SSO extension manually
- Mac is heavily Intune-managed and PSSO configuration somehow applies
- Running headless / remote-dev environment
- User just prefers to authenticate on their phone

## Files

- `docs/SETUP_MACOS_EN.md` (193 lines)
- `docs/SETUP_MACOS_FR.md` (193 lines)

Same 9-section structure as the Windows guides, aligned for side-by-side review:

1. Who this is for + both auth paths explained upfront
2. Prerequisites (brew/Homebrew instead of winget, zsh Terminal instead of PowerShell)
3. Step 1 — Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`)
4. **Step 2 — Browser flow (primary)**
5. Step 3 — Test
6. **Alternative: device code (fallback)**
7. Reset / re-authenticate
8. Troubleshooting
9. What the MCP can do + security notes (includes current write-mode note)

## Test plan

- [x] Prettier formatting clean
- [x] Renders correctly on GitHub
- [ ] Alexis follows FR guide end-to-end from his Mac (real validation target)
- [ ] Marc confirms the browser-flow section matches what he experienced this morning once PSSO was bypassed via Safari Private / Firefox
- [ ] macOS users with Enterprise SSO extension manually installed can reach the device code fallback cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)