### PR TITLE
fix(auth): map RFC 6750 token failures to 401 vs 403 status codes

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -3,8 +3,11 @@ import type { Request, Response, NextFunction } from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import logger from './logger.js';
-import { validateEntraToken, type TokenValidatorOptions } from './token-validator.js';
-import { validateUserToken, type UserTokenValidatorOptions } from './user-token-validator.js';
+import { validateEntraTokenExplain, type TokenValidatorOptions } from './token-validator.js';
+import {
+  validateUserTokenExplain,
+  type UserTokenValidatorOptions,
+} from './user-token-validator.js';
 import { formatUpnForLog } from './user-token-authorization.js';
 import { registerOAuthRoutes, type OAuthProxyOptions } from './oauth-proxy.js';
 import { registerOAuthRateLimiters } from './oauth-rate-limiters.js';
@@ -38,6 +41,107 @@ function resourceMetadataUrl(publicUrl: string): string {
   // header-derived fallback here either, to keep the WWW-Authenticate challenge
   // consistent with the advertised metadata.
   return `${stripTrailingSlash(publicUrl)}/.well-known/oauth-protected-resource`;
+}
+
+export interface McpAuthMiddlewareOptions {
+  serviceValidator?: TokenValidatorOptions;
+  userValidator?: UserTokenValidatorOptions;
+  /**
+   * When set, every challenge response includes a
+   * `WWW-Authenticate: Bearer resource_metadata="..."` header pointing at the
+   * RFC 9728 protected-resource metadata document. Omit when no OAuth proxy
+   * is configured — there is nothing for the client to discover.
+   */
+  oauthPublicUrl?: string;
+}
+
+/**
+ * Builds the `/mcp` Bearer-token validation middleware.
+ *
+ * Extracted from `startHttpServer` so it can be unit-tested in isolation
+ * without spinning up the OAuth proxy, rate limiter, or MCP transport. The
+ * RFC 6750 §3.1 status mapping (invalid_token → 401, insufficient_scope →
+ * 403) is the load-bearing contract — see `http-server.test.ts` for the
+ * regression suite that pins it.
+ */
+export function createMcpAuthMiddleware(
+  options: McpAuthMiddlewareOptions
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  const { serviceValidator, userValidator, oauthPublicUrl } = options;
+
+  function setChallengeHeader(_req: Request, res: Response, errorCode?: string): void {
+    if (!oauthPublicUrl) return;
+    const metadata = resourceMetadataUrl(oauthPublicUrl);
+    const parts = [`resource_metadata="${metadata}"`];
+    if (errorCode) parts.push(`error="${errorCode}"`);
+    res.setHeader('WWW-Authenticate', `Bearer ${parts.join(', ')}`);
+  }
+
+  return async function mcpAuthMiddleware(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      logger.info(`MCP ${req.method} ${req.path} → 401 (no bearer)`);
+      setChallengeHeader(req, res);
+      res.status(401).json({ error: 'Missing or invalid Authorization header' });
+      return;
+    }
+    const token = authHeader.slice(7);
+
+    // RFC 6750 §3.1: distinguish `invalid_token` (→ 401, prompts the client
+    // to refresh or re-authenticate) from `insufficient_scope` (→ 403, the
+    // principal lacks permission and a refresh would not help). mcp-remote
+    // and other compliant clients only attempt token refresh on 401; mapping
+    // an expired access_token to 403 caused infinite reconnect loops in the
+    // field — see commit history for the regression.
+    let userInsufficientScope = false;
+    if (userValidator) {
+      const userResult = await validateUserTokenExplain(token, userValidator);
+      if (userResult.ok) {
+        // SEC-F08 (SEC-004): respect --log-redact-upn here too. The Entra `oid`
+        // (non-PII GUID) stays plain when no UPN is present so operators can
+        // still pivot through the directory.
+        const upnForLog = formatUpnForLog(userResult.claims.upn, userValidator.redactUpn);
+        logger.info(
+          `MCP request authenticated as user ${userResult.claims.upn ? upnForLog : userResult.claims.oid} (oid ${userResult.claims.oid})`
+        );
+        // Store the raw bearer token so OBO can use it as the user assertion downstream.
+        res.locals.userToken = token;
+        next();
+        return;
+      }
+      if (userResult.reason === 'insufficient_scope') {
+        userInsufficientScope = true;
+      }
+    }
+
+    if (serviceValidator) {
+      const serviceResult = await validateEntraTokenExplain(token, serviceValidator);
+      if (serviceResult.ok) {
+        next();
+        return;
+      }
+    }
+
+    // If the user-token path rejected on insufficient_scope and the service
+    // path could not rescue (or was not configured), the most accurate
+    // signal back to the client is 403 insufficient_scope. Otherwise the
+    // failure was identity/integrity (signature, expiry, audience, allowlist)
+    // → 401 invalid_token, which lets the client refresh and retry.
+    if (userInsufficientScope) {
+      logger.warn(`MCP ${req.method} ${req.path} → 403 (insufficient_scope)`);
+      setChallengeHeader(req, res, 'insufficient_scope');
+      res.status(403).json({ error: 'insufficient_scope' });
+      return;
+    }
+
+    logger.warn(`MCP ${req.method} ${req.path} → 401 (invalid_token)`);
+    setChallengeHeader(req, res, 'invalid_token');
+    res.status(401).json({ error: 'invalid_token' });
+  };
 }
 
 export async function startHttpServer(options: HttpServerOptions): Promise<void> {
@@ -83,56 +187,14 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
     );
   }
 
