### PR TITLE
fix(security): SEC-002 validate redirect_uri at /authorize and /token (CYSEC-1474)

### DIFF
--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -268,6 +268,30 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       return;
     }
 
+    // SEC-F04c (SEC-002): /authorize must verify that the redirect_uri matches
+    // one of the URIs registered at /register (DCR). Without this, anyone who
+    // possesses a client_id + secret pair (e.g. recovered from a shared
+    // ~/.mcp-auth cache) can swap in an attacker-controlled redirect_uri and
+    // exfiltrate the auth code — Entra's upstream allowlist mitigates only when
+    // the operator has tightly configured their app registration. We enforce at
+    // this proxy regardless. Empty redirectUris means the client registered
+    // none (legacy / minimal DCR call) — we don't enforce in that case to keep
+    // backward compatibility with existing deployments, but log it.
+    if (known.redirectUris.length === 0) {
+      logger.warn(
+        `OAuth /authorize: client ${clientId} has no registered redirect_uris — skipping enforcement`
+      );
+    } else if (!known.redirectUris.includes(redirectUri)) {
+      logger.warn(
+        `OAuth /authorize rejected: redirect_uri ${redirectUri} not in registered list for ${clientId}`
+      );
+      res.status(400).json({
+        error: 'invalid_request',
+        error_description: 'redirect_uri does not match a registered URI',
+      });
+      return;
+    }
+
     const serverVerifier = randomVerifier();
     const serverChallenge = sha256Base64url(serverVerifier);
     await storage.savePkce({
@@ -375,10 +399,24 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
         });
         return;
       }
+      // SEC-F04c (SEC-002): the redirect_uri presented at /token must match
+      // the one bound to the auth code at /authorize. RFC 6749 §4.1.3 requires
+      // this check. Without it, an attacker who steals an auth code could
+      // redeem it pointing at their own redirect target.
+      if (bridge.redirectUri !== redirectUri) {
+        logger.warn(
+          `OAuth /token rejected: redirect_uri mismatch (bridge=${bridge.redirectUri}, req=${redirectUri})`
+        );
+        res.status(400).json({
+          error: 'invalid_grant',
+          error_description: 'redirect_uri does not match the one used at /authorize',
+        });
+        return;
+      }
 
       form.set('grant_type', 'authorization_code');
       form.set('code', code);
-      form.set('redirect_uri', redirectUri);
+      form.set('redirect_uri', bridge.redirectUri);
       form.set('code_verifier', bridge.serverVerifier);
     } else if (grantType === 'refresh_token') {
       const refreshToken = body.refresh_token as string | undefined;

--- a/test/oauth-proxy.test.ts
+++ b/test/oauth-proxy.test.ts
@@ -74,11 +74,13 @@ beforeEach(() => {
   }) as typeof fetch;
 });
 
