### PR TITLE
fix(sec-003): override uuid to >=14.0.0 to resolve CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,5 +84,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "overrides": {
+    "uuid": ">=14.0.0"
   }
 }


### PR DESCRIPTION
Closes #70

## Summary
Add npm override to force `uuid >=14.0.0`, resolving GHSA-w5hq-g745-h8pq (missing buffer bounds check in v3/v5/v6).

## Changes
- `package.json`: add `overrides: { "uuid": ">=14.0.0" }`

## Testing
- Run `npm audit --omit=dev` after install to confirm the moderate severity finding is gone.