-  const oauthPublicUrl = options.oauthProxyOptions?.publicUrl;
-  const oauthEnabled = Boolean(options.oauthProxyOptions);
-
-  function setChallengeHeader(_req: Request, res: Response, errorCode?: string): void {
-    if (!oauthEnabled || !oauthPublicUrl) return;
-    const metadata = resourceMetadataUrl(oauthPublicUrl);
-    const parts = [`resource_metadata="${metadata}"`];
-    if (errorCode) parts.push(`error="${errorCode}"`);
-    res.setHeader('WWW-Authenticate', `Bearer ${parts.join(', ')}`);
-  }
-
-  app.use('/mcp', async (req: Request, res: Response, next: NextFunction) => {
-    const authHeader = req.headers.authorization;
-    if (!authHeader || !authHeader.startsWith('Bearer ')) {
-      logger.info(`MCP ${req.method} ${req.path} → 401 (no bearer)`);
-      setChallengeHeader(req, res);
-      res.status(401).json({ error: 'Missing or invalid Authorization header' });
-      return;
-    }
-    const token = authHeader.slice(7);
-
-    if (userValidator) {
-      const userClaims = await validateUserToken(token, userValidator);
-      if (userClaims) {
-        // SEC-F08 (SEC-004): respect --log-redact-upn here too. The Entra `oid`
-        // (non-PII GUID) stays plain when no UPN is present so operators can
-        // still pivot through the directory.
-        const upnForLog = formatUpnForLog(userClaims.upn, userValidator.redactUpn);
-        logger.info(
-          `MCP request authenticated as user ${userClaims.upn ? upnForLog : userClaims.oid} (oid ${userClaims.oid})`
-        );
-        // Store the raw bearer token so OBO can use it as the user assertion downstream.
-        res.locals.userToken = token;
-        next();
-        return;
-      }
-    }
-
-    if (serviceValidator) {
-      const serviceValid = await validateEntraToken(token, serviceValidator);
-      if (serviceValid) {
-        next();
-        return;
-      }
-    }
-
-    logger.warn(`MCP ${req.method} ${req.path} → 403 (token validation failed)`);
-    setChallengeHeader(req, res, 'invalid_token');
-    res.status(403).json({ error: 'Token validation failed' });
-  });
+  app.use(
+    '/mcp',
+    createMcpAuthMiddleware({
+      serviceValidator,
+      userValidator,
+      oauthPublicUrl: options.oauthProxyOptions?.publicUrl,
+    })
+  );
 
   async function handleMcpRequest(req: Request, res: Response): Promise<void> {
     const server = options.createServer(res.locals.userToken as string | undefined);

--- a/src/token-validator.ts
+++ b/src/token-validator.ts
@@ -74,17 +74,26 @@ function getSigningKey(
   return withStaleKeyFallback(kid, () => fetchSigningKey(client, kid), getStaleKeyCache(tenantId));
 }
 
-export async function validateEntraToken(
+/**
+ * Result of `validateEntraTokenExplain`. Service tokens (client_credentials)
+ * do not carry user scopes, so every failure mode reduces to `invalid_token`
+ * — there is no `insufficient_scope` path here. Kept as a tagged union for
+ * symmetry with `validateUserTokenExplain` and to make future scope checks
+ * (e.g. `roles` claim) trivial to slot in.
+ */
+export type ValidateEntraTokenResult = { ok: true } | { ok: false; reason: 'invalid_token' };
+
+export async function validateEntraTokenExplain(
   token: string,
   options: TokenValidatorOptions
-): Promise<boolean> {
+): Promise<ValidateEntraTokenResult> {
   try {
     const client = getJwksClient(options.tenantId);
 
     const decoded = jwt.decode(token, { complete: true });
     if (!decoded || typeof decoded === 'string') {
       logger.warn('Token could not be decoded');
-      return false;
+      return { ok: false, reason: 'invalid_token' };
     }
 
     const publicKey = await getSigningKey(options.tenantId, client, decoded.header);
@@ -99,26 +108,40 @@ export async function validateEntraToken(
     if (options.expectedAudience) {
       if (payload.aud !== options.expectedAudience) {
         logger.warn('Token audience mismatch');
-        return false;
+        return { ok: false, reason: 'invalid_token' };
       }
     }
 
     // Verify tenant ID from token payload
     if (payload.tid && payload.tid !== options.tenantId) {
       logger.warn('Token tenant ID mismatch');
-      return false;
+      return { ok: false, reason: 'invalid_token' };
     }
 
     // Verify client ID is in the allowed list
     const clientId = payload.appid || payload.azp;
     if (!clientId || !options.allowedClientIds.includes(clientId)) {
       logger.warn('Token client ID not in allowed list');
-      return false;
+      return { ok: false, reason: 'invalid_token' };
     }
 
-    return true;
+    return { ok: true };
   } catch (error) {
+    // Signature, expiry (TokenExpiredError), JWKS lookup, decode — all collapse
+    // to RFC 6750 `invalid_token` from the wire's point of view.
     logger.error(`Token validation failed: ${(error as Error).message}`);
-    return false;
+    return { ok: false, reason: 'invalid_token' };
   }
+}
+
+/**
+ * Backwards-compatible wrapper. Prefer `validateEntraTokenExplain` in new
+ * callers so the failure mode can be surfaced as an HTTP status.
+ */
+export async function validateEntraToken(
+  token: string,
+  options: TokenValidatorOptions
+): Promise<boolean> {
+  const result = await validateEntraTokenExplain(token, options);
+  return result.ok;
 }

--- a/src/user-token-authorization.ts
+++ b/src/user-token-authorization.ts
@@ -44,6 +44,24 @@ export interface UserTokenClaims {
   appid?: string;
 }
 
+/**
+ * Structured outcome of `authorizeUserClaimsExplain`. Distinguishes
+ * `invalid_token` (signature/audience/issuer/expiry/missing-claim/allowlist
+ * failures — the bearer is unauthenticated as far as RFC 6750 §3.1 is
+ * concerned) from `insufficient_scope` (token is otherwise valid but lacks a
+ * required `scp` claim entry — RFC 6750 §3.1 §insufficient_scope).
+ *
+ * mcp-remote and other RFC-compliant clients only attempt a refresh on 401
+ * `invalid_token`; on 403 `insufficient_scope` they correctly stop. Mapping
+ * the wrong reason to the wrong HTTP status causes infinite reconnect loops
+ * when the access_token simply expired.
+ */
+export type AuthorizationFailureReason = 'invalid_token' | 'insufficient_scope';
+
+export type AuthorizeUserClaimsResult =
+  | { ok: true; claims: UserTokenClaims }
+  | { ok: false; reason: AuthorizationFailureReason };
+
 export interface UserTokenPayload {
   iss?: string;
   aud?: string | string[];
@@ -73,27 +91,31 @@ function parseTokenScopes(scp: string | undefined): string[] {
  * Post-signature-verification authorization checks on the user token payload.
  * Pure function — no network, no JWT verification — so it is safe to import
  * from tests without pulling the JWKS / jose dependency chain.
+ *
+ * Returns a structured result so callers (HTTP layer) can map RFC 6750 §3.1
+ * error codes to the correct HTTP status: `invalid_token` → 401,
+ * `insufficient_scope` → 403. See `AuthorizeUserClaimsResult` for rationale.
  */
-export function authorizeUserClaims(
+export function authorizeUserClaimsExplain(
   payload: UserTokenPayload,
   options: UserTokenValidatorOptions
-): UserTokenClaims | null {
+): AuthorizeUserClaimsResult {
   if (payload.tid && payload.tid !== options.tenantId) {
     logger.warn(`User token tenant mismatch: tid=${payload.tid}, expected=${options.tenantId}`);
-    return null;
+    return { ok: false, reason: 'invalid_token' };
   }
 
   if (!audienceMatches(payload.aud, options.expectedAudiences)) {
     logger.warn(
       `User token audience not in expected list: aud=${JSON.stringify(payload.aud)}, expected=${JSON.stringify(options.expectedAudiences)}`
     );
-    return null;
+    return { ok: false, reason: 'invalid_token' };
   }
 
   const oid = payload.oid;
   if (!oid) {
     logger.warn('User token missing oid claim');
-    return null;
+    return { ok: false, reason: 'invalid_token' };
   }
 
   // SEC-F01: fail-closed when no per-user allowlist is configured.
@@ -105,14 +127,17 @@ export function authorizeUserClaims(
       logger.warn(
         `User ${upnForLog} (oid ${oid}) rejected: no --authorized-users allowlist configured and --allow-any-tenant-user not set`
       );
-      return null;
+      return { ok: false, reason: 'invalid_token' };
     }
   } else if (!options.authorizedUserOids.includes(oid)) {
     logger.warn(`User oid ${oid} (${upnForLog}) not in authorized-users allowlist`);
-    return null;
+    return { ok: false, reason: 'invalid_token' };
   }
 
   // SEC-F03: enforce required scopes (e.g. access_as_user) on the `scp` claim.
+  // This is the one case where the token is "valid" (signed, audience OK,
+  // identity OK) but the principal lacks the required scope — RFC 6750
+  // `insufficient_scope` / HTTP 403, distinct from `invalid_token` / 401.
   if (options.requiredScopes.length > 0) {
     const tokenScopes = parseTokenScopes(payload.scp);
     const missing = options.requiredScopes.filter((s) => !tokenScopes.includes(s));
@@ -120,14 +145,30 @@ export function authorizeUserClaims(
       logger.warn(
         `User token missing required scope(s): ${missing.join(', ')}; token scp=${payload.scp ?? '<none>'}`
       );
-      return null;
+      return { ok: false, reason: 'insufficient_scope' };
     }
   }
 
   return {
-    oid,
-    upn: payload.upn || payload.preferred_username,
-    name: payload.name,
-    appid: payload.appid || payload.azp,
+    ok: true,
+    claims: {
+      oid,
+      upn: payload.upn || payload.preferred_username,
+      name: payload.name,
+      appid: payload.appid || payload.azp,
+    },
   };
+}
+
+/**
+ * Backwards-compatible wrapper around `authorizeUserClaimsExplain`. Returns
+ * the claims on success or `null` on any rejection. Prefer the explain variant
+ * in new callers so the failure mode can be surfaced as an HTTP status.
+ */
+export function authorizeUserClaims(
+  payload: UserTokenPayload,
+  options: UserTokenValidatorOptions
+): UserTokenClaims | null {
+  const result = authorizeUserClaimsExplain(payload, options);
+  return result.ok ? result.claims : null;
 }

--- a/src/user-token-validator.ts
+++ b/src/user-token-validator.ts
@@ -3,18 +3,23 @@ import jwksRsa from 'jwks-rsa';
 import logger from './logger.js';
 import { withStaleKeyFallback } from './jwks-stale-cache.js';
 import {
-  authorizeUserClaims,
+  authorizeUserClaimsExplain,
+  type AuthorizeUserClaimsResult,
   type UserTokenClaims,
   type UserTokenPayload,
   type UserTokenValidatorOptions,
 } from './user-token-authorization.js';
 
-export { authorizeUserClaims } from './user-token-authorization.js';
+export { authorizeUserClaims, authorizeUserClaimsExplain } from './user-token-authorization.js';
 export type {
+  AuthorizationFailureReason,
+  AuthorizeUserClaimsResult,
   UserTokenClaims,
   UserTokenPayload,
   UserTokenValidatorOptions,
 } from './user-token-authorization.js';
+
+export type ValidateUserTokenResult = AuthorizeUserClaimsResult;
 
 const jwksClients = new Map<string, jwksRsa.JwksClient>();
 // SEC-F08: per-tenant stale-while-revalidate cache of PEM public keys.
@@ -64,17 +69,23 @@ function getSigningKey(
   return withStaleKeyFallback(kid, () => fetchSigningKey(client, kid), getStaleKeyCache(tenantId));
 }
 
-export async function validateUserToken(
+/**
+ * Verify a user token and run authorization checks. Returns a structured
+ * result so the HTTP layer can map failures to the correct RFC 6750 status:
+ * `invalid_token` (signature, JWKS, expiry, audience, allowlist) → 401,
+ * `insufficient_scope` (token valid but `scp` missing a required entry) → 403.
+ */
+export async function validateUserTokenExplain(
   token: string,
   options: UserTokenValidatorOptions
-): Promise<UserTokenClaims | null> {
+): Promise<ValidateUserTokenResult> {
   try {
     const client = getJwksClient(options.tenantId);
 
     const decoded = jwt.decode(token, { complete: true });
     if (!decoded || typeof decoded === 'string') {
       logger.warn('User token could not be decoded');
-      return null;
+      return { ok: false, reason: 'invalid_token' };
     }
 
     const publicKey = await getSigningKey(options.tenantId, client, decoded.header);
@@ -88,9 +99,24 @@ export async function validateUserToken(
       clockTolerance: 30,
     }) as UserTokenPayload;
 
-    return authorizeUserClaims(payload, options);
+    return authorizeUserClaimsExplain(payload, options);
   } catch (error) {
+    // Signature, expiry, JWKS, decode failures all collapse to invalid_token.
+    // jsonwebtoken throws TokenExpiredError, JsonWebTokenError, NotBeforeError —
+    // all are RFC 6750 invalid_token from the wire's point of view.
     logger.error(`User token validation failed: ${(error as Error).message}`);
-    return null;
+    return { ok: false, reason: 'invalid_token' };
   }
+}
+
+/**
+ * Backwards-compatible wrapper. Returns claims on success or `null` on any
+ * failure. Prefer `validateUserTokenExplain` in new callers.
+ */
+export async function validateUserToken(
+  token: string,
+  options: UserTokenValidatorOptions
+): Promise<UserTokenClaims | null> {
+  const result = await validateUserTokenExplain(token, options);
+  return result.ok ? result.claims : null;
 }

--- a/test/http-server.test.ts
+++ b/test/http-server.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import express from 'express';
+import type { Server } from 'http';
+
+// Mock the JWT-validating modules BEFORE importing http-server, so the
+// middleware picks up our stubs instead of reaching out to JWKS. This keeps
+// the test focused on the RFC 6750 §3.1 status mapping (invalid_token → 401,
+// insufficient_scope → 403) without re-testing the underlying signature
+// verification logic, which is exercised in user-token-validator.test.ts.
+//
+// vi.hoisted is required because vi.mock factories are hoisted to the top of
+// the file before any const declarations. The stubs must be created in a
+// hoisted block so the factories can close over them.
+const { validateUserTokenExplainMock, validateEntraTokenExplainMock } = vi.hoisted(() => ({
+  validateUserTokenExplainMock: vi.fn(),
+  validateEntraTokenExplainMock: vi.fn(),
+}));
+
+vi.mock('../src/user-token-validator.js', () => ({
+  validateUserTokenExplain: validateUserTokenExplainMock,
+}));
+
+vi.mock('../src/token-validator.js', () => ({
+  validateEntraTokenExplain: validateEntraTokenExplainMock,
+}));
+
+import { createMcpAuthMiddleware } from '../src/http-server.js';
+import type { TokenValidatorOptions } from '../src/token-validator.js';
+import type { UserTokenValidatorOptions } from '../src/user-token-validator.js';
+
+const TENANT = '11111111-1111-1111-1111-111111111111';
+const CLIENT_ID = '22222222-2222-2222-2222-222222222222';
+const PUBLIC_URL = 'https://mcp.example.com';
+const VALID_CLAIMS = {
+  oid: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  upn: 'alice@contoso.com',
+  name: 'Alice',
+  appid: CLIENT_ID,
+};
+
+const userValidator: UserTokenValidatorOptions = {
+  tenantId: TENANT,
+  expectedAudiences: [CLIENT_ID, `api://${CLIENT_ID}`],
+  authorizedUserOids: [],
+  allowAnyTenantUser: true,
+  requiredScopes: ['access_as_user'],
+};
+
+const serviceValidator: TokenValidatorOptions = {
+  tenantId: TENANT,
+  allowedClientIds: [CLIENT_ID],
+  expectedAudience: `api://${CLIENT_ID}`,
+};
+
+interface BuiltServer {
+  url: string;
+  server: Server;
+}
+
+async function buildServer(opts: {
+  withUserValidator?: boolean;
+  withServiceValidator?: boolean;
+  withOauthPublicUrl?: boolean;
+}): Promise<BuiltServer> {
+  const app = express();
+  app.use(express.json({ limit: '100kb' }));
+
+  app.use(
+    '/mcp',
+    createMcpAuthMiddleware({
+      userValidator: opts.withUserValidator ? userValidator : undefined,
+      serviceValidator: opts.withServiceValidator ? serviceValidator : undefined,
+      oauthPublicUrl: opts.withOauthPublicUrl ? PUBLIC_URL : undefined,
+    })
+  );
+
+  // Downstream endpoint that only fires when the middleware calls next().
+  // The body echoes whether the user-OBO bearer was forwarded via res.locals
+  // so we can assert the user-token path stores the raw bearer correctly.
+  app.post('/mcp', (req, res) => {
+    res.status(200).json({
+      ok: true,
+      hasUserToken: typeof res.locals.userToken === 'string',
+    });
+  });
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => {
+      const addr = server.address();
+      if (addr && typeof addr === 'object') {
+        resolve({ url: `http://127.0.0.1:${addr.port}`, server });
+      }
+    });
+  });
+}
+
+let baseUrl: string;
+let server: Server;
+
+beforeAll(async () => {
+  // Build with both validators wired and OAuth metadata enabled — covers the
+  // common production config (user OBO + service principal fallback).
+  const built = await buildServer({
+    withUserValidator: true,
+    withServiceValidator: true,
+    withOauthPublicUrl: true,
+  });
+  baseUrl = built.url;
+  server = built.server;
+});
+
+afterAll(() => {
+  server.close();
+});
+
+async function postMcp(authHeader?: string): Promise<Response> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (authHeader) headers.Authorization = authHeader;
+  return fetch(`${baseUrl}/mcp`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+  });
+}
+
+function resetMocks(): void {
+  validateUserTokenExplainMock.mockReset();
+  validateEntraTokenExplainMock.mockReset();
+}
+
+describe('createMcpAuthMiddleware — RFC 6750 §3.1 status mapping', () => {
+  // This is the regression suite for the "Token validation failed → 403"
+  // bug that broke mcp-remote refresh in production. Expired access tokens
+  // MUST surface as 401 invalid_token so the client refreshes; only a
+  // genuinely scoped-down token may surface as 403 insufficient_scope.
+
+  it('returns 401 with WWW-Authenticate when no Authorization header is present', async () => {
+    resetMocks();
+    const res = await postMcp();
+    expect(res.status).toBe(401);
+    const challenge = res.headers.get('www-authenticate');
+    expect(challenge).toMatch(/^Bearer /);
+    expect(challenge).toContain(
+      `resource_metadata="${PUBLIC_URL}/.well-known/oauth-protected-resource"`
+    );
+    // The "no bearer" path should not announce an error code — the client
+    // hasn't presented credentials yet.
+    expect(challenge).not.toContain('error=');
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('Missing or invalid Authorization header');
+  });
+
+  it('returns 401 with WWW-Authenticate when the header is not a Bearer token', async () => {
+    resetMocks();
+    const res = await postMcp('Basic dXNlcjpwYXNz');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 and forwards the user bearer when the user token is valid', async () => {
+    resetMocks();
+    validateUserTokenExplainMock.mockResolvedValueOnce({ ok: true, claims: VALID_CLAIMS });
+    const res = await postMcp('Bearer valid-user-token');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; hasUserToken: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.hasUserToken).toBe(true);
+    // Service validator must NOT be consulted once the user path succeeds —
+    // both for performance and to avoid double-counting auth events.
+    expect(validateEntraTokenExplainMock).not.toHaveBeenCalled();
+    expect(validateUserTokenExplainMock).toHaveBeenCalledWith(
+      'valid-user-token',
+      expect.objectContaining({ tenantId: TENANT })
+    );
+  });
+
+  it('returns 200 when the user path rejects but the service path accepts', async () => {
+    resetMocks();
+    validateUserTokenExplainMock.mockResolvedValueOnce({ ok: false, reason: 'invalid_token' });
+    validateEntraTokenExplainMock.mockResolvedValueOnce({ ok: true });
+    const res = await postMcp('Bearer valid-service-token');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; hasUserToken: boolean };
+    // Service tokens do not populate res.locals.userToken — there is no UPN
+    // to perform on-behalf-of with downstream.
+    expect(body.hasUserToken).toBe(false);
+  });
+
+  it('returns 401 invalid_token when both validators reject with invalid_token (THE bug fix)', async () => {
+    // This is the exact production failure mode: an expired user access
+    // token. Pre-fix the server returned 403, mcp-remote did not attempt a
+    // refresh (it only refreshes on 401 per the MCP spec), and the client
+    // looped on the same dead token. After the fix, 401 makes the client
+    // refresh and recover automatically.
+    resetMocks();
+    validateUserTokenExplainMock.mockResolvedValueOnce({ ok: false, reason: 'invalid_token' });
+    validateEntraTokenExplainMock.mockResolvedValueOnce({ ok: false, reason: 'invalid_token' });
+    const res = await postMcp('Bearer expired-token');
+    expect(res.status).toBe(401);
+    const challenge = res.headers.get('www-authenticate');
+    expect(challenge).toContain('error="invalid_token"');
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid_token');
+  });
+
+  it('returns 403 insufficient_scope when the user path rejects on missing scope and no service fallback succeeds', async () => {
+    resetMocks();
+    validateUserTokenExplainMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'insufficient_scope',
+    });
+    validateEntraTokenExplainMock.mockResolvedValueOnce({ ok: false, reason: 'invalid_token' });
+    const res = await postMcp('Bearer scoped-down-token');
+    expect(res.status).toBe(403);
+    const challenge = res.headers.get('www-authenticate');
+    expect(challenge).toContain('error="insufficient_scope"');
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('insufficient_scope');
+  });
+
+  it('insufficient_scope on the user path is rescued by a successful service token', async () => {
+    // A service principal that bypasses user-scope checks should still get
+    // through — e.g. an admin runbook calling on its own behalf. The
+    // user-path insufficient_scope must NOT poison the eventual outcome.
+    resetMocks();
+    validateUserTokenExplainMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'insufficient_scope',
+    });
+    validateEntraTokenExplainMock.mockResolvedValueOnce({ ok: true });
+    const res = await postMcp('Bearer admin-service-token');
+    expect(res.status).toBe(200);
+  });
+
+  it('omits WWW-Authenticate entirely when no oauthPublicUrl is configured', async () => {
+    // Without an OAuth proxy there is no resource-metadata document to point
+    // clients at; RFC 9728 §5.1 says the challenge MAY be omitted in that
+    // case, and the server SHOULD avoid advertising a metadata URL it does
+    // not host.
+    resetMocks();
+    const built = await buildServer({
+      withUserValidator: true,
+      withServiceValidator: false,
+      withOauthPublicUrl: false,
+    });
+    try {
+      validateUserTokenExplainMock.mockResolvedValueOnce({
+        ok: false,
+        reason: 'invalid_token',
+      });
+      const res = await fetch(`${built.url}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer x' },
+        body: '{}',
+      });
+      expect(res.status).toBe(401);
+      expect(res.headers.get('www-authenticate')).toBeNull();
+    } finally {
+      built.server.close();
+    }
+  });
+
+  it('returns 401 when only the service validator is configured and rejects', async () => {
+    // Service-only deployments (no OAuth proxy, --allowed-clients only) must
+    // still emit 401 on token failure so machine-to-machine clients can
+    // detect transient credential issues vs. permanent authorization gaps.
+    resetMocks();
+    const built = await buildServer({
+      withUserValidator: false,
+      withServiceValidator: true,
+      withOauthPublicUrl: true,
+    });
+    try {
+      validateEntraTokenExplainMock.mockResolvedValueOnce({
+        ok: false,
+        reason: 'invalid_token',
+      });
+      const res = await fetch(`${built.url}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer x' },
+        body: '{}',
+      });
+      expect(res.status).toBe(401);
+      const challenge = res.headers.get('www-authenticate');
+      expect(challenge).toContain('error="invalid_token"');
+      // User validator must not be called when not configured.
+      expect(validateUserTokenExplainMock).not.toHaveBeenCalled();
+    } finally {
+      built.server.close();
+    }
+  });
+});

