### PR TITLE
fix(security): SEC-007 record OAuth state in PKCE bridge for audit (CYSEC-1478)

### DIFF
--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -275,6 +275,13 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       serverVerifier,
       redirectUri,
       clientId,
+      // SEC-F04d (SEC-007): record the client's state for audit correlation.
+      // The proxy never observes the redirect callback (Entra → client direct),
+      // so cannot validate round-trip equivalence — but storing state lets us
+      // correlate /authorize and /token entries for the same OAuth session in
+      // the audit logs, which is otherwise impossible across the PKCE bridge.
+      // Optional: clients may omit state per RFC 6749 §10.12.
+      clientState: state,
       expiresAt: Date.now() + PKCE_TTL_MS,
     });
 
@@ -306,8 +313,10 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     // use a non-WebKit browser (Chrome, Firefox) to bypass that layer.
     upstream.searchParams.set('prompt', 'select_account');
 
+    // SEC-F04d (SEC-007): include state in the audit log so /authorize and
+    // /token entries can be correlated to the same OAuth session.
     logger.info(
-      `OAuth /authorize → Entra (client=${clientId}, redirect_uri=${redirectUri}, scope=${upstreamScope}, prompt=select_account)`
+      `OAuth /authorize → Entra (client=${clientId}, redirect_uri=${redirectUri}, scope=${upstreamScope}, prompt=select_account, state=${state ?? '(none)'})`
     );
     res.redirect(302, upstream.toString());
   });
@@ -375,6 +384,14 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
         });
         return;
       }
+
+      // SEC-F04d (SEC-007): log the state recorded at /authorize so audit can
+      // correlate this /token call to the originating session. The proxy never
+      // sees the redirect callback, so this log line is the only record that
+      // ties the two endpoints together for a single OAuth flow.
+      logger.info(
+        `OAuth /token authorization_code redemption (client=${reqClientId}, state=${bridge.clientState ?? '(none)'})`
+      );
 
       form.set('grant_type', 'authorization_code');
       form.set('code', code);

--- a/src/storage/oauth-storage.ts
+++ b/src/storage/oauth-storage.ts
@@ -8,6 +8,14 @@ export interface PkceEntry {
   // /authorize call. /token then rejects any attempt to redeem a code under a
   // different client_id.
   clientId: string;
+  // SEC-F04d (SEC-007): the client-supplied 'state' parameter from /authorize.
+  // The proxy never sees the redirect callback (Entra → client direct), so we
+  // cannot compare round-trip values. Storing 'state' here closes the finding
+  // by enabling audit-log correlation between /authorize and /token for the
+  // same OAuth session, which is otherwise impossible across the PKCE bridge.
+  // Optional: clients may omit 'state' — its absence is not itself an issue,
+  // RFC 6749 §10.12 only RECOMMENDS it.
+  clientState?: string;
   expiresAt: number;
 }
 

--- a/src/storage/table-storage.ts
+++ b/src/storage/table-storage.ts
@@ -11,6 +11,10 @@ interface PkceEntity {
   serverVerifier: string;
   redirectUri: string;
   clientId: string;
+  // SEC-F04d (SEC-007): client-supplied state parameter, kept for audit-log
+  // correlation. Optional — clients may omit it. Stored as '' when absent
+  // because Azure Table Storage does not roundtrip undefined cleanly.
+  clientState: string;
   expiresAt: number;
 }
 
@@ -69,6 +73,7 @@ export class TableStorage implements OAuthStorage {
       serverVerifier: entry.serverVerifier,
       redirectUri: entry.redirectUri,
       clientId: entry.clientId,
+      clientState: entry.clientState ?? '',
       expiresAt: entry.expiresAt,
     };
     await this.client.upsertEntity(entity, 'Replace');
@@ -101,6 +106,7 @@ export class TableStorage implements OAuthStorage {
       serverVerifier: entity.serverVerifier,
       redirectUri: entity.redirectUri,
       clientId: entity.clientId,
+      clientState: entity.clientState || undefined,
       expiresAt: entity.expiresAt,
     };
   }

--- a/test/oauth-proxy.test.ts
+++ b/test/oauth-proxy.test.ts
@@ -282,6 +282,59 @@ describe('SEC-F04b /token authorization_code — PKCE client_id binding', () => 
   });
 });
 
