### PR TITLE
docs(troubleshooting): DNS forced-lookup diagnostic for VNet-integrated CAE

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -171,6 +171,41 @@ You exceeded 100 req/min on `/mcp` from the source IP. Either back off, reshape 
 - Firewall / NSG rules blocking the port?
 - Check `GET /health` from the same network as the client.
 
+### `Could not resolve host` / DNS lookup fails (VNet-integrated CAE)
+
+Symptom: `npx ms-365-admin-mcp-auth --server https://...` or a plain `curl https://.../health` fails with **Could not resolve host: `<cae-name>.<env-subdomain>.canadacentral.azurecontainerapps.io`** even though the VPN is connected.
+
+**Context.** When the Container App Environment is VNet-integrated and `internal: true`, the CAE only has a private IP (e.g. `172.22.2.113`) reachable through the corporate VPN. DNS resolution for `<env-subdomain>.canadacentral.azurecontainerapps.io` comes from a **Private DNS Zone** linked to the hub VNet, which your VPN profile is supposed to push as your DNS server.
+
+**Quick diagnostic — force the DNS query through the VPN-pushed server**
+
+Windows PowerShell:
+
+```powershell
+# Replace 172.22.2.9 with your hub DNS server IP. Find yours via:
+#   Get-NetIPConfiguration | Where-Object InterfaceAlias -Match 'VPN' | Select DnsServer
+Resolve-DnsName ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io -Server 172.22.2.9
+```
+
+macOS / Linux:
+
+```bash
+# Get your VPN's pushed DNS first:
+#   scutil --dns | grep -A2 'resolver #' | head
+dig @172.22.2.9 ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io
+```
+
+**Interpretation**
+
+- **Resolution succeeds with `-Server`/`@` but fails without it** → your OS is using a different DNS server than the VPN pushed. Classic causes:
+  - Hand-edited VPN profile (old troubleshooting sessions) that pinned public DNS instead of the VPN-pushed one.
+  - A local DNS override in the OS (Windows: `Get-DnsClientServerAddress`; macOS: `System Settings > Network > VPN > Details > DNS`).
+  - Split-tunnel DNS config where `canadacentral.azurecontainerapps.io` isn't routed through the VPN's resolver.
+
+  **Fix**: download a fresh VPN configuration from the Azure portal (Virtual Network Gateway → Point-to-site configuration → Download VPN client) and replace your local profile. The fresh profile pushes the correct DNS server for the private DNS zone.
+
+- **Resolution fails even with `-Server`/`@`** → the VPN itself is missing routes, or the Private DNS Zone isn't linked to the hub VNet. Not a client-side issue — escalate to the infra owner (who provisioned the CAE + Private DNS zone).
+
 ---
 
 ## Key Vault


### PR DESCRIPTION
## Summary

Adds a new subsection under "HTTP transport" in `docs/TROUBLESHOOTING.md` covering the **"Could not resolve host"** failure mode that bites first-time admins connecting through the corporate VPN to an internal (VNet-integrated) Container App Environment.

## Observed in prod today (2026-04-23)

During Saad Tariq's bootstrap onto the pilot, his `npx ms-365-admin-mcp-auth` failed with:

\`\`\`
Could not resolve host: ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io
\`\`\`

VPN was connected on the correct admin subnet (`172.25.1.5`), but a hand-edited VPN profile from past troubleshooting was pinning a DNS server that couldn't see the private DNS zone for the CAE.

**The smoking-gun diagnostic** (huge credit to [@amichaud]) was to force the DNS query through the known-good VPN-pushed DNS server:

\`\`\`powershell
Resolve-DnsName ca-cc-mcpms365admin-p.bravecliff-2d3b4e20.canadacentral.azurecontainerapps.io -Server 172.22.2.9
\`\`\`

Forced lookup succeeded, confirming a client-side DNS override was the culprit. Fix: re-download a fresh VPN configuration from the Azure portal to replace the stale hand-edited profile.

## What this PR adds

Section `### "Could not resolve host" / DNS lookup fails (VNet-integrated CAE)` with:

1. **Problem statement + context** — why internal CAE + private DNS zone is a thing.
2. **Diagnostic commands** for Windows (`Resolve-DnsName -Server`) and macOS/Linux (`dig @`), plus helpers to find the correct VPN-pushed DNS server on each OS.
3. **Two-branch interpretation:**
   - Succeeds with `-Server` / `@` → client-side DNS override, refresh VPN profile.
   - Fails even with `-Server` / `@` → infra issue, escalate.

## Why it matters

Saves the next admin who hits this error the 7-minute triage dance between Marc, Alexis, and the new pilot member — they can jump straight to the forced-lookup command.

## Test plan

- [x] Prettier clean
- [x] Renders correctly on GitHub
- [ ] Next admin who hits `Could not resolve host` reports back that the section resolved their issue faster than the previous triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)