--- a/test/user-token-validator.test.ts
+++ b/test/user-token-validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   authorizeUserClaims,
+  authorizeUserClaimsExplain,
   formatUpnForLog,
   type UserTokenValidatorOptions,
 } from '../src/user-token-authorization.js';
@@ -192,6 +193,91 @@ describe('SEC-F08 (SEC-004) — formatUpnForLog', () => {
     expect(formatUpnForLog(undefined, true)).toBe('<none>');
     expect(formatUpnForLog(undefined, false)).toBe('<none>');
     expect(formatUpnForLog('', true)).toBe('<none>');
+  });
+});
+
+describe('authorizeUserClaimsExplain — RFC 6750 reason mapping', () => {
+  // These tests guard the wire contract: identity / integrity failures must
+  // surface as `invalid_token` (→ HTTP 401, client refreshes), and only a
+  // missing required scope on an otherwise-valid token may surface as
+  // `insufficient_scope` (→ HTTP 403, refresh would not help). Mis-mapping
+  // expiry / audience to 403 caused infinite reconnect loops with mcp-remote
+  // in the field.
+
+  it('returns ok:true with claims when the token is fully valid', () => {
+    const payload = basePayload();
+    const result = authorizeUserClaimsExplain(
+      payload,
+      baseOptions({ allowAnyTenantUser: true, requiredScopes: ['access_as_user'] })
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.claims.oid).toBe(OID_ALICE);
+    }
+  });
+
+  it('reports invalid_token on tenant mismatch', () => {
+    const payload = basePayload({ tid: 'other-tenant-id' });
+    const result = authorizeUserClaimsExplain(payload, baseOptions({ allowAnyTenantUser: true }));
+    expect(result).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  it('reports invalid_token on audience mismatch', () => {
+    const payload = basePayload({ aud: 'api://some-other-app' });
+    const result = authorizeUserClaimsExplain(payload, baseOptions({ allowAnyTenantUser: true }));
+    expect(result).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  it('reports invalid_token when oid is missing', () => {
+    const payload = basePayload({ oid: undefined });
+    const result = authorizeUserClaimsExplain(payload, baseOptions({ allowAnyTenantUser: true }));
+    expect(result).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  it('reports invalid_token on SEC-F01 fail-closed (no allowlist, allowAnyTenantUser=false)', () => {
+    const payload = basePayload();
+    const result = authorizeUserClaimsExplain(payload, baseOptions());
+    expect(result).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  it('reports invalid_token when oid is not in a non-empty allowlist', () => {
+    const payload = basePayload({ oid: 'cccccccc-cccc-cccc-cccc-cccccccccccc' });
+    const result = authorizeUserClaimsExplain(
+      payload,
+      baseOptions({ authorizedUserOids: [OID_ALICE, OID_BOB], allowAnyTenantUser: true })
+    );
+    expect(result).toEqual({ ok: false, reason: 'invalid_token' });
+  });
+
+  it('reports insufficient_scope when scp is missing a required entry', () => {
+    const payload = basePayload({ scp: 'profile email' });
+    const result = authorizeUserClaimsExplain(
+      payload,
+      baseOptions({ allowAnyTenantUser: true, requiredScopes: ['access_as_user'] })
+    );
+    expect(result).toEqual({ ok: false, reason: 'insufficient_scope' });
+  });
+
+  it('reports insufficient_scope when scp claim is absent and scopes are required', () => {
+    const payload = basePayload({ scp: undefined });
+    const result = authorizeUserClaimsExplain(
+      payload,
+      baseOptions({ allowAnyTenantUser: true, requiredScopes: ['access_as_user'] })
+    );
+    expect(result).toEqual({ ok: false, reason: 'insufficient_scope' });
+  });
+
+  it('reports invalid_token (not insufficient_scope) when both identity and scope fail — identity wins', () => {
+    // Audience mismatch is checked before the scope check, so the wire signal
+    // should be invalid_token. This guards the order: a client that does not
+    // even have the right audience must not be told "your scope is wrong"
+    // (which would imply identity is fine).
+    const payload = basePayload({ aud: 'api://some-other-app', scp: 'profile' });
+    const result = authorizeUserClaimsExplain(
+      payload,
+      baseOptions({ allowAnyTenantUser: true, requiredScopes: ['access_as_user'] })
+    );
+    expect(result).toEqual({ ok: false, reason: 'invalid_token' });
   });
 });
 


### PR DESCRIPTION
## Summary

The `/mcp` middleware was returning HTTP **403 "Token validation failed"** for every token failure mode (expired, signature mismatch, audience error, missing scope, etc.). This violates **RFC 6750 §3.1**, which reserves 403 (`insufficient_scope`) for tokens that are otherwise valid but lack the required scope, and uses 401 (`invalid_token`) for everything else.

mcp-remote and other compliant MCP clients only attempt token refresh on **401**. Expired access tokens were producing infinite reconnect loops in production: client never refreshes on 403, dead token replayed every ~1h until manual cache wipe. Reported on the LCI deployment of `ca-cc-mcpms365admin-p`.

## What changed

| File | Change |
|---|---|
| `src/token-validator.ts` | New `validateEntraTokenExplain()` returns a tagged result. Old `validateEntraToken(): boolean` wraps it. |
| `src/user-token-authorization.ts` | New `authorizeUserClaimsExplain()` distinguishes `invalid_token` (tenant/audience/oid/allowlist) from `insufficient_scope` (`scp` missing a required entry). Old `authorizeUserClaims()` wraps it. |
| `src/user-token-validator.ts` | New `validateUserTokenExplain()` composes signature verification + the explain authorization. Old `validateUserToken()` wraps it. |
| `src/http-server.ts` | Middleware extracted into `createMcpAuthMiddleware()` for unit testability. Maps `invalid_token` → **401**, `insufficient_scope` → **403**, with matching `WWW-Authenticate: Bearer error="..."` challenge. |
| `test/user-token-validator.test.ts` | +8 tests pinning the explain reason for every authorization branch. |
| `test/http-server.test.ts` (new) | +9 end-to-end tests via Express + `vi.hoisted` mocks. Pins the bug-fix path (expired token → 401 invalid_token) and edge cases. |

All public APIs (`validateUserToken`, `validateEntraToken`, `authorizeUserClaims`) remain backwards-compatible.

## Test plan

- [x] `npm run verify` — generate + lint + format + build + 177 tests pass
- [x] `vitest run test/user-token-validator.test.ts` — 8 new authorization-reason tests green
- [x] `vitest run test/http-server.test.ts` — 9 new HTTP-mapping tests green, including the regression test "returns 401 invalid_token when both validators reject with invalid_token (THE bug fix)"
- [ ] **After merge + release tag + Container App redeploy:** confirm production endpoint returns `401 + WWW-Authenticate: Bearer error="invalid_token"` for an expired token (was 403). Once verified, mcp-remote should refresh tokens automatically without operator intervention.

## Deployment notes

`release.yml` triggers on tag push or `workflow_dispatch` — merge alone does not redeploy. Cut a patch release tag (or dispatch the workflow manually) once this is reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)