### PR TITLE
chore(release): 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@okapi-ca/ms-365-admin-mcp-server",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-node": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Bump version for the RFC 6750 token-failure status-mapping fix shipped in #91. Triggers the `release.yml` workflow once the `v0.6.2` tag is pushed (npm + GHCR publish).

## Test plan

- [x] CI verify green
- [ ] After merge: tag `v0.6.2` on the resulting main commit, push, confirm the release workflow runs.
- [ ] Container App `ca-cc-mcpms365admin-p` redeployed to `0.6.2` and returning `401 + WWW-Authenticate: Bearer error="invalid_token"` for an expired token (was 403).