### PR TITLE
fix(sec-005): add global rate-limiter before body parsers

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -44,6 +44,20 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
 
   app.set('trust proxy', 1);
   app.use(securityHeaders);
+
+  // SEC-005: global per-IP rate-limiter before body parsers to prevent
+  // unauthenticated DoS via JSON parsing of large payloads.
+  app.use(
+    rateLimit({
+      windowMs: 60_000,
+      max: 200,
+      standardHeaders: true,
+      legacyHeaders: false,
+      keyGenerator: (req) => req.ip ?? 'unknown',
+      message: { error: 'Too many requests, please try again later' },
+    }),
+  );
+
   app.use(express.json({ limit: '100kb' }));
   app.use(express.urlencoded({ extended: true, limit: '100kb' }));
 


### PR DESCRIPTION
Closes #72

## Summary
Prevent unauthenticated DoS by placing a global per-IP rate-limiter before `express.json()` and `express.urlencoded()`.

## Changes
- `src/http-server.ts`: add `rateLimit` middleware (200 req/min per IP) before body parsers
- keep existing `/mcp` rate-limiter as inner gate

## Testing
- Start the server and verify `/mcp` still accepts authenticated requests
- Verify `/health` is not affected by the new limiter
- Run `npm test` to confirm no regressions