### PR TITLE
fix(security): SEC-004 --log-redact-upn flag + PII docs (CYSEC-1476)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,6 +63,24 @@ If you run this server, we recommend:
 6. **HTTP mode exposure.** Never expose the HTTP transport on `0.0.0.0` without a reverse proxy enforcing TLS and additional authentication. Always pass `--allowed-clients` with the minimum set of Entra app IDs.
 7. **Audit trail.** Enable verbose logging (`-v`) and forward logs to a SIEM. All Graph mutations are also auditable via `list-directory-audits` and `list-intune-audit-events`.
 8. **Network segmentation.** Run the server in a network segment that only permits egress to `login.microsoftonline.com` and `graph.microsoft.com` (or sovereign equivalents).
+9. **PII-aware logging.** Pass `--log-redact-upn` when logs are forwarded to a SIEM or external log forwarder. The flag replaces UPN values in log lines with a deterministic SHA-256 prefix (`sha256:<16hex>`), preserving forensic correlation while removing the work-email PII (see "Personal data handled by this server" below).
+
+## Personal data handled by this server
+
+When the server runs in `--oauth-mode`, the following user-attributable values appear in normal operation. Operators in regulated jurisdictions (PIPEDA, RGPD, Loi 25, KVKK, UU PDP, etc.) should account for these in their DPIA / records-of-processing:
+
+| Value                                                 | Source                                                         | Where it appears                                                                              | Mitigation                                                                                           |
+| ----------------------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| **UPN** (`user@tenant.onmicrosoft.com` or work email) | User token `upn` / `preferred_username` claim                  | Log lines on auth success and rejection in `user-token-authorization.ts` and `http-server.ts` | `--log-redact-upn` replaces with `sha256:<16hex>`                                                    |
+| **Entra `oid`**                                       | User token `oid` claim                                         | Same log lines                                                                                | None — `oid` is a tenant-scoped GUID, not PII per most regulators; required for incident attribution |
+| **Source IP**                                         | TCP connection / `X-Forwarded-For` (when `trust proxy` is set) | Express access logs, rate-limit accounting                                                    | Sanitize at the reverse proxy / log forwarder if required                                            |
+| **Bearer tokens**                                     | Inbound `/mcp` requests                                        | **Never logged** — only the authentication outcome                                            | n/a                                                                                                  |
+| **Tool call parameters**                              | MCP tool invocations                                           | Logged at `info` level with parameter names only, never values (`graph-tools.ts`)             | n/a                                                                                                  |
+| **Graph API responses**                               | Microsoft Graph                                                | Returned to the caller, never logged                                                          | n/a                                                                                                  |
+
+Default Log Analytics retention in the included Bicep template is **30 days** (parameter `logRetentionDays`). Lower this for stricter data-minimization regimes.
+
+The Entra `oid` is intentionally **not** redacted: it is a non-PII GUID, audit teams need a stable forensic anchor, and pivoting from `oid` to a user requires directory access that an external log forwarder does not have.
 
 ## Known hardening in this codebase
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,10 @@ program
   .option(
     '--no-dynamic-registration',
     'Disable the OAuth Dynamic Client Registration endpoint (default: enabled with --oauth-mode)'
+  )
+  .option(
+    '--log-redact-upn',
+    'Replace UPN values in log lines with a SHA-256 prefix (SEC-F08 / SEC-004). Recommended for regulated tenants (PIPEDA, RGPD, Loi 25) when logs are forwarded to a SIEM. The Entra oid (non-PII GUID) stays plaintext for forensic pivots.'
   );
 
 export interface CommandOptions {
@@ -90,6 +94,7 @@ export interface CommandOptions {
   allowAnyTenantUser?: boolean;
   requiredUserScopes?: string;
   dynamicRegistration?: boolean;
+  logRedactUpn?: boolean;
   [key: string]: unknown;
 }
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import logger from './logger.js';
 import { validateEntraToken, type TokenValidatorOptions } from './token-validator.js';
 import { validateUserToken, type UserTokenValidatorOptions } from './user-token-validator.js';
+import { formatUpnForLog } from './user-token-authorization.js';
 import { registerOAuthRoutes, type OAuthProxyOptions } from './oauth-proxy.js';
 import { registerOAuthRateLimiters } from './oauth-rate-limiters.js';
 import rateLimit from 'express-rate-limit';
@@ -106,7 +107,13 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     if (userValidator) {
       const userClaims = await validateUserToken(token, userValidator);
       if (userClaims) {
-        logger.info(`MCP request authenticated as user ${userClaims.upn ?? userClaims.oid}`);
+        // SEC-F08 (SEC-004): respect --log-redact-upn here too. The Entra `oid`
+        // (non-PII GUID) stays plain when no UPN is present so operators can
+        // still pivot through the directory.
+        const upnForLog = formatUpnForLog(userClaims.upn, userValidator.redactUpn);
+        logger.info(
+          `MCP request authenticated as user ${userClaims.upn ? upnForLog : userClaims.oid} (oid ${userClaims.oid})`
+        );
         // Store the raw bearer token so OBO can use it as the user assertion downstream.
         res.locals.userToken = token;
         next();

--- a/src/server.ts
+++ b/src/server.ts
@@ -145,6 +145,8 @@ class AdminGraphServer {
             authorizedUserOids,
             allowAnyTenantUser,
             requiredScopes,
+            // SEC-F08 (SEC-004): plumb the CLI flag through so logger sees redaction.
+            redactUpn: Boolean(this.options.logRedactUpn),
           }
         : undefined;
 

--- a/src/user-token-authorization.ts
+++ b/src/user-token-authorization.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import logger from './logger.js';
 
 export interface UserTokenValidatorOptions {
@@ -10,6 +11,30 @@ export interface UserTokenValidatorOptions {
   // SEC-F03: user tokens must contain every scope listed here in their `scp` claim.
   // Default is enforced at the caller (server.ts); an empty list disables the check.
   requiredScopes: string[];
+  // SEC-F08 (SEC-004): when true, log lines emit a stable SHA-256 prefix of the
+  // UPN instead of the plaintext value. Investigation correlation is preserved
+  // (the same UPN always hashes to the same prefix) while the log stream is
+  // safe to ship to a SIEM / forwarder under PIPEDA / RGPD / Loi 25 without a
+  // separate Data Processing Agreement covering work-email PII. The Entra
+  // `oid` (a non-PII GUID) remains in plaintext so operators can still pivot
+  // to a user via the directory.
+  redactUpn?: boolean;
+}
+
+/**
+ * SEC-F08 (SEC-004): format a UPN-like value for emission to logs.
+ *
+ * Returns the value verbatim when `redact` is false (default). When true,
+ * returns a 16-char prefix of the SHA-256 hash, prefixed with `sha256:` so
+ * forwarders and SIEM rules can recognise the format. The hash is keyed only
+ * on the value itself (no salt) — the goal is non-reversibility for casual
+ * log readers, not cryptographic resistance to an attacker who already has
+ * tenant directory access.
+ */
+export function formatUpnForLog(value: string | undefined, redact: boolean | undefined): string {
+  if (!value) return '<none>';
+  if (!redact) return value;
+  return 'sha256:' + crypto.createHash('sha256').update(value, 'utf8').digest('hex').slice(0, 16);
 }
 
 export interface UserTokenClaims {
@@ -74,17 +99,16 @@ export function authorizeUserClaims(
   // SEC-F01: fail-closed when no per-user allowlist is configured.
   // Without this guard, any tenant user who obtains a token with the expected
   // audience would gain the server's full app-permission capability.
+  const upnForLog = formatUpnForLog(payload.upn || payload.preferred_username, options.redactUpn);
   if (options.authorizedUserOids.length === 0) {
     if (!options.allowAnyTenantUser) {
       logger.warn(
-        `User ${payload.upn || payload.preferred_username || oid} rejected: no --authorized-users allowlist configured and --allow-any-tenant-user not set`
+        `User ${upnForLog} (oid ${oid}) rejected: no --authorized-users allowlist configured and --allow-any-tenant-user not set`
       );
       return null;
     }
   } else if (!options.authorizedUserOids.includes(oid)) {
-    logger.warn(
-      `User oid ${oid} (${payload.upn || payload.preferred_username || 'no upn'}) not in authorized-users allowlist`
-    );
+    logger.warn(`User oid ${oid} (${upnForLog}) not in authorized-users allowlist`);
     return null;
   }
 

--- a/test/user-token-validator.test.ts
+++ b/test/user-token-validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   authorizeUserClaims,
+  formatUpnForLog,
   type UserTokenValidatorOptions,
 } from '../src/user-token-authorization.js';
 
@@ -159,5 +160,61 @@ describe('authorizeUserClaims — claims extraction', () => {
     const payload = basePayload({ appid: undefined, azp: 'client-app-id' });
     const claims = authorizeUserClaims(payload, baseOptions({ allowAnyTenantUser: true }));
     expect(claims?.appid).toBe('client-app-id');
+  });
+});
+
+describe('SEC-F08 (SEC-004) — formatUpnForLog', () => {
+  it('returns the value verbatim when redact is false or undefined', () => {
+    expect(formatUpnForLog('alice@contoso.com', false)).toBe('alice@contoso.com');
+    expect(formatUpnForLog('alice@contoso.com', undefined)).toBe('alice@contoso.com');
+  });
+
+  it('returns a sha256-prefixed truncated hash when redact is true', () => {
+    const out = formatUpnForLog('alice@contoso.com', true);
+    expect(out).toMatch(/^sha256:[0-9a-f]{16}$/);
+    expect(out).not.toContain('alice');
+    expect(out).not.toContain('contoso');
+  });
+
+  it('is deterministic — the same UPN always hashes to the same prefix', () => {
+    const a = formatUpnForLog('alice@contoso.com', true);
+    const b = formatUpnForLog('alice@contoso.com', true);
+    expect(a).toBe(b);
+  });
+
+  it('different UPNs produce different prefixes', () => {
+    const alice = formatUpnForLog('alice@contoso.com', true);
+    const bob = formatUpnForLog('bob@contoso.com', true);
+    expect(alice).not.toBe(bob);
+  });
+
+  it('returns <none> for undefined or empty', () => {
+    expect(formatUpnForLog(undefined, true)).toBe('<none>');
+    expect(formatUpnForLog(undefined, false)).toBe('<none>');
+    expect(formatUpnForLog('', true)).toBe('<none>');
+  });
+});
+
+describe('SEC-F08 (SEC-004) — UPN redaction in authorizeUserClaims rejection paths', () => {
+  it('still rejects on missing allowlist regardless of redactUpn', () => {
+    const payload = basePayload();
+    expect(authorizeUserClaims(payload, baseOptions({ redactUpn: false }))).toBeNull();
+    expect(authorizeUserClaims(payload, baseOptions({ redactUpn: true }))).toBeNull();
+  });
+
+  it('still rejects oid-not-in-allowlist regardless of redactUpn', () => {
+    const payload = basePayload({ oid: OID_BOB });
+    const opts = baseOptions({ authorizedUserOids: [OID_ALICE], redactUpn: true });
+    expect(authorizeUserClaims(payload, opts)).toBeNull();
+  });
+
+  it('returned claims still carry plaintext upn (only logs are redacted)', () => {
+    const payload = basePayload({ oid: OID_ALICE });
+    const opts = baseOptions({
+      authorizedUserOids: [OID_ALICE],
+      redactUpn: true,
+    });
+    const claims = authorizeUserClaims(payload, opts);
+    expect(claims?.upn).toBe('alice@contoso.com');
   });
 });


### PR DESCRIPTION
## Summary

Closes #71. Adds a `--log-redact-upn` CLI flag that replaces UPN values in log lines with a deterministic SHA-256 prefix, plus a new "Personal data handled by this server" section in `SECURITY.md` listing every user-attributable value the server emits.

## Why

UPN appears on every authentication log line (success + rejection paths). Under PIPEDA, RGPD, Loi 25, KVKK, UU PDP, etc., shipping logs to a SIEM or external forwarder either requires a DPA covering work-email PII, or the PII has to be removed before egress. The current code requires the operator to redact downstream — which is fragile and easy to miss.

The fix gives operators a single flag to neutralize the issue, while keeping the Entra `oid` (a non-PII GUID) in plaintext so audit teams can pivot through the directory. Hash is deterministic, so a single user produces the same prefix across log lines — **forensic correlation is preserved**.

## Why opt-in (default false)

- Preserves current log behavior for existing deployments — no surprise change in observability tooling that may parse the existing format
- Operators in jurisdictions that don't require redaction (or that have a DPA in place) keep the more readable plaintext
- LCI Education and similar regulated tenants should enable it; the SECURITY.md hardening checklist now recommends it

## Changes

- `src/user-token-authorization.ts`:
  - New `redactUpn?: boolean` option on `UserTokenValidatorOptions`
  - New named export `formatUpnForLog(value, redact)` — returns plaintext when `redact=false/undefined`, returns `sha256:<16hex>` when `redact=true`, returns `<none>` for empty/undefined input
  - Both rejection log lines (no-allowlist + oid-not-in-list) use the helper
  - The returned `UserTokenClaims.upn` stays plaintext — only logs are redacted, in-memory state is unaffected
- `src/http-server.ts`: import + use the helper on the authentication-success log line, reading `redactUpn` from the validator options
- `src/cli.ts`: new `--log-redact-upn` flag with help text referencing the regulated-tenant rationale
- `src/server.ts`: plumb the flag into `userTokenValidatorOptions`
- `SECURITY.md`:
  - New "Personal data handled by this server" section with a 6-row table listing UPN, oid, source IP, bearer tokens, tool call parameters, and Graph API responses — with source, where-it-appears, and mitigation columns
  - Hardening checklist gains a 9th item recommending `--log-redact-upn` for SIEM-forwarded logs
  - Notes the 30-day default Log Analytics retention and explicitly explains why `oid` is **not** redacted

## Test plan

- [x] `npm run verify` passes (lint, format, build, 159 tests — was 151 before this PR)
- [x] 8 new test cases in `test/user-token-validator.test.ts`:
  - `formatUpnForLog` returns plaintext when `redact=false/undefined`
  - Returns `sha256:<16hex>` when `redact=true`, doesn't contain the original local-part or domain
  - Deterministic — same UPN → same prefix
  - Different UPNs → different prefixes
  - `<none>` for empty/undefined
  - Rejection paths still reject regardless of `redactUpn`
  - `authorizeUserClaims` still surfaces plaintext UPN to callers (in-memory unaffected)

## References

- Finding: [SECURITY_REVIEW_2026-04-25.md §SEC-004](docs/SECURITY_REVIEW_2026-04-25.md)
- Issue: #71
- Jira: [CYSEC-1476](https://lcieducation.atlassian.net/browse/CYSEC-1476)
- LCI privacy officer: Mery Paz Monroy (DPIA inventory benefits from the new SECURITY.md table)