-async function register(): Promise<{ clientId: string; clientSecret: string }> {
+async function register(
+  redirectUris: string[] = ['http://localhost/cb']
+): Promise<{ clientId: string; clientSecret: string }> {
   const res = await realFetch(`${baseUrl}/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ redirect_uris: ['http://localhost:3000/cb'] }),
+    body: JSON.stringify({ redirect_uris: redirectUris }),
   });
   expect(res.status).toBe(201);
   const body = (await res.json()) as {
@@ -278,6 +280,83 @@ describe('SEC-F04b /token authorization_code — PKCE client_id binding', () => 
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('invalid_grant');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('SEC-F04c (SEC-002) /authorize — redirect_uri must match DCR registration', () => {
+  it('rejects /authorize when redirect_uri is not in the registered list', async () => {
+    const { clientId } = await register(['http://localhost/cb']);
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+
+    const res = await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=https%3A%2F%2Fattacker.example.com%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe('invalid_request');
+    expect(body.error_description).toMatch(/redirect_uri/);
+  });
+
+  it('accepts /authorize when redirect_uri exactly matches a registered URI', async () => {
+    const { clientId } = await register(['http://localhost/cb', 'http://127.0.0.1/cb']);
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+
+    const res = await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2F127.0.0.1%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(302);
+    const location = res.headers.get('location') || '';
+    expect(location).toContain('login.microsoftonline.com');
+  });
+
+  it('skips redirect_uri enforcement when client registered with empty redirect_uris (legacy compat)', async () => {
+    const { clientId } = await register([]);
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+
+    const res = await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2Fanything%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(302);
+  });
+});
+
+describe('SEC-F04c (SEC-002) /token — redirect_uri must match the one used at /authorize', () => {
+  it('rejects /token when redirect_uri differs from the one bound to the auth code', async () => {
+    const { clientId, clientSecret } = await register(['http://localhost/cb']);
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+
+    // /authorize with the registered URI — this binds redirect_uri to the bridge.
+    await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+
+    // /token with a different redirect_uri — must be rejected before any
+    // upstream call.
+    const res = await realFetch(`${baseUrl}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: 'any-code',
+        code_verifier: verifier,
+        redirect_uri: 'http://localhost/different',
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe('invalid_grant');
+    expect(body.error_description).toMatch(/redirect_uri/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes #69. Adds RFC 6749 §4.1.3-style validation of `redirect_uri` at both ends of the OAuth code flow:

1. **`/authorize`** — verifies the requested `redirect_uri` is in the list registered at `/register` (DCR). Rejects with `invalid_request` 400 if not.
2. **`/token`** (authorization_code grant) — verifies the `redirect_uri` in the body matches the one bound to the auth code at `/authorize`. Rejects with `invalid_grant` 400 if mismatched, and uses `bridge.redirectUri` for the upstream form (defense in depth).

## Why

An attacker with a leaked `client_id + client_secret` pair (e.g. recovered from a shared `~/.mcp-auth/...` cache on a multi-user host) could call `/authorize?client_id=...&redirect_uri=https://attacker.example.com/cb` and exfiltrate the auth code. Mitigated upstream by Entra's app registration allowlist — but only when the operator has tightly configured it. With a wildcard or loose schema (common in dev), the proxy was an open redirect.

## Backward compatibility

- Clients that registered with non-empty `redirect_uris`: enforcement applies normally (must match exactly).
- Clients that registered with empty `redirect_uris` (legacy / minimal DCR): enforcement is skipped, warning logged. Operators can spot these in the logs and remediate.

## Changes

- `src/oauth-proxy.ts`: add validation in `/authorize` (after the `getClient` lookup) and in `/token` (after the PKCE bridge consumption + clientId binding check).
- `src/oauth-proxy.ts`: `/token` now uses `bridge.redirectUri` (rather than `body.redirect_uri`) when building the upstream Entra form — guarantees consistency even if the body slips a different URI through validation.
- `test/oauth-proxy.test.ts`: 4 new cases under \`SEC-F04c (SEC-002)\`:
  - `/authorize` rejects unregistered redirect_uri (`https://attacker.example.com/cb` against registered `http://localhost/cb`)
  - `/authorize` accepts a redirect_uri matching one of multiple registered URIs
  - `/authorize` skips enforcement when the client registered with empty list (legacy compat)
  - `/token` rejects redirect_uri mismatch and never calls upstream
- `test/oauth-proxy.test.ts`: refactor `register()` helper to take an optional `redirectUris` parameter (defaults to `['http://localhost/cb']`).

## Test plan

- [x] \`npm run verify\` passes (lint, format, build, 148 tests — was 144 before this PR)
- [x] All existing SEC-F04b tests still pass (no regression on PKCE clientId binding, scope handling, prompt=select_account, etc.)
- [x] Reject path: \`fetchMock\` is never called (upstream never reached)
- [x] Accept path: 302 redirect to login.microsoftonline.com still works

## References

- Finding: [SECURITY_REVIEW_2026-04-25.md §SEC-002](docs/SECURITY_REVIEW_2026-04-25.md)
- Issue: #69
- Jira: [CYSEC-1474](https://lcieducation.atlassian.net/browse/CYSEC-1474)
- RFC 6749 §4.1.3 (auth code grant — redirect_uri requirement)
- RFC 6819 §5.2.3.5 (recommendation to compare redirect_uri at /token)