### PR TITLE
fix(security): SEC-008 add restrictStorageNetworkAccess Bicep param (CYSEC-1479)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -76,6 +76,22 @@ param hubVnetName string = ''
 @description('Subnet in the hub VNet pre-delegated to Microsoft.App/environments, used as CAE infrastructure subnet. Required when vnetIntegrated=true.')
 param infrastructureSubnetName string = ''
 
+// --- Storage network access (SEC-008) ---
+//
+// SEC-008: when true, the Storage Account that backs the OAuth PKCE bridge and
+// DCR client credentials switches its network ACL default to 'Deny'. The
+// Container App's user-assigned managed identity continues to access the
+// Storage Tables through the 'AzureServices' bypass — no functional change as
+// long as the deployment stays in the same Azure tenant. Recommended for any
+// regulated-tenant deployment (PIPEDA, RGPD, Loi 25, etc.) where audit
+// frameworks require explicit network-level isolation in addition to the
+// existing identity-based controls (allowSharedKeyAccess: false).
+// Default false to preserve backward compatibility; set true on new and
+// regulated deployments.
+
+@description('SEC-008: switch Storage networkAcls.defaultAction to Deny (recommended for regulated tenants). The Container App UAMI still reaches Storage Tables via the AzureServices bypass + Azure AD trust within the same tenant.')
+param restrictStorageNetworkAccess bool = false
+
 // --- Resource name overrides ---
 //
 // Every Azure resource has a default name derived from baseName. Operators with strict
@@ -216,7 +232,12 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
     supportsHttpsTrafficOnly: true
     defaultToOAuthAuthentication: true
     networkAcls: {
-      defaultAction: 'Allow'
+      // SEC-008: Deny + AzureServices bypass keeps the Storage Tables
+      // unreachable from the public internet while the Container App's UAMI
+      // (a trusted Azure service authenticated via Azure AD in the same
+      // tenant) continues to read/write the OAuth state. Set
+      // restrictStorageNetworkAccess=true on regulated-tenant deployments.
+      defaultAction: restrictStorageNetworkAccess ? 'Deny' : 'Allow'
       bypass: 'AzureServices'
     }
   }
@@ -387,3 +408,14 @@ output uamiPrincipalId string = uami.properties.principalId
 output uamiClientId string = uami.properties.clientId
 output vnetIntegrated bool = vnetIntegrated
 output infrastructureSubnetId string = infrastructureSubnetId
+
+// SEC-008: surface the deployment's security posture so operators can audit
+// it via `az deployment group show` without re-reading the parameters file.
+// Regulated-tenant baseline: vnetIntegrated=true AND restrictStorageNetworkAccess=true.
+output securityPosture object = {
+  vnetIntegrated: vnetIntegrated
+  restrictStorageNetworkAccess: restrictStorageNetworkAccess
+  storageNetworkDefaultAction: restrictStorageNetworkAccess ? 'Deny' : 'Allow'
+  oauthMode: oauthMode
+  regulatedTenantBaseline: vnetIntegrated && restrictStorageNetworkAccess
+}

--- a/infra/parameters.example.jsonc
+++ b/infra/parameters.example.jsonc
@@ -41,6 +41,12 @@
     // Requires a pre-existing subnet delegated to Microsoft.App/environments.
     // When true: CAE runs workload-profiles + internal ingress (clients must reach
     // the VNet via VPN, ExpressRoute, or VNet peering). No public ingress, no PE.
+    //
+    // REGULATED TENANTS (PIPEDA, RGPD, Loi 25, KVKK, UU PDP, etc.):
+    // Set vnetIntegrated=true AND restrictStorageNetworkAccess=true. The
+    // resulting posture has no public ingress on the OAuth surface and the
+    // Storage Account that holds DCR clients + PKCE state is unreachable from
+    // the public internet. Audit frameworks typically require both.
     "vnetIntegrated": { "value": false },
     "hubSubscriptionId": { "value": "<subscription id hosting the hub VNet>" },
     "hubVnetRg": { "value": "<resource group of the hub VNet>" },