+describe('SEC-F04d (SEC-007) /authorize — state recorded in PKCE bridge for audit', () => {
+  it('records the client-supplied state in the PKCE entry', async () => {
+    const { clientId } = await register();
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+    const clientStateValue = 'session-abc-' + crypto.randomBytes(8).toString('hex');
+
+    const saveSpy = vi.spyOn(storage, 'savePkce');
+    await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=${challenge}&code_challenge_method=S256&state=${encodeURIComponent(clientStateValue)}`,
+      { redirect: 'manual' }
+    );
+
+    expect(saveSpy).toHaveBeenCalled();
+    const entry = saveSpy.mock.calls[0][0];
+    expect(entry.clientState).toBe(clientStateValue);
+    expect(entry.clientChallenge).toBe(challenge);
+    saveSpy.mockRestore();
+  });
+
+  it('relays state unchanged to Entra (no rewriting / proxy-state substitution)', async () => {
+    const { clientId } = await register();
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+    const clientStateValue = 'csrf-token-' + crypto.randomBytes(8).toString('hex');
+
+    const res = await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=${challenge}&code_challenge_method=S256&state=${encodeURIComponent(clientStateValue)}`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(302);
+    const upstream = new URL(res.headers.get('location')!);
+    expect(upstream.searchParams.get('state')).toBe(clientStateValue);
+  });
+
+  it('accepts /authorize without state (state is optional per RFC 6749 §10.12)', async () => {
+    const { clientId } = await register();
+    const verifier = base64url(crypto.randomBytes(64));
+    const challenge = sha256(verifier);
+
+    const saveSpy = vi.spyOn(storage, 'savePkce');
+    const res = await realFetch(
+      `${baseUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(302);
+    expect(saveSpy).toHaveBeenCalled();
+    const entry = saveSpy.mock.calls[0][0];
+    expect(entry.clientState).toBeUndefined();
+    saveSpy.mockRestore();
+  });
+});
+
 describe('SEC-F04b oauth-mode startup — refuses when DCR is disabled', () => {
   it('throws when enableDynamicRegistration is false', () => {
     const app = express();


### PR DESCRIPTION
## Summary

Closes #74. Stores the client-supplied OAuth `state` parameter in the PKCE bridge entry and logs it on both `/authorize` and `/token`, enabling forensic correlation of the two endpoints for a single OAuth session.

## Why a minimal fix (and why that's the right scope)

The recommended "ideal" mitigation — emit a distinct proxy `state` and verify round-trip equivalence — **is not implementable in this architecture**. The proxy sits at `/authorize` and `/token`, but Entra redirects directly to the client's `redirect_uri` after authentication. The state callback never traverses the proxy, so there is no second observation to compare against.

What the proxy *can* do is bind state to the PKCE bridge so audit logs can correlate `/authorize` and `/token` entries for the same OAuth session, which is otherwise impossible (the only shared identifier across the two is the PKCE `code_challenge`, which is internal). This is the closure recommended by [SEC-007](https://github.com/okapi-ca/ms-365-admin-mcp-server/issues/74) once the architectural reality is taken into account.

## Changes

- `src/storage/oauth-storage.ts`: `PkceEntry` gains optional `clientState?: string`
- `src/storage/table-storage.ts`: `PkceEntity` carries `clientState` (`''` sentinel when absent — Azure Tables does not roundtrip `undefined` cleanly)
- `src/storage/memory-storage.ts`: no changes — already stores the entire entry as-is
- `src/oauth-proxy.ts`:
  - `/authorize` records `state` in the PKCE bridge
  - `/authorize` includes `state` in the existing upstream-redirect log line
  - `/token` logs `bridge.clientState` before the upstream call (auth code grant only)
- `test/oauth-proxy.test.ts`: 3 new cases under \`SEC-F04d (SEC-007)\`

## Tests

- `/authorize` records the client state in the PKCE entry (verified via spy on `storage.savePkce`)
- `/authorize` relays state unchanged to Entra (no proxy-state substitution that would break clients)
- `/authorize` accepts requests without state (state is optional per RFC 6749 §10.12) and stores `undefined`

## Test plan

- [x] `npm run verify` passes (lint, format, build, 147 tests — was 144 before this PR)
- [x] All existing SEC-F04b/c tests still pass (PKCE binding, redirect_uri validation, etc.)
- [x] Storage backends both handle the new field (Memory: trivially; Table: with `''` sentinel)

## References

- Finding: [SECURITY_REVIEW_2026-04-25.md §SEC-007](docs/SECURITY_REVIEW_2026-04-25.md)
- Issue: #74
- Jira: [CYSEC-1478](https://lcieducation.atlassian.net/browse/CYSEC-1478)
- RFC 6749 §10.12 (state — recommended for CSRF mitigation)
- RFC 6819 §5.3.5 (state — recommended to bind request and response)