@@ -48,6 +54,14 @@
     "infrastructureSubnetName": {
       "value": "<subnet delegated to Microsoft.App/environments, pre-created by network team>"
     },
+
+    // --- Storage network access (SEC-008) ---
+    // When true: Storage Account networkAcls.defaultAction is set to 'Deny'.
+    // The Container App's UAMI continues to access the Storage Tables via the
+    // 'AzureServices' bypass + Azure AD trust within the same tenant — no
+    // functional change for the deployment. Recommended for regulated tenants
+    // (see comment on vnetIntegrated above).
+    "restrictStorageNetworkAccess": { "value": false },
 
     // --- Resource name overrides (optional) ---
     // Leave empty to derive from baseName. Override when your org has strict


### PR DESCRIPTION
## Summary

Closes #75. Adds a Bicep parameter `restrictStorageNetworkAccess` that switches the OAuth Storage account's `networkAcls.defaultAction` from `'Allow'` to `'Deny'` while keeping the `AzureServices` bypass. Default `false` preserves backward compatibility; regulated-tenant deployments should set `true`.

## Why

The Storage account holds DCR client metadata + PKCE bridge entries. Existing controls (`allowSharedKeyAccess: false`, `defaultToOAuthAuthentication: true`) already prevent exfiltration without an Azure AD token, but the endpoint itself was reachable from the public internet. Regulated tenants under PIPEDA, RGPD, Loi 25, KVKK, UU PDP, etc. typically require explicit network-level isolation in addition to identity controls.

## How the bypass keeps Container App access working

`bypass: 'AzureServices'` continues to apply when `defaultAction: 'Deny'`. The Container App's user-assigned managed identity authenticates via Azure AD within the same tenant, which Azure Storage trusts as a bypassed source. No functional change for the deployment as long as it stays in one tenant.

If an operator's network architecture requires more granular control (specific subnet rules, IP allowlists), they can extend `networkAcls` from this baseline.

## Changes

- `infra/main.bicep`:
  - New parameter `restrictStorageNetworkAccess: bool = false` with rationale comment
  - `Microsoft.Storage/storageAccounts.properties.networkAcls.defaultAction` is now conditional on the parameter
  - New output `securityPosture` summarizing `vnetIntegrated`, `restrictStorageNetworkAccess`, the resulting `storageNetworkDefaultAction`, `oauthMode`, and a derived `regulatedTenantBaseline` boolean for quick compliance checks
- `infra/parameters.example.jsonc`:
  - New section under VNet integration explicitly naming the regulated-tenant baseline (`vnetIntegrated=true` + `restrictStorageNetworkAccess=true`) and listing the regulations it satisfies
  - New `restrictStorageNetworkAccess` entry with the recommended-when-regulated note

## Test plan

- [x] `npm run verify` passes (lint, format, build, 151 tests)
- [x] Bicep syntax: parameter type / output object syntax matches existing usage in the file
- [x] Default behavior unchanged: `restrictStorageNetworkAccess: false` → `defaultAction: 'Allow'` (current production state)
- [x] Regulated baseline: `restrictStorageNetworkAccess: true` → `defaultAction: 'Deny'`, output `regulatedTenantBaseline: true` when also `vnetIntegrated=true`

Validating the end-to-end Azure deployment is out of scope for this PR — that requires a real Azure subscription. Recommended path for the operator: redeploy the existing dev RG with `restrictStorageNetworkAccess=true`, confirm the Container App can still read/write Storage Tables, then promote to prod.

## References

- Finding: [SECURITY_REVIEW_2026-04-25.md §SEC-008](docs/SECURITY_REVIEW_2026-04-25.md)
- Issue: #75
- Jira: [CYSEC-1479](https://lcieducation.atlassian.net/browse/CYSEC-1479)
- Microsoft docs: [Storage AzureServices bypass](https://learn.microsoft.com/azure/storage/common/storage-network-security#exceptions)