### PR TITLE
docs(skills): add ms365-admin-mcp agent skill for LLM clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | [docs/USE_CASES.md](docs/USE_CASES.md)                                 | 15 typical admin scenarios with sample prompts and tool lists               |
 | [docs/playbooks/](docs/playbooks/README.md)                            | End-to-end security incident response playbooks                             |
+| [agent-skills/](agent-skills/README.md)                                | Drop-in skills for LLM agents (Claude Code et al.) with safety patterns     |
 | [docs/APP_REGISTRATION.md](docs/APP_REGISTRATION.md)                   | Step-by-step Azure AD app registration and permission consent               |
 | [docs/HTTP_DEPLOYMENT.md](docs/HTTP_DEPLOYMENT.md)                     | HTTP transport, JWT validation, Docker, Azure Container Apps                |
 | [docs/AZURE_DEPLOYMENT_SECURITY.md](docs/AZURE_DEPLOYMENT_SECURITY.md) | Threat model, required controls, and checklist for Azure production deploys |

--- a/agent-skills/README.md
+++ b/agent-skills/README.md
@@ -1,0 +1,43 @@
+# Agent skills
+
+Drop-in skills for LLM agents that operate `ms-365-admin-mcp-server`. Skills wrap the server's 515 tools with a structured safety pattern (dry-run → confirm → audit) and route requests by use case to keep the model focused on the right subset.
+
+## Available skills
+
+| Skill                                  | Purpose                                                                                                                                   |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [`ms365-admin-mcp/`](ms365-admin-mcp/) | Reference skill for tenant-scoped administration: security triage, identity, Intune, Conditional Access, eDiscovery, hunting, governance. |
+
+## How skills relate to the rest of the docs
+
+Skills are an **operating layer** on top of the server, oriented at LLM clients. They complement the existing documentation rather than replacing it:
+
+- [`docs/USE_CASES.md`](../docs/USE_CASES.md) — canonical list of 15 admin scenarios with sample prompts.
+- [`docs/playbooks/`](../docs/playbooks/README.md) — end-to-end incident response procedures.
+- [`docs/RISK_MODEL.md`](../docs/RISK_MODEL.md) — risk classification rubric for write tools.
+- This directory — agent-loadable skills that index those docs by use case and enforce the safety pattern on every mutation.
+
+## Installing a skill
+
+### Claude Code
+
+1. Copy the skill directory into your project's `.claude/skills/` (or your global `~/.claude/skills/`):
+   ```bash
+   cp -r agent-skills/ms365-admin-mcp ~/.claude/skills/
+   ```
+2. Restart Claude Code. The skill auto-loads when the conversation matches its `description` field.
+
+### Other clients
+
+The skill format is portable. The `SKILL.md` file is plain markdown with YAML frontmatter (`name`, `description`). Reference files under `references/` are lazy-loaded — the main `SKILL.md` indexes them and the model loads one at a time as needed. Most modern agent runtimes can ingest this structure directly.
+
+## Contributing a skill
+
+When proposing a new skill:
+
+1. Place it under `agent-skills/<skill-name>/`.
+2. Keep `SKILL.md` under ~200 lines — it's loaded at the start of every relevant conversation.
+3. Use `references/<topic>.md` for domain-specific guidance, lazy-loaded one at a time.
+4. Anonymize all examples (`@contoso.com`, generic role names — no real users, no tenant-specific deployment details).
+5. Link to authoritative server docs (`docs/USE_CASES.md`, `docs/playbooks/`, `docs/RISK_MODEL.md`) rather than duplicating their content.
+6. For any tool reference, confirm the tool exists in [`src/endpoints.json`](../src/endpoints.json).

--- a/agent-skills/ms365-admin-mcp/SKILL.md
+++ b/agent-skills/ms365-admin-mcp/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: ms365-admin-mcp
+description: Reference skill for operating ms-365-admin-mcp-server through an LLM client. Load when a request involves a Microsoft 365 administrative operation requiring tenant-level permissions — Defender alert triage, sign-in investigation, PIM audit, Intune actions, eDiscovery, KQL hunting, Conditional Access management, or any tenant-scoped directory operation through application (client credentials) permissions.
+---
+
+# ms365-admin-mcp
+
+A reusable Claude Code skill that wraps `ms-365-admin-mcp-server` with a structured safety pattern: discover the right tool by use case, dry-run first, confirm explicitly, audit after. The skill is a router — its reference files index the server's 515 tools by domain and point back to the authoritative documentation in [`docs/USE_CASES.md`](../../docs/USE_CASES.md) and [`docs/playbooks/`](../../docs/playbooks/README.md).
+
+## When to load this skill
+
+Load this skill when the request involves a **Microsoft 365 administrative operation** requiring tenant-level permissions. Typical signals:
+
+- "List security alerts / open incidents / risky users"
+- "Audit sign-ins for…", "what changed in the directory yesterday"
+- "Permanent Global Admin members", "PIM assignments"
+- "Non-compliant Intune devices", "wipe the device of user X"
+- "Create a Conditional Access policy", "audit current CA policies"
+- "Applications with expiring secrets", "suspicious OAuth grants"
+- "Run a hunting query", "threat intel on this IP"
+- "Create an eDiscovery case", "apply a hold on user X's mailbox"
+
+## When NOT to load this skill
+
+This server uses **application permissions** (client credentials). Do not load it when the request concerns the operator's own data: their personal mailbox, calendar, OneDrive, Teams chats, or anything that should run as a connected user. Those scenarios belong to a **delegated** companion server such as [Softeria/ms-365-mcp-server](https://github.com/Softeria/ms-365-mcp-server).
+
+| Situation                                 | Server to use             |
+| ----------------------------------------- | ------------------------- |
+| "Read my emails"                          | Delegated companion       |
+| "List tenant message traces"              | `ms-365-admin-mcp-server` |
+| "Create an event in my calendar"          | Delegated companion       |
+| "List risky sign-ins for the last 7 days" | `ms-365-admin-mcp-server` |
+| "Send an email to the team"               | Delegated companion       |
+| "Disable user `jdoe@contoso.com`"         | `ms-365-admin-mcp-server` |
+
+When in doubt, ask whether the operation concerns **the operator's own data** (delegated) or **the tenant / other users** (application).
+
+## Security model — read this before every write
+
+### Read-only by default
+
+The server is read-only unless started with `--allow-writes`. Even when writes are enabled, treat reads as the default and route every mutation through the dry-run / confirmation / audit pattern below.
+
+### Risk levels
+
+Every write tool is classified `low` / `medium` / `high` / `critical` in [`docs/RISK_MODEL.md`](../../docs/RISK_MODEL.md). Each `references/usecase-*.md` file in this skill names the tools in scope along with their risk level — consult the relevant use case file before invoking any write.
+
+The server can be capped at startup with `--max-risk-level <level>` to hide tools above a chosen level (`--max-risk-level medium` keeps low- and medium-risk writes, hides `high` and `critical`). Recommend this when you don't need the riskier surface.
+
+### Mandatory pattern for `high` and `critical` tools
+
+For any tool classified `high` or `critical`, follow this sequence without exception:
+
+1. **Dry-run.** Read and display the target object (user, device, policy, app). List the expected effects in plain English.
+2. **Ask for explicit confirmation,** naming the tool, the target, and the impact. Example: _"I'm about to call `disable-user-account` on `jdoe@contoso.com`. This will immediately block all sessions and authentication. Confirm?"_
+3. **Wait for a clear positive confirmation** ("yes", "go", "confirmed") before invoking the write.
+4. **Audit after execution** via `list-directory-audits` (or `list-intune-audit-events` for device actions) filtered to the operation's time window.
+
+A vague reply ("ok", "sure") is not sufficient for a `critical` tool — ask again explicitly.
+
+### Tools to escalate before invoking, even with operator confirmation
+
+These are classified `critical` and have tenant-wide blast radius. The operator's confirmation in chat is not enough — surface the escalation requirement and refuse to call them autonomously:
+
+- `delete-user` — permanent account removal
+- `delete-group` — group removal (cascades to license assignment, CA scoping, access)
+- `delete-application`, `delete-service-principal` — can break integrations
+- `delete-conditional-access-policy` — can break tenant authentication
+- `delete-exchange-mailbox` — mailbox destruction
+- `delete-ediscovery-case` — destroys legal evidence
+- `wipe-managed-device`, `clean-windows-device` — user data destruction
+- `delete-team` — team removal (30-day soft-delete window)
+- `disable-user-account` on a privileged, admin, or break-glass account — tenant lockout risk
+- `add-directory-role-member` for Global Admin / Privileged Role Admin — privilege elevation
+- `create-pim-role-assignment-request` on a privileged role — privilege elevation
+
+Standard response for these: _"This operation is classified `critical` and requires sign-off outside this session before execution. I can prepare the dry-run and a written change request, but I won't invoke the write tool here."_
+
+### General guardrails
+
+- **Conditional Access changes.** Create new policies in `enabledForReportingButNotEnforced` (report-only) first; never go straight to `enabled`. Always exclude the tenant's break-glass account from any new policy.
+- **Break-glass accounts.** No mutation on these accounts under any circumstance without out-of-band sign-off.
+- **Privileged accounts.** `disable-user-account`, `revoke-user-sessions`, `delete-user-phone-auth-method` on an admin or executive account need escalation, not chat confirmation.
+- **Post-action traceability.** After every mutation, propose `list-directory-audits` or `list-intune-audit-events` filtered to the window, and offer to file an incident ticket in the operator's tracker.
+
+## Navigation by use case
+
+Load the file matching the task at hand. **Do not preload multiple files** — lazy-load one at a time.
+
+| Use case                                                            | Reference file                          | When to use                                                  |
+| ------------------------------------------------------------------- | --------------------------------------- | ------------------------------------------------------------ |
+| Defender alert / incident triage, attack simulations                | `references/usecase-security.md`        | Daily triage, SOC escalations, attack-sim follow-up          |
+| Sign-in audit, directory audits, deleted-item recovery              | `references/usecase-audit.md`           | Investigation, forensics, traceability                       |
+| Compromised account investigation and containment                   | `references/usecase-response.md`        | Suspected compromise, session revocation, risk-state changes |
+| Users, groups, PIM, roles, applications, guests                     | `references/usecase-identity.md`        | Identity hygiene, credential audits, B2B governance          |
+| Access reviews, entitlement management, lifecycle workflows         | `references/usecase-governance.md`      | Quarterly reviews, joiner/mover/leaver automation            |
+| Licenses, Secure Score, Identity Protection, Conditional Access     | `references/usecase-compliance.md`      | Posture, scoring, CA audit/deployment, risk detection triage |
+| Intune devices, compliance, Autopilot, MAM, remote actions          | `references/usecase-intune.md`          | Fleet audit, lost/compromised device, MAM                    |
+| Message traces, Exchange mailboxes                                  | `references/usecase-exchange.md`        | Mail delivery investigation, mailbox audit                   |
+| SharePoint tenant settings, sites, permissions                      | `references/usecase-sharepointadmin.md` | External-sharing audit, site permissions                     |
+| Service health, Message Center                                      | `references/usecase-health.md`          | Active incident, MS status checks                            |
+| Usage reports (Teams, Email, SP, OD, M365 Apps)                     | `references/usecase-reports.md`         | License optimization, adoption metrics                       |
+| eDiscovery (Purview), holds, custodians                             | `references/usecase-ediscovery.md`      | Legal/HR requests, formal investigation                      |
+| Cloud PC / Windows 365                                              | `references/usecase-cloudpc.md`         | CPC provisioning, images, audits                             |
+| Threat intelligence (hosts, IOCs, WHOIS, passive DNS) + KQL hunting | `references/usecase-threatintel.md`     | IOC investigation, enrichment, advanced hunting              |
+| Teams call records, PSTN                                            | `references/usecase-callrecords.md`     | Call quality investigation, PSTN audit                       |
+| Universal Print                                                     | `references/usecase-print.md`           | Printer inventory, usage audit                               |
+| Information Protection, BitLocker, sensitivity labels               | `references/usecase-infoprotection.md`  | Key recovery, classification audit                           |
+| Records management, retention                                       | `references/usecase-retention.md`       | Document retention, file plan                                |
+| Teams admin (teams, channels, app policies)                         | `references/usecase-teamsadmin.md`      | Tenant-level Teams governance                                |
+
+For end-to-end incident response procedures, refer to the upstream playbooks: [`docs/playbooks/`](../../docs/playbooks/README.md).
+
+## Troubleshooting
+
+### Network error / timeout on the first call
+
+If the server is deployed behind a private network (Azure Container Apps with VNet, on-prem proxy, etc.), verify network reachability before retrying. Surface the error to the operator rather than attempting fallbacks.
+
+### `403 Forbidden` or `Insufficient privileges`
+
+The corresponding Graph permission has not been consented on the app registration. Document which permission is missing (Microsoft Graph docs list the required `Application` permission per endpoint) and escalate to whoever has consent rights on the tenant. See `references/graph-permissions.md` for the full list of permissions used by the server.
+
+### `get-security-alert` (or another `get-*`) times out
+
+Known pattern on large Defender alerts. Workaround: use `list-security-alerts` with tight filters (`$top`, `severity`, `lastModifiedDateTime`) to identify the alert, then retry `get-security-alert` with the exact ID. If it still times out, capture the essential fields from the list response and note the limitation.
+
+### Pagination on large tenants (>10k users, >50k devices)
+
+Always start with `$top=50` or `$top=100`. For bulk reads, paginate via `@odata.nextLink`. The server respects `MS365_ADMIN_MCP_MAX_TOP` on the config side.
+
+### Too many tools visible, model picks the wrong one
+
+Load the appropriate `usecase-*.md` file and stay within its named tool set. The file's "scope" table is the source of truth for that domain.
+
+### Confusion between this server and a delegated companion
+
+See the decision table at the top of this file. If the operation concerns the tenant or another user, it's this server. If it concerns the operator's own data, it's a delegated server.
+
+## References
+
+- Upstream USE_CASES: [`docs/USE_CASES.md`](../../docs/USE_CASES.md)
+- Incident response playbooks: [`docs/playbooks/`](../../docs/playbooks/README.md)
+- Risk classification rubric: [`docs/RISK_MODEL.md`](../../docs/RISK_MODEL.md)
+- App registration setup: [`docs/APP_REGISTRATION.md`](../../docs/APP_REGISTRATION.md)
+- HTTP deployment + Azure: [`docs/HTTP_DEPLOYMENT.md`](../../docs/HTTP_DEPLOYMENT.md)
+- Tool risk index: `references/tools-catalog.md`
+- Graph permissions: `references/graph-permissions.md`
+
+## Metadata
+
+- Source server: [`okapi-ca/ms-365-admin-mcp-server`](https://github.com/okapi-ca/ms-365-admin-mcp-server) (515 tools)
+- Permission model: application (client credentials) — see [Acknowledgments](../../README.md#acknowledgments) for the delegated companion
+- License: MIT (same as the server)

--- a/agent-skills/ms365-admin-mcp/references/graph-permissions.md
+++ b/agent-skills/ms365-admin-mcp/references/graph-permissions.md
@@ -1,0 +1,167 @@
+# Graph API permissions
+
+Reference list of Microsoft Graph **application** permissions (client credentials) consumed by `ms-365-admin-mcp-server`. Match these to the app registration backing your deployment.
+
+For the canonical list as exposed by a running server:
+
+```bash
+node dist/index.js --list-permissions
+```
+
+For setup instructions (admin consent, redirect URIs, etc.), see [`docs/APP_REGISTRATION.md`](../../../docs/APP_REGISTRATION.md).
+
+## Read-only permissions (default)
+
+```
+AccessReview.Read.All
+AdministrativeUnit.Read.All
+Agreement.Read.All
+APIConnectors.Read.All
+AppCatalog.Read.All
+Application.Read.All
+AppRoleAssignment.Read.All
+AttackSimulation.Read.All
+AuditLog.Read.All
+BitlockerKey.Read.All
+CallRecords.Read.All
+Channel.ReadBasic.All
+CloudPC.Read.All
+ConsentRequest.Read.All
+CopilotSettings-Internal.ReadWrite.All
+CustomAuthenticationExtension.Read.All
+CustomSecAttributeDefinition.Read.All
+Device.Read.All
+DeviceLocalCredential.Read.All
+DeviceManagementApps.Read.All
+DeviceManagementConfiguration.Read.All
+DeviceManagementManagedDevices.Read.All
+DeviceManagementRBAC.Read.All
+DeviceManagementServiceConfig.Read.All
+Directory.Read.All
+Domain.Read.All
+eDiscovery.Read.All
+EntitlementManagement.Read.All
+Exchange.ManageAsApp
+Group.Read.All
+GroupMember.Read.All
+IdentityProvider.Read.All
+IdentityRiskEvent.Read.All
+IdentityRiskyServicePrincipal.Read.All
+IdentityRiskyUser.Read.All
+IdentityUserFlow.Read.All
+InformationProtectionPolicy.Read.All
+LifecycleWorkflows.Read.All
+MailboxSettings.Read
+OnPremDirectorySynchronization.Read.All
+Organization.Read.All
+Policy.Read.All
+Printer.Read.All
+PrintConnector.Read.All
+PrintJob.Read.All
+PrivilegedAccess.Read.AzureADGroup
+RecordsManagement.Read.All
+Reports.Read.All
+RoleAssignmentSchedule.Read.Directory
+RoleEligibilitySchedule.Read.Directory
+RoleManagement.Read.Directory
+RoleManagementPolicy.Read.Directory
+SecurityAlert.Read.All
+SecurityEvents.Read.All
+SecurityIdentitiesHealth.Read.All
+SecurityIncident.Read.All
+ServiceHealth.Read.All
+ServiceMessage.Read.All
+SharePointTenantSettings.Read.All
+Sites.Read.All
+Sites.FullControl.All
+SubjectRightsRequest.Read.All
+Team.ReadBasic.All
+TeamMember.Read.All
+TeamsAppInstallation.ReadForTeam.All
+TeamworkAppSettings.Read.All
+TeamworkDevice.Read.All
+ThreatAssessment.Read.All
+ThreatHunting.Read.All
+ThreatIntelligence.Read.All
+User.Invite.All
+User.Read.All
+UserAuthenticationMethod.Read.All
+```
+
+## Write permissions (incident response, device actions, CA, Teams, SharePoint, identity management)
+
+Required only when the server is started with `--allow-writes`.
+
+```
+AccessReview.ReadWrite.All
+AdministrativeUnit.ReadWrite.All
+Application.ReadWrite.All
+Application.ReadWrite.OwnedBy
+AppRoleAssignment.ReadWrite.All
+AttackSimulation.ReadWrite.All
+Channel.Create
+Channel.Delete.All
+CloudPC.ReadWrite.All
+Device.ReadWrite.All
+DeviceManagementConfiguration.ReadWrite.All
+DeviceManagementManagedDevices.PrivilegedOperations.All
+DeviceManagementManagedDevices.ReadWrite.All
+DeviceManagementServiceConfig.ReadWrite.All
+Directory.AccessAsUser.All
+Domain.ReadWrite.All
+eDiscovery.ReadWrite.All
+EntitlementManagement.ReadWrite.All
+Group.ReadWrite.All
+GroupMember.ReadWrite.All
+IdentityRiskyServicePrincipal.ReadWrite.All
+IdentityRiskyUser.ReadWrite.All
+LifecycleWorkflows.ReadWrite.All
+Policy.ReadWrite.AuthenticationMethod
+Policy.ReadWrite.ConditionalAccess
+PrivilegedAccess.ReadWrite.AzureADGroup
+RoleAssignmentSchedule.ReadWrite.Directory
+RoleEligibilitySchedule.ReadWrite.Directory
+RoleManagement.ReadWrite.Directory
+RoleManagementPolicy.ReadWrite.Directory
+SecurityAlert.ReadWrite.All
+SecurityIncident.ReadWrite.All
+Sites.ReadWrite.All
+Team.Create
+Team.ReadWrite.All
+TeamMember.ReadWrite.All
+TeamworkAppSettings.ReadWrite.All
+User.ReadWrite.All
+UserAuthenticationMethod.ReadWrite.All
+```
+
+## Verifying consent
+
+On the Microsoft Entra portal:
+
+1. Entra → App registrations → select the app backing your server.
+2. API permissions → Configured permissions.
+3. Confirm "Granted for `<tenant>`" status for each permission used.
+
+When an MCP call returns **403 Forbidden** or `Insufficient privileges`:
+
+1. Identify the required `Application` permission from the Microsoft Graph documentation for that endpoint.
+2. Verify whether it is listed and consented on the app registration.
+3. If missing, consent it (Application Administrator or Privileged Role Administrator).
+
+## Notes on scope
+
+- All permissions here are **application-level** (client credentials), not delegated.
+- `Sites.FullControl.All` is very broad — it backs the SharePoint admin tools. Restrict the app to the sites it needs via SharePoint sites.selected if your tenant requires least-privilege scoping.
+- `Directory.AccessAsUser.All` is the most sensitive — it is functionally equivalent to a tenant admin operating through Graph. Treat the app registration accordingly (Key Vault for secrets, federated credentials in Azure, Conditional Access restricting where the SP can sign in, regular sign-in log review).
+
+## Operator hardening checklist
+
+The app registration backing this server is, in practice, a high-privilege identity. At minimum:
+
+- Store the client secret in a secrets manager (Azure Key Vault, AWS Secrets Manager, 1Password, etc.), never in code or environment files committed to a repo.
+- Rotate the secret at least every 12 months. Prefer federated credentials (workload identity federation) when the server runs in Azure / GitHub Actions.
+- Limit the application's owners list. Audit periodically.
+- Apply Conditional Access to the application's service principal if your tenant supports it (geofencing, sign-in risk).
+- Monitor `list-sign-ins` filtered on the SP's `appId` for anomalies.
+
+See also: [`SECURITY.md`](../../../SECURITY.md) and [`docs/AZURE_DEPLOYMENT_SECURITY.md`](../../../docs/AZURE_DEPLOYMENT_SECURITY.md).

--- a/agent-skills/ms365-admin-mcp/references/tools-catalog.md
+++ b/agent-skills/ms365-admin-mcp/references/tools-catalog.md
@@ -1,0 +1,127 @@
+# Tools catalogue
+
+Index of the 515 tools exposed by `ms-365-admin-mcp-server`, organized by preset and by risk level. **Do not preload this file** — prefer the per-domain `usecase-*.md` files. This is a reference for cross-cutting questions ("what's critical across the server?", "which preset contains tool X?").
+
+## Source of truth
+
+This catalogue mirrors the presets defined in [`src/tool-categories.ts`](../../../src/tool-categories.ts) and the risk levels in [`docs/RISK_MODEL.md`](../../../docs/RISK_MODEL.md). For the exact list of tools exposed by a running server:
+
+```bash
+node dist/index.js --list-tools
+node dist/index.js --list-permissions  # show required Graph permissions
+```
+
+## Index by preset
+
+| Preset            | Description                                                               | Use case file                                   |
+| ----------------- | ------------------------------------------------------------------------- | ----------------------------------------------- |
+| `security`        | Alerts, incidents, attack simulations, threat intel                       | `usecase-security.md`, `usecase-threatintel.md` |
+| `audit`           | Directory audits, sign-ins, provisioning logs, deleted items              | `usecase-audit.md`                              |
+| `health`          | Service health, Message Center                                            | `usecase-health.md`                             |
+| `reports`         | Usage reports (Teams, Email, SP, OD, M365 Apps)                           | `usecase-reports.md`                            |
+| `identity`        | Users, groups, roles, devices, PIM, guests, external identities           | `usecase-identity.md`                           |
+| `exchange`        | Message traces, mailboxes                                                 | `usecase-exchange.md`                           |
+| `intune`          | Devices, compliance, configurations, Autopilot, apps, RBAC                | `usecase-intune.md`                             |
+| `governance`      | Access reviews, entitlement, lifecycle workflows, terms of use            | `usecase-governance.md`                         |
+| `compliance`      | Licenses, Secure Score, Identity Protection, risk detections, CA policies | `usecase-compliance.md`                         |
+| `response`        | Incident response writes (disable, revoke, confirm, dismiss)              | `usecase-response.md`                           |
+| `ediscovery`      | eDiscovery cases (Purview)                                                | `usecase-ediscovery.md`                         |
+| `cloudpc`         | Cloud PC / Windows 365                                                    | `usecase-cloudpc.md`                            |
+| `callrecords`     | Teams call records                                                        | `usecase-callrecords.md`                        |
+| `print`           | Universal Print                                                           | `usecase-print.md`                              |
+| `infoprotection`  | BitLocker, threat assessment, sensitivity labels                          | `usecase-infoprotection.md`                     |
+| `sharepointadmin` | SharePoint tenant administration                                          | `usecase-sharepointadmin.md`                    |
+| `retention`       | Records management                                                        | `usecase-retention.md`                          |
+
+## Index by risk level (write tools)
+
+### Critical — require out-of-band sign-off
+
+The chat operator's confirmation is not enough for these. Prepare the dry-run, document the intended change, but route the actual execution through a formal change request.
+
+- `delete-user`
+- `delete-group`
+- `delete-application`
+- `delete-service-principal`
+- `delete-conditional-access-policy`
+- `delete-exchange-mailbox`
+- `delete-ediscovery-case`
+- `delete-team`
+- `delete-managed-device`
+- `wipe-managed-device`
+- `clean-windows-device`
+- `add-directory-role-member`
+- `create-pim-role-assignment-request` (on privileged roles)
+- `create-pim-role-eligibility-request`
+- `disable-user-account` (on privileged or break-glass accounts)
+
+### High — explicit confirmation + dry-run
+
+- `revoke-user-sessions`
+- `confirm-compromised-users`, `confirm-safe-users`, `dismiss-risky-users`
+- `confirm-compromised-service-principals`, `dismiss-risky-service-principals`
+- `delete-user-phone-auth-method`
+- `change-user-password`
+- `update-device`
+- `create-conditional-access-policy`, `update-conditional-access-policy`
+- `delete-named-location`
+- `create-auth-strength-policy`, `update-auth-strength-policy`, `delete-auth-strength-policy`
+- `update-application`, `update-service-principal`
+- `add-application-password`, `remove-application-password`, `add-application-key`, `remove-application-key`
+- `create-application`, `add-application-owner`, `remove-application-owner`
+- `create-app-federated-credential`, `update-app-federated-credential`, `delete-app-federated-credential`
+- `create-service-principal`, `add-sp-password`, `remove-sp-password`, `add-sp-key`, `remove-sp-key`, `add-sp-token-signing-certificate`, `add-sp-owner`, `remove-sp-owner`, `create-sp-app-role-assignment`
+- `delete-administrative-unit`
+- `create-domain`
+- `apply-hold-ediscovery-custodian`, `remove-hold-ediscovery-custodian`
+- `delete-cloud-pc-provisioning-policy`
+- `retire-managed-device`, `reset-device-passcode`, `reboot-managed-device`, `shutdown-managed-device`, `bypass-activation-lock`, `delete-shared-apple-user`
+- `delete-compliance-policy`, `delete-device-configuration`, `delete-enrollment-configuration`, `delete-autopilot-device`
+- `update-teams-app-settings`
+- `delete-team-admin-channel`
+- `delete-site-list`, `delete-site-permission`
+- `apply-access-review-decisions`, `stop-access-review-instance`, `reset-access-review-decisions`, `delete-access-review-definition`
+- `activate-lifecycle-workflow`, `delete-lifecycle-workflow`, `delete-lifecycle-custom-task-extension`
+- `delete-access-package`, `delete-access-package-catalog`, `delete-access-package-assignment-policy`
+- `cancel-pim-role-assignment-request`, `cancel-pim-role-eligibility-request`
+- `create-pim-group-assignment-request`, `create-pim-group-eligibility-request`
+- `create-attack-simulation`
+- `create-role-management-policy-assignment`, `update-role-management-policy`
+
+### Medium — confirmation recommended
+
+- `update-user`, `assign-user-license`
+- `create-group`, `update-group`, `add-group-member`
+- `create-administrative-unit`, `update-administrative-unit`, `add-administrative-unit-member`
+- `verify-domain`
+- `set-application-verified-publisher`
+- `create-invitation`
+- `create-named-location`, `update-named-location`
+- `update-security-alert`, `update-security-incident`, `update-attack-simulation`, `delete-attack-simulation`
+- `update-exchange-mailbox`, `export-exchange-mailbox-items`
+- `create-compliance-policy`, `update-compliance-policy`
+- `create-device-configuration`, `update-device-configuration`
+- `create-enrollment-configuration`, `update-enrollment-configuration`, `update-autopilot-device`, `import-autopilot-device`
+- `remote-lock-device`, `logout-shared-apple-user`, `update-windows-device-account`
+- `update-sharepoint-site`, `delete-site-list-item`
+- `create-site-permission`, `update-site-permission`
+- `create-team`, `update-team`, `add-team-admin-members`, `remove-team-admin-members`, `archive-team`, `clone-team`
+- `create-cloud-pc-provisioning-policy`, `update-cloud-pc-provisioning-policy`
+- `create-ediscovery-case`, `update-ediscovery-case`, `close-ediscovery-case`, `reopen-ediscovery-case`, `create-ediscovery-custodian`, `create-ediscovery-search`
+- `create-access-review-definition`, `update-access-review-definition`, `accept-access-review-recommendations`
+- `create-access-package`, `update-access-package`, `create-access-package-catalog`, `update-access-package-catalog`, `create-access-package-assignment-policy`, `update-access-package-assignment-policy`, `create-access-package-assignment-request`, `cancel-access-package-assignment-request`
+- `create-lifecycle-workflow`, `update-lifecycle-workflow`, `restore-lifecycle-workflow`, `create-lifecycle-custom-task-extension`, `update-lifecycle-custom-task-extension`
+- `cancel-pim-group-assignment-request`, `cancel-pim-group-eligibility-request`
+
+### Low — limited blast radius
+
+- `add-security-alert-comment`
+- `reprocess-user-license`
+- `sync-managed-device`, `locate-managed-device`, `disable-lost-mode`, `trigger-defender-scan`, `update-defender-signatures`
+- `unarchive-team`
+- `create-team-admin-channel`
+- `create-site-list`, `update-site-list`, `create-site-list-item`, `update-site-list-item`
+- `send-reminder-access-review`
+- `reprocess-access-package-assignment-request`
+- `run-hunting-query` (POST but read-only in practice — KQL does not mutate state)
+- Intune reports (POST endpoints, read-only in practice)

--- a/agent-skills/ms365-admin-mcp/references/usecase-audit.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-audit.md
@@ -1,0 +1,56 @@
+# usecase-audit — Sign-ins, directory audits, deleted items
+
+**When to load:** forensic investigation, traceability of an admin action, audit of suspicious sign-ins, recovery of deleted objects.
+
+**Upstream references:** [USE_CASES.md §3 Suspicious sign-in audit](../../../docs/USE_CASES.md), [§4 Privileged identity hygiene](../../../docs/USE_CASES.md).
+
+## Tools in scope
+
+| Tool                     | Usage                                                                                                                                           |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list-directory-audits`  | All admin events (object create/modify/delete, role assignments, etc.). Filter by `activityDateTime`, `initiatedBy`, `category`, `result`.      |
+| `list-sign-ins`          | Interactive + non-interactive sign-ins. Filter by `userPrincipalName`, `appId`, `createdDateTime`, `riskLevelDuringSignIn`, `status/errorCode`. |
+| `list-provisioning-logs` | Provisioning events (Entra Connect, SCIM, etc.).                                                                                                |
+| `list-deleted-users`     | Soft-deleted users (recoverable for 30 days).                                                                                                   |
+| `list-deleted-groups`    | Soft-deleted groups.                                                                                                                            |
+
+All read-only. No direct mutation risk, but the responses contain **PII** (UPNs, IPs, devices) — handle accordingly.
+
+## Patterns
+
+### Pattern 1 — Post-mutation audit
+
+> _"Who modified the CA policy yesterday?"_
+
+1. `list-directory-audits` with `category eq 'Policy'` and `activityDateTime ge <yesterday 00:00>`.
+2. Identify `initiatedBy.user.userPrincipalName`, `targetResources`, `result`.
+3. Present as a table: timestamp, actor, action, target, result.
+
+### Pattern 2 — Suspicious sign-in investigation
+
+> _"Risky sign-ins from the last 7 days outside expected geographies."_
+
+1. `list-sign-ins` with `$filter=createdDateTime ge <-7d> and (riskLevelDuringSignIn eq 'medium' or riskLevelDuringSignIn eq 'high')`, `$top=100`.
+2. Filter results by `location.countryOrRegion` against the operator's expected list.
+3. For recurring patterns (same user, multiple IPs), cross-reference with `list-risk-detections` (see `usecase-compliance.md`).
+4. If action is required → `usecase-response.md`.
+
+### Pattern 3 — Recovering a deleted user
+
+> _"User `jdoe@contoso.com` was deleted by mistake — can we restore?"_
+
+1. `list-deleted-users` filtered by UPN or displayName.
+2. If found within 30 days, the restore is done via direct Graph (`POST /directory/deletedItems/{id}/restore`) — not currently exposed as an MCP tool. Document the limitation and perform the restore via the Entra portal or PowerShell, logging it as a manual admin action.
+
+## Legal and privacy notes
+
+- Sign-ins and directory audits are **legal audit logs**. Don't export them outside authorized environments.
+- For formal investigation requests (HR, Legal), route through `usecase-ediscovery.md` for proper preservation.
+- For requests touching personal data of employees in GDPR jurisdictions (or other regional privacy regimes), involve your privacy officer before exporting or sharing raw logs.
+
+## Crosswalk
+
+- Audit a specific user → `usecase-identity.md` for account context.
+- Sign-in suspected to lead to compromise → `usecase-response.md`.
+- Related risk detections → `usecase-compliance.md`.
+- Formal legal preservation → `usecase-ediscovery.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-callrecords.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-callrecords.md
@@ -1,0 +1,47 @@
+# usecase-callrecords — Teams call records and PSTN
+
+**When to load:** Teams call investigation, call quality analysis, PSTN audit, direct routing.
+
+## Tools in scope
+
+| Tool                                                           | Usage               |
+| -------------------------------------------------------------- | ------------------- |
+| `list-call-records`                                            | Teams calls.        |
+| `get-call-record`                                              | Call detail.        |
+| `list-call-record-sessions`, `get-call-record-session`         | Sessions of a call. |
+| `list-call-session-segments`, `get-call-session-segment`       | Segments.           |
+| `list-call-record-participants`, `get-call-record-participant` | Participants.       |
+| `get-call-record-organizer`                                    | Organizer.          |
+| `get-pstn-calls`                                               | PSTN calls.         |
+| `get-direct-routing-calls`                                     | Direct Routing.     |
+
+All read-only.
+
+## Pattern 1 — Call quality investigation
+
+> _"User reports a bad call yesterday at 2 p.m."_
+
+1. `list-call-records` filtered on `participants/any(p: p.identity.user.id eq <user-id>)` and the time window.
+2. `get-call-record` → metadata.
+3. `list-call-record-sessions` → sessions of the call.
+4. `list-call-session-segments` → per-segment metrics (jitter, packet loss, codec).
+5. Identify degraded segments, present to the requester.
+
+## Pattern 2 — PSTN / Direct Routing audit
+
+> _"PSTN call audit for the month."_
+
+1. `get-pstn-calls` filtered on the monthly window.
+2. Aggregate: total duration, calls per user, destinations.
+3. For Direct Routing, `get-direct-routing-calls`.
+4. Reporting to Finance / Telecom.
+
+## Guardrails
+
+- No writes, but call records contain **communication data** (who called whom, when, duration). High confidentiality, especially for executives.
+- Don't distribute without a legitimate basis.
+
+## Crosswalk
+
+- User involved → `usecase-identity.md`.
+- Investigation potentially linked to an incident → `usecase-response.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-cloudpc.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-cloudpc.md
@@ -1,0 +1,63 @@
+# usecase-cloudpc — Cloud PC / Windows 365
+
+**When to load:** Cloud PC provisioning, image management, CPC audit, Windows 365 governance.
+
+## Tools in scope
+
+### Read
+
+| Tool                                    | Usage                              |
+| --------------------------------------- | ---------------------------------- |
+| `list-cloud-pcs`                        | Provisioned Cloud PCs.             |
+| `list-cloud-pc-provisioning-policies`   | Provisioning policies.             |
+| `list-cloud-pc-device-images`           | Custom images.                     |
+| `list-cloud-pc-gallery-images`          | Microsoft-provided gallery images. |
+| `list-cloud-pc-on-premises-connections` | On-prem network connections.       |
+| `list-cloud-pc-user-settings`           | User-settings policies.            |
+| `list-cloud-pc-audit-events`            | Cloud PC audit events.             |
+
+### Write
+
+| Tool                                  | Risk   |
+| ------------------------------------- | ------ |
+| `create-cloud-pc-provisioning-policy` | medium |
+| `update-cloud-pc-provisioning-policy` | medium |
+| `delete-cloud-pc-provisioning-policy` | high   |
+
+## Pattern 1 — Cloud PC fleet audit
+
+> _"How many Cloud PCs deployed and their status?"_
+
+1. `list-cloud-pcs` → all CPCs.
+2. Present: User | License (Windows 365 SKU) | Image | Provisioning policy | Status | Last login.
+3. Flag:
+   - CPCs `failed` or stuck in `provisioning` → investigate.
+   - CPCs without recent login (wasted license).
+4. Cross-reference with `list-subscribed-skus` (Windows 365) for cost analysis.
+
+## Pattern 2 — Provisioning policy audit
+
+> _"What provisioning policies exist?"_
+
+1. `list-cloud-pc-provisioning-policies` → all policies.
+2. For each: Image source, network connection, domain join type (Entra / Hybrid), assigned groups.
+3. `list-cloud-pc-device-images` → verify image versions are current.
+4. Flag policies using stale images.
+
+## Pattern 3 — Audit events
+
+> _"What happened on Cloud PCs this week?"_
+
+1. `list-cloud-pc-audit-events` filtered on the time window.
+2. Categorize by type (provisioning, deprovisioning, modify, restore).
+3. Present as a timeline.
+
+## Guardrails
+
+- **`delete-cloud-pc-provisioning-policy` (high)** can affect already-provisioned CPCs (verify exact MS behavior). Always check assignments first.
+- **Policy modifications** affect re-provisioning. Communicate with affected users before `update-`.
+
+## Crosswalk
+
+- Users assigned to CPCs → `usecase-identity.md`.
+- Directory audit events related → `usecase-audit.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-compliance.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-compliance.md
@@ -1,0 +1,156 @@
+# usecase-compliance — Licenses, Secure Score, Identity Protection, Conditional Access
+
+**When to load:** security posture review, scoring trends, risk detection triage, Conditional Access audit / deployment, auth methods policy, tenant licenses.
+
+**Upstream references:** [USE_CASES.md §15 Conditional Access — audit and deployment](../../../docs/USE_CASES.md), [§1 Daily security monitoring](../../../docs/USE_CASES.md) (Secure Score).
+
+## Section A — Secure Score
+
+| Tool                         | Usage                         |
+| ---------------------------- | ----------------------------- |
+| `list-secure-scores`         | Score history.                |
+| `get-secure-score`           | Score detail at a given date. |
+| `list-secure-score-controls` | Recommendations (controls).   |
+| `get-secure-score-control`   | Control detail.               |
+
+All read-only. Use for:
+
+- Trends over 30 / 60 / 90 days.
+- Top non-implemented controls (impact / effort).
+- Comparison vs. peer benchmark provided by Microsoft.
+
+## Section B — Identity Protection / risky users
+
+### Read
+
+| Tool                                                           | Usage                                                                       |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `list-risky-users`                                             | Currently-risky users. Filters: `riskLevel` (low/medium/high), `riskState`. |
+| `get-risky-user`                                               | Detail incl. risky activities.                                              |
+| `list-risky-user-history`                                      | History for a user.                                                         |
+| `list-risky-service-principals`, `get-risky-service-principal` | Risky SPs.                                                                  |
+| `list-service-principal-risk-detections`                       | SP risk detections.                                                         |
+| `list-risk-detections`                                         | All detections (users + SPs).                                               |
+| `get-risk-detection`                                           | Detection detail.                                                           |
+
+### Write
+
+All writes are `high` and routed through `usecase-response.md` (`confirm-compromised-users`, `confirm-safe-users`, `dismiss-risky-users`, and SP equivalents).
+
+## Section C — Licenses (subscribed SKUs)
+
+| Tool                   | Usage                          |
+| ---------------------- | ------------------------------ |
+| `list-subscribed-skus` | SKUs subscribed by the tenant. |
+| `get-subscribed-sku`   | SKU detail (units, services).  |
+
+Combine with `list-users` for assignment analysis (see Pattern 3 below).
+
+## Section D — Conditional Access
+
+### Read
+
+| Tool                                  | Usage                             |
+| ------------------------------------- | --------------------------------- |
+| `list-conditional-access-policies`    | All CA policies.                  |
+| `get-conditional-access-policy`       | Policy detail.                    |
+| `list-named-locations`                | Named locations (IPs, countries). |
+| `list-conditional-access-templates`   | Available templates.              |
+| `list-conditional-access-policies-v2` | v2 endpoint.                      |
+
+### Write
+
+| Tool                               | Risk         |
+| ---------------------------------- | ------------ |
+| `create-conditional-access-policy` | high         |
+| `update-conditional-access-policy` | high         |
+| `delete-conditional-access-policy` | **critical** |
+| `create-named-location`            | medium       |
+| `update-named-location`            | medium       |
+| `delete-named-location`            | high         |
+
+## Section E — Authentication policies
+
+| Tool                                                                                              | Usage                                           |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `get-auth-methods-policy`                                                                         | Global auth methods policy.                     |
+| `list-auth-method-configs`, `get-auth-method-config`                                              | Per-method configs (FIDO2, MS Auth, SMS, etc.). |
+| `get-security-defaults`                                                                           | Security defaults status.                       |
+| `get-admin-consent-policy`                                                                        | Admin consent workflow.                         |
+| `list-auth-strength-policies`, `get-auth-strength-policy`                                         | Auth strength policies.                         |
+| `create-auth-strength-policy`, `update-auth-strength-policy`, `delete-auth-strength-policy`       | high / high / high                              |
+| `get-cross-tenant-access-policy`, `list-cross-tenant-partners`, `get-cross-tenant-default-policy` | read                                            |
+
+## Section F — Identity governance policies (read-only references)
+
+`list-activity-timeout-policies`, `get-authorization-policy`, `get-auth-flows-policy`, `list-claims-mapping-policies`, `get-default-app-management-policy`, `get-device-registration-policy`, `list-feature-rollout-policies`, `list-home-realm-discovery-policies`, `list-permission-grant-policies`, `list-role-management-policies`, `list-role-management-policy-assignments`, `list-token-issuance-policies`, `list-token-lifetime-policies`.
+
+## Pattern 1 — Conditional Access audit
+
+> _"Full audit of CA policies."_
+
+1. `list-conditional-access-policies` → all policies.
+2. For each, present: Name | State (`enabled` / `disabled` / `enabledForReportingButNotEnforced`) | Users (include/exclude) | Apps | Conditions | Grant controls | Session controls.
+3. `list-named-locations` → join names.
+4. **Findings to flag:**
+   - Policies in `report-only` for > 30d (enforce or remove).
+   - Policies without break-glass exclusion.
+   - Critical apps (M365, Azure, admin portals) without MFA requirement.
+   - Disabled orphan policies.
+5. Cross-reference with `list-applications` to identify apps not covered by any MFA-requiring CA.
+
+## Pattern 2 — Deploying a new CA policy
+
+> _"Create a CA to block legacy auth."_
+
+1. **Prepare the policy** in JSON. Verify:
+   - `state: enabledForReportingButNotEnforced` (never `enabled` directly).
+   - `excludeUsers`: break-glass account ID(s).
+   - `excludeGroups`: any defined exception groups.
+2. Dry-run: present the full JSON to the operator.
+3. `create-conditional-access-policy` (high) → explicit confirmation.
+4. Document in your change tracker.
+5. Monitor for at least 7 days in report-only.
+6. Before promoting to `enabled`, review impact via `list-sign-ins` filtered on `conditionalAccessStatus eq 'failure'` for the policy.
+7. `update-conditional-access-policy` (high) to set `enabled` → explicit confirmation.
+
+## Pattern 3 — License optimization
+
+> _"Find E5 users inactive for 30 days."_
+
+1. `list-subscribed-skus` → identify the E5 SKU.
+2. `list-users` with `$filter=assignedLicenses/any(l:l/skuId eq <E5-id>)` → E5 holders.
+3. Cross-reference with `list-sign-ins` or `get-active-users-report` (see `usecase-reports.md`) for activity.
+4. Present: User | Department | Manager | Last activity | License assigned.
+5. Recovery plan: manager review → reassign to a lower SKU or recover.
+
+## Pattern 4 — Risky user triage
+
+> _"Untriaged risky users."_
+
+1. `list-risky-users` with `$filter=riskState eq 'atRisk'` (= never handled).
+2. For each `riskLevel eq 'high'`:
+   - `get-risky-user` → detail.
+   - `list-risky-user-history` → patterns.
+   - `list-risk-detections` filtered on UPN → source detections.
+   - `list-sign-ins` filtered → context.
+3. Decide per user:
+   - **Compromised** → `usecase-response.md` (`confirm-compromised-users`).
+   - **False positive** → `confirm-safe-users` (high).
+   - **Indeterminate** → request more info from user / manager before deciding.
+
+All writes are `high` → confirm per case.
+
+## Guardrails
+
+- **`delete-conditional-access-policy` (critical)**: out-of-band escalation required. A mis-deleted CA can grant or revoke access en masse.
+- **`update-conditional-access-policy` that flips `state` from `report-only` to `enabled`** is functionally equivalent to deploying a new enforcement — explicit confirmation and a monitoring window.
+- **`create-auth-strength-policy` / `update-` / `delete-`** affects every CA that references it. Always check dependencies first.
+- **`auth-methods-policy` changes**: not covered by write tools here other than auth-strength. Modify via the Entra portal with formal change management.
+
+## Crosswalk
+
+- Risky user → containment → `usecase-response.md`.
+- Suspicious sign-ins → `usecase-audit.md`.
+- Apps in scope of CAs → `usecase-identity.md`.
+- Usage reports for license analysis → `usecase-reports.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-ediscovery.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-ediscovery.md
@@ -1,0 +1,150 @@
+# usecase-ediscovery — Microsoft Purview eDiscovery
+
+**When to load:** formal Legal / HR request, investigation with preservation, holds, custodians, eDiscovery searches.
+
+⚠ **High legal and confidentiality impact.** Always validate the legal basis (formal HR request, documented Legal request, signed consent) **before** executing any action.
+
+**Upstream references:** [USE_CASES.md §11 eDiscovery — legal investigation](../../../docs/USE_CASES.md).
+
+## Tools in scope
+
+### Read
+
+| Tool                         | Usage                 |
+| ---------------------------- | --------------------- |
+| `list-ediscovery-cases`      | Existing cases.       |
+| `get-ediscovery-case`        | Case detail.          |
+| `list-ediscovery-custodians` | Custodians on a case. |
+| `list-ediscovery-searches`   | Searches on a case.   |
+
+### Write
+
+These require `--allow-writes`.
+
+| Tool                               | Risk                                                         |
+| ---------------------------------- | ------------------------------------------------------------ |
+| `create-ediscovery-case`           | medium                                                       |
+| `update-ediscovery-case`           | medium                                                       |
+| `delete-ediscovery-case`           | **critical** — out-of-band escalation. Evidence destruction. |
+| `close-ediscovery-case`            | medium                                                       |
+| `reopen-ediscovery-case`           | medium                                                       |
+| `create-ediscovery-custodian`      | medium                                                       |
+| `apply-hold-ediscovery-custodian`  | high                                                         |
+| `remove-hold-ediscovery-custodian` | high                                                         |
+| `create-ediscovery-search`         | medium                                                       |
+
+## Mandatory pattern for any eDiscovery action
+
+```
+1. CONFIRM legal basis (who requested, what authority, written reference)
+2. NOTIFY privacy officer / legal counsel as appropriate
+3. DRY-RUN: prepare parameters
+4. EXPLICIT CONFIRMATION with the operator
+5. EXECUTE ONE ACTION AT A TIME
+6. DOCUMENT each action in your case tracker
+```
+
+## Pattern 1 — Creating a formal case
+
+> _"Create an eDiscovery case for HR investigation HR-INV-2026-014."_
+
+### Step 1 — Pre-checks
+
+- [ ] Written HR / Legal request received (reference).
+- [ ] Privacy officer informed (priority in GDPR / other regulated jurisdictions).
+- [ ] Custodians identified with exact UPNs.
+- [ ] Keywords and time window defined.
+- [ ] Hold decision: yes / no (impacts retention).
+
+### Step 2 — Create the case
+
+```
+create-ediscovery-case(
+  displayName="HR-INV-2026-014",
+  description="<reference to HR/Legal request>"
+)
+```
+
+Confirmation required. Document the returned `caseId` in your case tracker.
+
+### Step 3 — Add custodians
+
+```
+create-ediscovery-custodian(caseId=..., email="alice@contoso.com", ...)
+```
+
+⚠ The custodian is **notified by default**. If the investigation requires non-notification (suspected exfiltration), disable notification and `applyHoldToSources` initially, then apply hold after preservation. Verify parameters with your legal counsel.
+
+### Step 4 — Apply holds (high)
+
+```
+apply-hold-ediscovery-custodian(caseId=..., custodianId=...)
+```
+
+**Explicit confirmation**: _"I'm about to apply a hold on `alice@contoso.com`'s mailbox and OneDrive. This blocks any deletion until the hold is released. Confirm?"_
+
+### Step 5 — Create searches
+
+```
+create-ediscovery-search(
+  caseId=...,
+  displayName="Search-1-keywords",
+  contentQuery="(project-atlas OR confidential-merger) AND (sent>=2025-01-01 AND sent<=2025-12-31)",
+  ...
+)
+```
+
+KQL eDiscovery — see Purview documentation.
+
+### Step 6 — Documentation
+
+Case tracker entry (restricted access):
+
+```
+Title: [EDISCOVERY] HR-INV-2026-014
+Link to the Purview case (caseId)
+Custodians + holds applied
+Searches created
+Requester, date
+```
+
+## Pattern 2 — Add a custodian to an existing case
+
+> _"Add `bob@contoso.com` to case HR-INV-2026-014."_
+
+1. `get-ediscovery-case` → confirm case and status (`active`).
+2. `list-ediscovery-custodians` → verify bob isn't already a custodian.
+3. `create-ediscovery-custodian` → confirmation.
+4. If hold required, `apply-hold-ediscovery-custodian` (high) → separate confirmation.
+5. Update the case tracker.
+
+## Pattern 3 — Release a hold
+
+> _"Investigation is closed — release holds on case HR-INV-2026-014."_
+
+1. **Written Legal / HR confirmation** that holds may be released.
+2. `list-ediscovery-custodians` → all custodians with active hold.
+3. For each, `remove-hold-ediscovery-custodian` (high) → confirm per case.
+4. Optional: `close-ediscovery-case` (medium) → confirmation.
+5. **Never** `delete-ediscovery-case` even after close — preserve for legal audit. That tool is critical, out-of-band escalation, and almost never justified.
+
+## Guardrails
+
+- **`delete-ediscovery-case` (critical)** — out-of-band escalation required. Evidence destruction, potential legal exposure. Almost never justified.
+- **`apply-hold-` and `remove-hold-`** — direct impact on user retention. No application / release without Legal documentation.
+- **Custodian notification** — default behavior notifies the custodian. For covert holds, verify parameters exactly.
+- **Overly broad searches** — avoid `contentQuery` that returns massive volumes and creates over-collection risk. Prefer iterative refinement.
+
+## Privacy officer / legal counsel involvement
+
+For any eDiscovery operation in a regulated jurisdiction (GDPR / EU, PIPEDA / Canada, etc.), the privacy officer should be:
+
+- **Informed** at case creation.
+- **Consulted** for covert holds.
+- **Signatory** on hold release in GDPR jurisdictions.
+
+## Crosswalk
+
+- Account identification → `usecase-identity.md`.
+- Audit of custodian's actions → `usecase-audit.md`.
+- Concurrent compromise → `usecase-response.md` (but preserve evidence BEFORE containment if legally required).

--- a/agent-skills/ms365-admin-mcp/references/usecase-exchange.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-exchange.md
@@ -1,0 +1,71 @@
+# usecase-exchange — Message traces and mailboxes
+
+**When to load:** mail delivery investigation (blocked, malware, missing), mailbox audit, item export.
+
+**Upstream references:** Exchange-adjacent topics appear throughout [USE_CASES.md](../../../docs/USE_CASES.md); the [phishing-tenant-wide playbook](../../../docs/playbooks/phishing-tenant-wide.md) is the canonical end-to-end procedure.
+
+## Tools in scope
+
+### Read
+
+| Tool                            | Usage                                                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `list-message-traces`           | Message traces. Filters: `senderAddress`, `recipientAddress`, `startDate`, `endDate`, `status`, `messageId`. |
+| `get-message-trace`             | Trace detail.                                                                                                |
+| `list-exchange-mailboxes`       | Mailbox list.                                                                                                |
+| `get-exchange-mailbox`          | Mailbox detail.                                                                                              |
+| `list-exchange-mailbox-folders` | Folders.                                                                                                     |
+| `get-exchange-mailbox-folder`   | Folder detail.                                                                                               |
+
+### Write
+
+| Tool                            | Risk                                  |
+| ------------------------------- | ------------------------------------- |
+| `export-exchange-mailbox-items` | medium                                |
+| `update-exchange-mailbox`       | medium                                |
+| `delete-exchange-mailbox`       | **critical** — out-of-band escalation |
+
+## Pattern 1 — Undelivered mail investigation
+
+> _"`partner@example.com`'s email didn't reach `jdoe@contoso.com`."_
+
+1. `list-message-traces` with `$filter=senderAddress eq 'partner@example.com' and recipientAddress eq 'jdoe@contoso.com' and startDate ge <yesterday>`.
+2. Identify `status`:
+   - `Delivered` — but user says not received: check Junk, inbox rules (use a delegated server or PowerShell `Get-InboxRule` since list-mail-rules over a third party's mailbox isn't exposed by this server).
+   - `FilteredAsSpam` / `Quarantined` — filtered.
+   - `Failed` — bounce, check reason.
+   - `Pending` / `GettingStatus` — in flight, retry.
+3. For non-trivial statuses, `get-message-trace` for the detail.
+
+## Pattern 2 — Suspicious mailbox audit
+
+> _"User reports emails are marked read without their intervention."_
+
+1. `get-exchange-mailbox` for the user.
+2. `list-exchange-mailbox-folders` → check for hidden / unexpected folders.
+3. **Hidden inbox rules** (attacker technique): not currently exposed by this server for third-party mailboxes. Workaround: PowerShell `Get-InboxRule -Mailbox <user>` or direct Graph with `MailboxSettings.Read`.
+4. If suspicious patterns (forwarding rules, delete rules), treat as compromise → `usecase-response.md`.
+
+## Pattern 3 — Light-weight item export
+
+> _"Export emails from `jdoe@contoso.com` matching keyword `project-atlas` from Q3."_
+
+⚠ For a **formal legal request**, use **Purview eDiscovery** (`usecase-ediscovery.md`), NOT this tool. `export-exchange-mailbox-items` is for lightweight admin needs (recover a lost email, employee offboarding).
+
+1. Confirm scope with the requester.
+2. Validate with your privacy officer if the export touches personal data in a regulated jurisdiction.
+3. `export-exchange-mailbox-items` (medium) → explicit confirmation.
+4. Document in your tracker.
+
+## Guardrails
+
+- **`delete-exchange-mailbox` (critical)** — out-of-band escalation. Data destruction. Prefer hold + standard offboarding.
+- **`export-exchange-mailbox-items`** — verify legal basis (user consent, formal HR request, or eDiscovery hold). Never export without documentation.
+- **`update-exchange-mailbox`** — verify you're not modifying quota or litigation hold unintentionally.
+
+## Crosswalk
+
+- Compromised account → `usecase-response.md`.
+- Formal legal search → `usecase-ediscovery.md`.
+- Account identity → `usecase-identity.md`.
+- Tenant-wide phishing campaign → [`docs/playbooks/phishing-tenant-wide.md`](../../../docs/playbooks/phishing-tenant-wide.md).

--- a/agent-skills/ms365-admin-mcp/references/usecase-governance.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-governance.md
@@ -1,0 +1,111 @@
+# usecase-governance — Access reviews, entitlement, lifecycle workflows
+
+**When to load:** quarterly access reviews, entitlement management (access packages), joiner/mover/leaver workflows, terms of use.
+
+**Upstream references:** [USE_CASES.md §14 Access reviews and lifecycle workflows](../../../docs/USE_CASES.md).
+
+## Tools in scope
+
+### Access reviews
+
+| Tool                                                                 | Risk                                        |
+| -------------------------------------------------------------------- | ------------------------------------------- |
+| `list-access-review-definitions`, `get-access-review-definition`     | read                                        |
+| `list-access-review-instances`, `get-access-review-instance`         | read                                        |
+| `list-access-review-decisions`, `list-access-review-history`         | read                                        |
+| `create-access-review-definition`, `update-access-review-definition` | medium                                      |
+| `delete-access-review-definition`                                    | high                                        |
+| `stop-access-review-instance`                                        | high                                        |
+| `send-reminder-access-review`                                        | low                                         |
+| `reset-access-review-decisions`                                      | high                                        |
+| `apply-access-review-decisions`                                      | high — irreversibly revokes denied accesses |
+| `accept-access-review-recommendations`                               | medium                                      |
+
+### Entitlement management (access packages)
+
+| Tool                                                                                                                                                                                                                                                                                                                                   | Risk                   |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `list-access-packages`, `get-access-package`, `list-access-package-assignments`, `list-access-package-requests`, `list-access-package-catalogs`, `list-connected-organizations`, `get-entitlement-management-settings`, `list-entitlement-assignment-policies`, `list-entitlement-resources`, `list-entitlement-resource-environments` | read                   |
+| `create-access-package`, `update-access-package`, `delete-access-package`                                                                                                                                                                                                                                                              | medium / medium / high |
+| `create-access-package-catalog`, `update-access-package-catalog`, `delete-access-package-catalog`                                                                                                                                                                                                                                      | medium / medium / high |
+| `create-access-package-assignment-policy`, `update-access-package-assignment-policy`, `delete-access-package-assignment-policy`                                                                                                                                                                                                        | medium / medium / high |
+| `create-access-package-assignment-request`                                                                                                                                                                                                                                                                                             | medium                 |
+| `reprocess-access-package-assignment-request`                                                                                                                                                                                                                                                                                          | low                    |
+| `cancel-access-package-assignment-request`                                                                                                                                                                                                                                                                                             | medium                 |
+
+### Lifecycle workflows
+
+| Tool                                                                                                                                                                                                                                         | Risk                   |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `list-lifecycle-workflows`, `get-lifecycle-workflow`, `list-lifecycle-workflow-templates`, `list-lifecycle-task-definitions`, `get-lifecycle-workflow-settings`, `list-lifecycle-custom-task-extensions`, `list-deleted-lifecycle-workflows` | read                   |
+| `create-lifecycle-workflow`, `update-lifecycle-workflow`                                                                                                                                                                                     | medium                 |
+| `delete-lifecycle-workflow`                                                                                                                                                                                                                  | high                   |
+| `activate-lifecycle-workflow`                                                                                                                                                                                                                | high                   |
+| `restore-lifecycle-workflow`                                                                                                                                                                                                                 | medium                 |
+| `create-lifecycle-custom-task-extension`, `update-lifecycle-custom-task-extension`, `delete-lifecycle-custom-task-extension`                                                                                                                 | medium / medium / high |
+
+### Terms of use, app consent, PIM groups
+
+`list-terms-of-use-agreements`, `get-terms-of-use-agreement`, `list-terms-of-use-acceptances`, `list-app-consent-requests`, `get-app-consent-request`, `list-user-consent-requests` — all read.
+
+PIM groups:
+
+| Tool                                                                                                                                                       | Risk   |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `list-pim-group-assignment-schedules`, `list-pim-group-eligibility-schedules`                                                                              | read   |
+| `list-pim-group-assignment-requests`, `list-pim-group-assignment-instances`, `list-pim-group-eligibility-requests`, `list-pim-group-eligibility-instances` | read   |
+| `create-pim-group-assignment-request`, `create-pim-group-eligibility-request`                                                                              | high   |
+| `cancel-pim-group-assignment-request`, `cancel-pim-group-eligibility-request`                                                                              | medium |
+
+## Pattern 1 — Tracking active access reviews
+
+> _"Status of the quarterly access reviews."_
+
+1. `list-access-review-definitions` → active reviews.
+2. For each definition, `list-access-review-instances` → current instance.
+3. `list-access-review-decisions` → decisions recorded.
+4. Present: Review | % decided | Approved / Denied / Not reviewed | Deadline.
+5. For reviews within 3 days of deadline with missing decisions, propose `send-reminder-access-review` (low — confirm).
+6. At review close, **`apply-access-review-decisions` (high)** → confirmation required. This revokes accesses marked `denied`.
+
+## Pattern 2 — Creating a new access review
+
+> _"Create a quarterly access review for the `SG-Admins` group."_
+
+Prefer the Entra portal for richer UI, but the API can serve scripted recurring reviews.
+
+1. Dry-run: confirm scope (group), reviewers (manager / self / specific users), recurrence, fallback.
+2. `create-access-review-definition` (medium) → confirmation.
+3. Document the returned `id` in your governance program tracker.
+
+## Pattern 3 — Lifecycle workflow audit
+
+> _"List joiner/mover/leaver workflows and their last run."_
+
+1. `list-lifecycle-workflows` → all defined workflows.
+2. For each, `get-lifecycle-workflow` → category (`joiner` / `mover` / `leaver`), schedule, lastRun.
+3. Identify failing runs or workflows not executed for a long time.
+4. Recommend config review with HR if applicable.
+
+## Pattern 4 — Access package audit
+
+> _"What access packages exist and who has access?"_
+
+1. `list-access-package-catalogs` → catalogs.
+2. `list-access-packages` → packages per catalog.
+3. For each package, `list-access-package-assignments` → active beneficiaries.
+4. `list-access-package-requests` filtered on status `pendingApproval` → pending requests.
+5. Present by catalog with counters.
+
+## Guardrails
+
+- **`apply-access-review-decisions` (high)** is irreversible — denied accesses are revoked immediately. Always dry-run + confirmation.
+- **`activate-lifecycle-workflow` (high)** — a misconfigured workflow can disable many accounts. Test on a narrow scope first.
+- **`delete-lifecycle-workflow` (high)** loses workflow history. Prefer `update` with disable instead.
+- **PIM group assignments on privileged-control groups** are functionally privilege elevation → out-of-band escalation.
+
+## Crosswalk
+
+- Directory role PIM audit → `usecase-identity.md`.
+- Accounts linked to access packages → `usecase-identity.md`.
+- Compliance / Identity Protection → `usecase-compliance.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-health.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-health.md
@@ -1,0 +1,53 @@
+# usecase-health — Service health and Message Center
+
+**When to load:** active incident, Microsoft service status check, Message Center triage.
+
+**Upstream references:** [USE_CASES.md §9 Service health monitoring](../../../docs/USE_CASES.md).
+
+## Tools in scope
+
+| Tool                    | Usage                                                                      |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `list-service-health`   | Global M365 service health view.                                           |
+| `list-service-issues`   | Active / resolved issues. Filter by `service`, `status`, `startDateTime`.  |
+| `list-service-messages` | Message Center (announcements, upcoming changes, action-required notices). |
+
+All read-only. No risk.
+
+## Pattern 1 — Check ongoing incident
+
+> _"Is Microsoft reporting an issue with Exchange?"_
+
+1. `list-service-health` → overview.
+2. `list-service-issues` filtered on `service eq 'Exchange Online'` and active status.
+3. Present: Issue ID | Title | Impact | Started | Last update | Workaround (if published).
+4. If active and impacting users, suggest helpdesk notification.
+
+## Pattern 2 — Message Center triage
+
+> _"What's new in Message Center this week?"_
+
+1. `list-service-messages` filtered on `lastModifiedDateTime ge <-7d>`.
+2. Categorize:
+   - **Action required** → high priority, route to the appropriate owner.
+   - **Plan for change** → planning.
+   - **Stay informed** → informational.
+3. For action-required items, create a tracker ticket with owner and deadline.
+
+## Pattern 3 — Correlation with internal incident
+
+> _"Teams is slow since 9 a.m. — is it us or Microsoft?"_
+
+1. `list-service-issues` filtered on Teams + active.
+2. If MS issue is active → communicate to users (known external).
+3. If clean on the MS side → internal investigation (network, proxy, recent CA change).
+
+## Guardrails
+
+- Read-only — no direct risk.
+- Service messages can contain references to upcoming security / auth changes (e.g. MFA enforcement, legacy auth deprecation). Treat those as action items.
+
+## Crosswalk
+
+- Security-impacting service messages → potential `usecase-compliance.md` follow-up (CA, auth methods).
+- Intune-related service issue → `usecase-intune.md` while the issue is live.

--- a/agent-skills/ms365-admin-mcp/references/usecase-identity.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-identity.md
@@ -1,0 +1,191 @@
+# usecase-identity — Users, groups, PIM, applications, guests
+
+**When to load:** identity management, PIM hygiene, application credential audit, B2B/guest governance, license assignment.
+
+**Upstream references:** [USE_CASES.md §4 Privileged identity hygiene](../../../docs/USE_CASES.md), [§5 Application and credential audit](../../../docs/USE_CASES.md), [§6 Guest user governance](../../../docs/USE_CASES.md).
+
+This is the largest domain — refer to the appropriate subsection below.
+
+## Section A — Users
+
+### Read
+
+| Tool                     | Usage                                                                                   |
+| ------------------------ | --------------------------------------------------------------------------------------- |
+| `list-users`             | Account list. Filters: `userType eq 'Guest'`, `accountEnabled eq false`, license-based. |
+| `get-user`               | Account detail.                                                                         |
+| `list-user-memberships`  | Groups and roles for a user.                                                            |
+| `list-user-auth-methods` | Configured MFA methods.                                                                 |
+| `list-user-devices`      | Entra-registered devices.                                                               |
+
+### Write
+
+| Tool                     | Risk         | When                                                          |
+| ------------------------ | ------------ | ------------------------------------------------------------- |
+| `create-user`            | high         | Manual provisioning — prefer Entra Connect / HR-driven flows. |
+| `update-user`            | medium       | Attribute updates (jobTitle, manager, department).            |
+| `delete-user`            | **critical** | Out-of-band escalation required.                              |
+| `assign-user-license`    | medium       | SKU assignment.                                               |
+| `reprocess-user-license` | low          | Re-process after group-based licensing change.                |
+| `change-user-password`   | high         | Admin reset — prefer self-service password reset.             |
+
+## Section B — Groups
+
+### Read
+
+| Tool                 | Usage                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------- |
+| `list-groups`        | Group list. Filter by `securityEnabled`, `mailEnabled`, `groupTypes` (e.g. `'Unified'` for M365). |
+| `get-group`          | Group detail.                                                                                     |
+| `list-group-members` | Direct members.                                                                                   |
+| `list-group-owners`  | Owners.                                                                                           |
+
+### Write
+
+| Tool               | Risk         | When                                                                         |
+| ------------------ | ------------ | ---------------------------------------------------------------------------- |
+| `create-group`     | medium       | Security or M365 group creation.                                             |
+| `update-group`     | medium       | Attribute updates.                                                           |
+| `delete-group`     | **critical** | Out-of-band escalation — cascades to license assignment, CA scoping, access. |
+| `add-group-member` | medium       | Care with groups used in CA, license assignment, or security boundaries.     |
+
+## Section C — Roles and PIM
+
+### Read
+
+| Tool                                 | Usage                          |
+| ------------------------------------ | ------------------------------ |
+| `list-directory-roles`               | Roles activated on the tenant. |
+| `list-role-members`                  | Permanent members of a role.   |
+| `list-role-assignments`              | Unified assignments.           |
+| `list-role-definitions`              | All role definitions.          |
+| `list-pim-eligible-assignments`      | Eligible (not yet activated).  |
+| `list-pim-active-assignments`        | Currently elevated.            |
+| `list-pim-role-assignment-schedules` | Activation schedules.          |
+| `list-pim-role-assignment-requests`  | Activation history.            |
+
+### Write (PIM activation)
+
+| Tool                                  | Risk                             | When                                                                                                                         |
+| ------------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `add-directory-role-member`           | **critical**                     | Direct elevation (bypasses PIM) — out-of-band escalation required.                                                           |
+| `create-pim-role-assignment-request`  | **critical** on privileged roles | PIM activation: legitimate for non-privileged roles; for Global Admin / Privileged Role Admin / Security Admin → escalation. |
+| `cancel-pim-role-assignment-request`  | high                             | Cancel an activation.                                                                                                        |
+| `create-pim-role-eligibility-request` | **critical**                     | Make someone eligible — out-of-band escalation required.                                                                     |
+
+## Section D — Applications, service principals, credentials
+
+### Read
+
+| Tool                             | Usage                                             |
+| -------------------------------- | ------------------------------------------------- |
+| `list-applications`              | App registrations.                                |
+| `get-application`                | Detail incl. passwordCredentials, keyCredentials. |
+| `list-application-owners`        | Owners.                                           |
+| `list-app-federated-credentials` | Workload identity federation credentials.         |
+| `get-app-federated-credential`   | Single FIC.                                       |
+| `list-service-principals`        | SPs (consented apps).                             |
+| `get-service-principal`          | SP detail.                                        |
+| `list-service-principal-owners`  | SP owners.                                        |
+| `list-oauth2-grants`             | Delegated consents.                               |
+| `list-sp-app-role-assignments`   | App roles assigned to the SP.                     |
+| `list-sp-delegated-permissions`  | SP delegated permissions.                         |
+| `list-user-app-role-assignments` | App roles assigned to a user.                     |
+| `list-app-management-policies`   | App credential management policies.               |
+
+### Write (all `high` or `critical`)
+
+| Tool                                                                                                                                                                           | Risk         |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------ |
+| `create-application`, `update-application`                                                                                                                                     | high         |
+| `delete-application`                                                                                                                                                           | **critical** |
+| `add-application-password`, `remove-application-password`, `add-application-key`, `remove-application-key`                                                                     | high         |
+| `add-application-owner`, `remove-application-owner`                                                                                                                            | high         |
+| `create-app-federated-credential`, `update-app-federated-credential`, `delete-app-federated-credential`                                                                        | high         |
+| `create-service-principal`                                                                                                                                                     | high         |
+| `delete-service-principal`                                                                                                                                                     | **critical** |
+| `add-sp-password`, `remove-sp-password`, `add-sp-key`, `remove-sp-key`, `add-sp-token-signing-certificate`, `add-sp-owner`, `remove-sp-owner`, `create-sp-app-role-assignment` | high         |
+| `set-application-verified-publisher`                                                                                                                                           | medium       |
+
+## Section E — Guests, B2B
+
+| Tool                                                                                                               | Risk   |
+| ------------------------------------------------------------------------------------------------------------------ | ------ |
+| `list-invitations`, `list-identity-providers`, `get-identity-provider`, `list-b2x-user-flows`, `get-b2x-user-flow` | read   |
+| `list-api-connectors`, `get-api-connector`, `list-custom-auth-extensions`                                          | read   |
+| `create-invitation`                                                                                                | medium |
+
+## Section F — Entra devices
+
+| Tool           | Usage                     |
+| -------------- | ------------------------- |
+| `list-devices` | Entra-registered devices. |
+| `get-device`   | Device detail.            |
+
+(For Intune managed devices, see `usecase-intune.md`.)
+
+## Section G — Administrative units
+
+| Tool                                                                                         | Risk   |
+| -------------------------------------------------------------------------------------------- | ------ |
+| `list-administrative-units`, `get-administrative-unit`, `list-administrative-unit-members`   | read   |
+| `create-administrative-unit`, `update-administrative-unit`, `add-administrative-unit-member` | medium |
+| `delete-administrative-unit`                                                                 | high   |
+
+## Section H — Organization, domains
+
+| Tool                               | Risk   |
+| ---------------------------------- | ------ |
+| `get-organization`, `list-domains` | read   |
+| `create-domain`                    | high   |
+| `verify-domain`                    | medium |
+
+## Pattern 1 — Quarterly PIM hygiene
+
+> _"Audit privileged roles on the tenant."_
+
+1. `list-directory-roles` → identify activated roles.
+2. For each privileged role (Global Admin, Privileged Role Admin, Security Admin, Exchange Admin, SharePoint Admin, Application Admin, User Access Admin, Conditional Access Admin):
+   - `list-role-members` (permanent)
+   - `list-pim-eligible-assignments` filtered by `roleDefinitionId`
+3. For each member:
+   - `get-user` → check `accountEnabled`, `lastSignInDateTime`
+   - `list-user-auth-methods` → confirm strong MFA
+   - `list-sign-ins` filtered → recent activity
+4. Present a table: Role | User | Type (permanent / eligible) | MFA | Last sign-in | Justification.
+5. Flag: permanents instead of eligibles, weak MFA, dormant 30d+.
+
+## Pattern 2 — Audit applications and expiring credentials
+
+> _"Which app registrations have secrets expiring in 60 days?"_
+
+1. `list-applications` with `$top=200` (paginate if needed).
+2. For each app, examine `passwordCredentials[].endDateTime` and `keyCredentials[].endDateTime`.
+3. Filter expirations < `now + 60d`.
+4. For each candidate: `list-application-owners` → identify owner to contact.
+5. Present: App | Cred type | Expiration | Owner | Graph permissions (severity).
+6. Flag **orphaned** apps (no owner) and apps with **privileged permissions** (`Directory.ReadWrite.All`, `Application.ReadWrite.All`, etc.).
+
+## Pattern 3 — Guest governance
+
+> _"List guests inactive for 90 days."_
+
+1. `list-users` with `$filter=userType eq 'Guest'` and `$top=200`.
+2. For each guest, cross-reference with `list-sign-ins` filtered by UPN.
+3. Identify those without sign-in > 90d.
+4. Group by invitation domain (`mail` or parsed UPN).
+5. Propose a cleanup plan: sponsor review before disable/delete.
+
+## Guardrails
+
+- **`delete-user`, `delete-group`, `delete-application`, `delete-service-principal`** — all critical, out-of-band escalation required.
+- **Modifying ownership of groups** used in CA scoping or license assignment has cascading impact — always document before.
+- **Privileged app registrations**: never add a secret without a rotation plan. Document in your secrets management system.
+- **B2B invitations**: verify the sponsor is identified and the partner domain is allowed by your cross-tenant access policy.
+
+## Crosswalk
+
+- Compromised user → `usecase-response.md`.
+- A user's devices → `usecase-intune.md` (managed) or this file (Entra-registered).
+- Conditional Access affecting a group → `usecase-compliance.md`.
+- Access reviews on groups / apps → `usecase-governance.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-infoprotection.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-infoprotection.md
@@ -1,0 +1,83 @@
+# usecase-infoprotection — BitLocker, sensitivity labels, threat assessment
+
+**When to load:** BitLocker key recovery, sensitivity label audit, Exchange threat assessment.
+
+## Tools in scope
+
+### BitLocker
+
+| Tool                           | Usage                    |
+| ------------------------------ | ------------------------ |
+| `list-bitlocker-recovery-keys` | BitLocker recovery keys. |
+
+⚠ **Highly sensitive.** Access to BitLocker keys enables disk decryption. Use only with legitimate basis (user-driven recovery after lockout, formal forensic investigation).
+
+### Threat assessment
+
+| Tool                              | Usage                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------ |
+| `list-threat-assessment-requests` | Threat assessment requests (URLs, files, emails) submitted to Microsoft. |
+
+### Sensitivity labels
+
+| Tool                                               | Usage                       |
+| -------------------------------------------------- | --------------------------- |
+| `list-sensitivity-labels`, `get-sensitivity-label` | Published labels.           |
+| `list-sensitivity-sublabels`                       | Sub-labels.                 |
+| `get-sensitivity-label-rights`                     | Rights attached to a label. |
+| `get-protection-scopes`                            | Protection scopes.          |
+
+## Pattern 1 — BitLocker key recovery
+
+> _"User `jdoe@contoso.com` can't unlock their laptop — BitLocker screen."_
+
+### Step 1 — Validation
+
+- [ ] Confirm requester's identity through a verified channel (not just email).
+- [ ] Confirm it's the user's device (cross-reference `list-managed-devices` or `list-devices`).
+- [ ] Document the helpdesk ticket with the reason.
+
+### Step 2 — Retrieval
+
+```
+list-bitlocker-recovery-keys($filter="deviceId eq '<device-id>'")
+```
+
+Retrieve the key and transmit via a secure channel (do not email in plain text).
+
+### Step 3 — Documentation
+
+In the helpdesk ticket:
+
+- Device involved.
+- Date/time of communication.
+- Channel used.
+
+⚠ **Do not log the key value itself** in the ticket.
+
+## Pattern 2 — Sensitivity label audit
+
+> _"What labels are published and what protection do they apply?"_
+
+1. `list-sensitivity-labels` → all labels.
+2. For each, `get-sensitivity-label` + `get-sensitivity-label-rights` → encryption, watermarking, content marking, conditions.
+3. `list-sensitivity-sublabels` → sub-labels.
+4. Present: Label | Encryption (Y/N + permissions) | Marking | Sub-labels | Scope.
+
+## Pattern 3 — Threat assessment audit
+
+> _"What threat assessments were submitted this month?"_
+
+1. `list-threat-assessment-requests` filtered on the window.
+2. Present by type (URL, file, email).
+3. Identify recurring submitter patterns.
+
+## Guardrails
+
+- **`list-bitlocker-recovery-keys`** — audit-logged. Every call is traced. Never use outside a validated ticket.
+- **Sensitivity labels** — no write tools exposed here. Modify via the Purview compliance portal.
+
+## Crosswalk
+
+- Device context → `usecase-intune.md`.
+- Forensic investigation → `usecase-ediscovery.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-intune.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-intune.md
@@ -1,0 +1,168 @@
+# usecase-intune — Devices, compliance, Autopilot, MAM, remote actions
+
+**When to load:** managed fleet audit, lost / compromised device, MAM / MDM, Autopilot, compliance reports.
+
+**Upstream references:** [USE_CASES.md §7 Intune compliance review](../../../docs/USE_CASES.md), [§8 Lost or compromised device](../../../docs/USE_CASES.md).
+
+## Section A — Inventory and state
+
+### Read
+
+| Tool                                                                  | Usage                                                                                                                         |
+| --------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `list-managed-devices`                                                | Intune device inventory. Filters: `complianceState`, `operatingSystem`, `osVersion`, `userPrincipalName`, `lastSyncDateTime`. |
+| `get-managed-device`                                                  | Device detail.                                                                                                                |
+| `list-device-compliance-states`                                       | Compliance state per device.                                                                                                  |
+| `list-device-configuration-states`                                    | Config state per device.                                                                                                      |
+| `get-managed-device-overview`                                         | Aggregated fleet view.                                                                                                        |
+| `list-detected-apps`, `get-detected-app`, `list-detected-app-devices` | Detected apps and the devices that have them.                                                                                 |
+
+### Write
+
+| Tool                    | Risk                                                                       |
+| ----------------------- | -------------------------------------------------------------------------- |
+| `delete-managed-device` | **critical** — removes the object (does not wipe). Out-of-band escalation. |
+
+## Section B — Compliance policies
+
+| Tool                                                                                                                                                                   | Risk   |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `list-compliance-policies`, `get-compliance-policy`, `list-compliance-policy-device-statuses`, `get-compliance-policy-status-overview`, `get-compliance-state-summary` | read   |
+| `create-compliance-policy`, `update-compliance-policy`                                                                                                                 | medium |
+| `delete-compliance-policy`                                                                                                                                             | high   |
+
+## Section C — Device configurations
+
+| Tool                                                                                                 | Risk   |
+| ---------------------------------------------------------------------------------------------------- | ------ |
+| `list-device-configurations`, `get-device-configuration`, `get-device-configuration-status-overview` | read   |
+| `create-device-configuration`, `update-device-configuration`                                         | medium |
+| `delete-device-configuration`                                                                        | high   |
+
+## Section D — Enrollment and Autopilot
+
+| Tool                                                                                                                                                  | Risk   |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `list-enrollment-configurations`, `get-enrollment-configuration`, `list-autopilot-devices`, `get-autopilot-device`, `list-imported-autopilot-devices` | read   |
+| `create-enrollment-configuration`, `update-enrollment-configuration`                                                                                  | medium |
+| `delete-enrollment-configuration`                                                                                                                     | high   |
+| `update-autopilot-device`                                                                                                                             | medium |
+| `delete-autopilot-device`                                                                                                                             | high   |
+| `import-autopilot-device`                                                                                                                             | medium |
+
+## Section E — Remote device actions (incident-time)
+
+**All POST writes. Several are critical/high.**
+
+| Tool                            | Risk         | Effect                                                    |
+| ------------------------------- | ------------ | --------------------------------------------------------- |
+| `sync-managed-device`           | low          | Forces an Intune sync. Safe.                              |
+| `locate-managed-device`         | low          | Geolocation (supervised iOS / Android).                   |
+| `disable-lost-mode`             | low          | Exits lost mode on a device.                              |
+| `trigger-defender-scan`         | low          | Triggers a Defender scan.                                 |
+| `update-defender-signatures`    | low          | Forces signature update.                                  |
+| `remote-lock-device`            | medium       | Remote lock.                                              |
+| `logout-shared-apple-user`      | medium       | Sign out a Shared iPad user.                              |
+| `update-windows-device-account` | medium       | Modifies the account on a Windows shared device.          |
+| `reboot-managed-device`         | high         | Forced reboot — unsaved work lost.                        |
+| `reset-device-passcode`         | high         | Reset passcode.                                           |
+| `shutdown-managed-device`       | high         | Forced shutdown.                                          |
+| `bypass-activation-lock`        | high         | Bypass iCloud activation lock.                            |
+| `delete-shared-apple-user`      | high         | Remove a Shared iPad user.                                |
+| `retire-managed-device`         | high         | Unenroll, remove corp data, retain personal data.         |
+| `wipe-managed-device`           | **critical** | Factory reset — DATA DESTRUCTION. Out-of-band escalation. |
+| `clean-windows-device`          | **critical** | Full Windows reset. Out-of-band escalation.               |
+
+## Section F — RBAC, infra, terms
+
+| Tool                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Usage |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
+| `list-intune-audit-events`, `get-software-update-summary`, `get-apple-push-certificate`, `list-intune-role-definitions`, `list-intune-role-assignments`, `list-intune-terms-and-conditions`, `list-intune-terms-acceptances`, `get-intune-conditional-access-settings`, `list-mtd-connectors`, `list-ios-update-statuses`, `list-device-categories`, `list-compliance-management-partners`, `list-device-management-partners`, `list-exchange-connectors`, `list-remote-assistance-partners`, `list-notification-message-templates`, `list-intune-resource-operations`, `list-windows-malware-info` | read  |
+
+## Section G — App management (MDM / MAM)
+
+| Tool                                                                                                                                                                                                                                                                                                                                                                                       | Usage |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----- |
+| `list-intune-mobile-apps`, `list-intune-app-categories`, `list-intune-app-configurations`, `list-managed-app-policies`, `list-managed-app-registrations`, `list-managed-app-statuses`, `list-android-app-protections`, `list-ios-app-protections`, `list-default-app-protections`, `list-targeted-app-configurations`, `list-mdm-wip-policies`, `list-mam-wip-policies`, `list-vpp-tokens` | read  |
+
+## Section H — Intune reports
+
+⚠ **Intune reports use POST endpoints even when read-only.** The server exposes them, classified `low` (read-only in practice).
+
+`intune-device-noncompliance-report`, `intune-compliance-policy-noncompliance-report`, `intune-compliance-policy-noncompliance-summary`, `intune-compliance-setting-noncompliance-report`, `intune-config-policy-noncompliance-report` / `*-summary`, `intune-config-setting-noncompliance-report`, `intune-devices-without-compliance-report`, `intune-noncompliant-devices-settings-report`, `intune-policy-noncompliance-report` / `*-summary` / `*-metadata`, `intune-setting-noncompliance-report`, `intune-report-filters`, `intune-historical-report`, `intune-cached-report`, `list-intune-report-export-jobs`, `intune-device-app-install-status-report`.
+
+## Pattern 1 — Fleet non-compliance audit
+
+> _"How many non-compliant devices and why?"_
+
+1. `get-compliance-state-summary` → overall view.
+2. `intune-device-noncompliance-report` → detailed list.
+3. `intune-policy-noncompliance-summary` → top causing policies.
+4. `intune-compliance-setting-noncompliance-report` → top causing settings.
+5. Present: OS distribution, top causes, top impacted users, % fleet compliant.
+
+## Pattern 2 — Lost device (containment sequence)
+
+> _"User `jdoe@contoso.com` lost their iPhone."_
+
+### Step 1 — Identify the device
+
+```
+list-user-devices(userId="jdoe@contoso.com")
+list-managed-devices($filter="userPrincipalName eq 'jdoe@contoso.com'")
+```
+
+Identify the iPhone (model, lastSyncDateTime).
+
+### Step 2 — Locate (low, OK direct)
+
+```
+locate-managed-device(managedDeviceId=<id>)
+```
+
+If successful → return coordinates. User may attempt recovery.
+
+### Step 3 — Lock (medium → confirmation)
+
+```
+remote-lock-device(managedDeviceId=<id>)
+```
+
+Confirm with operator before invoking. Effect: immediate lock.
+
+### Step 4 — If not recovered within 24h
+
+Present the options:
+
+- **`retire-managed-device` (high)** — recommended. Unenrolls, removes corp data, keeps personal data (photos, etc.) if the device is recovered.
+- **`wipe-managed-device` (critical)** — full factory reset. **Out-of-band escalation required.** Permanent loss of all data.
+
+For `retire`, explicit confirmation. For `wipe`, escalation — prepare the dry-run without executing.
+
+### Step 5 — Audit + ticket
+
+```
+list-intune-audit-events($filter="<window>" + target)
+```
+
+File the ticket in your tracker (helpdesk for lost device, security incident for suspected compromise / theft).
+
+## Pattern 3 — APNs expiration tracking
+
+> _"Is the Apple Push certificate about to expire?"_
+
+1. `get-apple-push-certificate` → expiration date.
+2. If `< 60d`, file a renewal task with the platform owner.
+
+## Guardrails
+
+- **`wipe-managed-device` and `clean-windows-device`** — out-of-band escalation, never autonomous.
+- **`retire-managed-device`** — explicit confirmation. Validate with the operator that `retire` (corp data only) is sufficient vs. `wipe`.
+- **Mass compliance / config policy modifications** — never tighten policy via `update-compliance-policy` without prior communication. Risk of blocking hundreds of devices.
+- **Large reports** — paginate and filter aggressively. The server may time out on large tenants.
+
+## Crosswalk
+
+- Device owner → `usecase-identity.md`.
+- Combined account + device compromise → `usecase-response.md` + this file.
+- BitLocker recovery key → `usecase-infoprotection.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-print.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-print.md
@@ -1,0 +1,30 @@
+# usecase-print — Universal Print
+
+**When to load:** Universal Print inventory, usage, shares audit.
+
+## Tools in scope
+
+| Tool                          | Usage                                   |
+| ----------------------------- | --------------------------------------- |
+| `list-printers`               | Universal Print printers.               |
+| `list-print-shares`           | Printer shares.                         |
+| `list-print-connectors`       | Connectors (devices exposing printers). |
+| `list-print-services`         | Services.                               |
+| `list-print-operations`       | Operations in progress.                 |
+| `list-print-task-definitions` | Task definitions.                       |
+
+All read-only.
+
+For usage reports (`list-daily-print-usage-by-*`, `list-monthly-print-usage-by-*`), see `usecase-reports.md`.
+
+## Pattern — Universal Print inventory audit
+
+1. `list-printers` → all printers.
+2. `list-print-shares` → shares.
+3. `list-print-connectors` → connector status.
+4. Present: Printer | Location | Connector | Status | Last seen.
+5. Flag offline printers / connectors.
+
+## Crosswalk
+
+- Usage reports → `usecase-reports.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-reports.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-reports.md
@@ -1,0 +1,76 @@
+# usecase-reports — M365 usage reports
+
+**When to load:** license optimization, adoption metrics, identifying inactive users, monthly reporting.
+
+**Upstream references:** [USE_CASES.md §10 Usage reports and license optimization](../../../docs/USE_CASES.md).
+
+## Tools in scope
+
+| Tool                                                                                                                                             | Usage                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------- |
+| `get-teams-activity-report`                                                                                                                      | Teams activity (chats, calls, meetings). |
+| `get-email-activity-report`                                                                                                                      | Email activity (sent, received, read).   |
+| `get-active-users-report`                                                                                                                        | Active users across services.            |
+| `get-active-user-counts-report`                                                                                                                  | Aggregated counts.                       |
+| `get-sharepoint-usage-report`, `get-onedrive-usage-report`, `get-mailbox-usage-report`, `get-m365-apps-usage-report`                             | Per-service usage.                       |
+| `list-user-registration-details`                                                                                                                 | MFA registration status.                 |
+| `list-daily-print-usage-by-printer`, `list-daily-print-usage-by-user`, `list-monthly-print-usage-by-printer`, `list-monthly-print-usage-by-user` | Universal Print usage.                   |
+
+All read-only.
+
+## Notes
+
+- **Period:** most reports accept `D7`, `D30`, `D90`, `D180`.
+- **PII:** depending on the tenant's privacy settings, names may be anonymized in report output. For real UPNs, verify `displayConcealedNames` is disabled in the Microsoft 365 Admin Center reports privacy setting.
+- **Format:** reports typically return CSV — format clearly when presenting.
+
+## Pattern 1 — E5 license optimization
+
+> _"E5 users inactive for 30 days to reassign."_
+
+1. `get-active-users-report` (period `D30`) → users active per service.
+2. `list-subscribed-skus` (see `usecase-compliance.md`) → identify the E5 SKU.
+3. `list-users` filtered on E5 licenses → license holders.
+4. Cross-reference: E5 holders ABSENT from the activity report = reassign candidates.
+5. Present: User | Department | Manager | License date | Activity.
+6. Plan: manager review → reassign.
+
+## Pattern 2 — Teams adoption
+
+> _"Teams adoption by department."_
+
+1. `get-teams-activity-report` (period `D30`).
+2. Cross-reference with `list-users` for `companyName` / `department`.
+3. Aggregate: Department | Active users | Total users | % adoption.
+
+## Pattern 3 — MFA registration audit
+
+> _"How many users have no MFA configured?"_
+
+1. `list-user-registration-details` → status per user.
+2. Filter `isMfaRegistered eq false`.
+3. Cross-reference with `list-users` for `accountEnabled eq true` (only count active accounts).
+4. Present: global count + breakdown by department.
+5. For admin / privileged accounts without MFA → immediate escalation.
+
+## Pattern 4 — Monthly KPI reporting
+
+Recurring pattern. Queries to run at the start of the month for the previous month:
+
+| KPI                    | Tool                                  |
+| ---------------------- | ------------------------------------- |
+| Active users count     | `get-active-user-counts-report` (D30) |
+| MFA registration %     | `list-user-registration-details`      |
+| Mailbox storage trends | `get-mailbox-usage-report` (D30)      |
+| OneDrive usage         | `get-onedrive-usage-report` (D30)     |
+| SharePoint usage       | `get-sharepoint-usage-report` (D30)   |
+
+## Guardrails
+
+- No writes, no direct risk.
+- Reports can contain sensitive user data (volume, frequency of use). Distribute only to authorized recipients.
+
+## Crosswalk
+
+- License management → `usecase-compliance.md`.
+- Identifying inactive users → `usecase-identity.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-response.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-response.md
@@ -1,0 +1,178 @@
+# usecase-response — Incident response and containment
+
+**When to load:** suspected or confirmed account compromise, session revocation, auth method removal, compromised/safe marking in Identity Protection.
+
+This is the **most dangerous file** in the skill — most tools are `high` or `critical`. The authoritative procedures are in the upstream playbooks; this file is a structured router.
+
+**Upstream references:**
+
+- [`docs/playbooks/compromised-account.md`](../../../docs/playbooks/compromised-account.md) — end-to-end procedure.
+- [`docs/playbooks/oauth-illicit-consent.md`](../../../docs/playbooks/oauth-illicit-consent.md) — when the compromise involves a malicious OAuth app.
+- [USE_CASES.md §2 Incident response — compromised account](../../../docs/USE_CASES.md).
+
+## Containment sequence
+
+```
+Identify → Dry-run (account info) → Confirm → Disable → Revoke → Confirm compromised → Audit → Ticket
+```
+
+## Tools in scope
+
+| Tool                                     | Risk         | Effect                                                                    |
+| ---------------------------------------- | ------------ | ------------------------------------------------------------------------- |
+| `disable-user-account`                   | **critical** | Blocks all auth for the account. Immediate.                               |
+| `revoke-user-sessions`                   | **high**     | Invalidates all refresh tokens — user must re-auth everywhere.            |
+| `confirm-compromised-users`              | **high**     | Marks the user `compromised` in Identity Protection, elevates risk level. |
+| `confirm-safe-users`                     | **high**     | Inverse: marks `safe` (false positive).                                   |
+| `dismiss-risky-users`                    | **high**     | Closes the `risky` status without further investigation.                  |
+| `delete-user-phone-auth-method`          | **high**     | Removes a compromised phone auth method (SIM-swap response).              |
+| `confirm-compromised-service-principals` | **high**     | Same for an SP.                                                           |
+| `dismiss-risky-service-principals`       | **high**     | Closes the SP risky status.                                               |
+| `update-device`                          | **high**     | Disable a device in Entra.                                                |
+| `add-security-alert-comment`             | low          | Document the action in the originating alert.                             |
+| `run-hunting-query`                      | low          | KQL investigation — read-only in practice; see `usecase-threatintel.md`.  |
+
+All writes above require `--allow-writes`.
+
+## Mandatory pattern for ANY response action
+
+```
+1. get-user                  ← Confirm identity, role, last sign-in
+2. list-sign-ins             ← Reconstruct timeline (IPs, devices, apps)
+3. list-user-auth-methods    ← Active MFA methods
+4. list-user-memberships     ← Privileged role check
+5. [PRESENT BILAN]           ← Clear recap to operator
+6. [REQUEST CONFIRMATION]    ← Explicit, per tool
+7. EXECUTE ONE TOOL AT A TIME
+8. list-directory-audits     ← Verify the audit trail
+9. add-security-alert-comment ← Annotate the source alert
+10. CREATE INCIDENT TICKET   ← In your tracker
+```
+
+**Never chain multiple `high` / `critical` writes without confirmation between each.**
+
+## Use case 1 — Standard user account compromise
+
+> _"`jdoe@contoso.com` clicked a phishing link — contain the account."_
+
+### Step 1 — Dry-run bilan
+
+```
+get-user(userId="jdoe@contoso.com")
+list-sign-ins($filter="userPrincipalName eq 'jdoe@contoso.com' and createdDateTime ge <-7d>", $top=20)
+list-user-auth-methods(userId="jdoe@contoso.com")
+list-user-memberships(userId="jdoe@contoso.com")
+```
+
+Present:
+
+- Identity confirmed (displayName, jobTitle, manager).
+- **Privileged account? → if YES, STOP and escalate.** See "Privileged account" below.
+- Suspicious sign-ins (timestamp, IP, location, app).
+- MFA methods in place.
+- Groups / roles.
+
+### Step 2 — Confirmation
+
+> "I'll execute in this order, confirming each step:
+>
+> 1. `disable-user-account` (critical) — blocks all auth immediately.
+> 2. `revoke-user-sessions` (high) — forces re-auth everywhere.
+> 3. `confirm-compromised-users` (high) — raises the risk level.
+>
+> Confirm step 1?"
+
+### Step 3 — Sequential execution, one step at a time
+
+After each step: display the result, ask confirmation for the next.
+
+### Step 4 — Audit and ticket
+
+```
+list-directory-audits($filter="activityDateTime ge <now -10min> and targetResources/any(t: t/userPrincipalName eq 'jdoe@contoso.com')")
+add-security-alert-comment(...)
+```
+
+Create an incident ticket in your tracker.
+
+## Use case 2 — Privileged or admin account compromise
+
+**STOP. Do not execute any action via MCP.**
+
+The tenant lockout risk is too high. Standard response:
+
+> "The targeted account is privileged (role `<role>`). This operation requires immediate escalation through your formal incident response process before any action via MCP. I can prepare the full dry-run for your team."
+
+Prepare the dry-run (step 1 above) and format it for fast transmission. Do not call `disable-user-account` or equivalents.
+
+## Use case 3 — Compromised service principal
+
+> _"SP `app-xyz` has anomalous activity."_
+
+```
+get-service-principal(id=...)
+list-sp-app-role-assignments(...)
+list-sp-delegated-permissions(...)
+list-sign-ins($filter="appId eq '<sp-app-id>'", $top=50)
+```
+
+If compromise is confirmed:
+
+- `confirm-compromised-service-principals` (high) — confirmation required.
+- Rotate SP credentials: see `usecase-identity.md` (`remove-application-password`, `add-application-password` — high).
+- **Never `delete-service-principal`** without escalation (critical, can break integrations).
+
+For the full playbook (including the disable-SP-before-revoke-sessions ordering), see [`docs/playbooks/oauth-illicit-consent.md`](../../../docs/playbooks/oauth-illicit-consent.md).
+
+## Ticket template
+
+Tracker-agnostic minimum:
+
+```
+Title: [INC] Account compromise — <UPN> — <YYYY-MM-DD>
+Priority: High (or Critical if privileged account, sensitive data, or lateral movement)
+
+## Context
+- Detection source (alert ID, SOC signal, user report)
+- Initial timeline
+
+## Targeted account
+- UPN, displayName, department, manager
+- Privileged roles / groups: yes/no
+
+## Indicators
+- Suspicious sign-ins: <summary>
+- Unusual IPs / devices / apps
+- Potentially compromised MFA methods
+
+## Containment actions executed
+- [HH:MM] disable-user-account → <result>
+- [HH:MM] revoke-user-sessions → <result>
+- [HH:MM] confirm-compromised-users → <result>
+- [HH:MM] delete-user-phone-auth-method (if applicable) → <result>
+
+## Audit trail
+<list-directory-audits output or reference IDs>
+
+## Follow-up
+- [ ] User communication (manager? HR?)
+- [ ] Password reset + new MFA registration
+- [ ] Conditional reactivation
+- [ ] Lessons learned
+```
+
+## Guardrails
+
+- **No action on break-glass accounts** under any circumstance without out-of-band sign-off.
+- **No action on admin accounts** (Global, Privileged Role, Security, Exchange, SharePoint, Intune) without out-of-band sign-off.
+- **Executive accounts** (CEO, CFO, CHRO, etc.): escalation required even when the account isn't admin — business and communication impact.
+- **One mutation at a time.** No automated pipeline of critical actions without confirmation between each.
+- **Document in the source alert immediately** via `add-security-alert-comment` after each action — not at the end of the process.
+
+## Crosswalk
+
+- Account identification → `usecase-identity.md`.
+- Timeline reconstruction → `usecase-audit.md`.
+- Related IOC investigation → `usecase-threatintel.md`.
+- Concurrent device compromise → `usecase-intune.md` (locate, lock, retire).
+- Legal preservation (potential litigation) → `usecase-ediscovery.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-retention.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-retention.md
@@ -1,0 +1,29 @@
+# usecase-retention — Records management
+
+**When to load:** document retention compliance, retention labels, file plan.
+
+## Tools in scope
+
+| Tool                                                  | Usage                  |
+| ----------------------------------------------------- | ---------------------- |
+| `list-retention-labels`                               | Retention labels.      |
+| `list-file-plan-authorities`                          | File plan authorities. |
+| `list-file-plan-categories`                           | Categories.            |
+| `list-file-plan-citations`                            | Legal citations.       |
+| `list-file-plan-departments`                          | Departments.           |
+| `list-file-plan-references`                           | References.            |
+| `list-retention-events`, `list-retention-event-types` | Retention events.      |
+
+All read-only.
+
+## Pattern — Retention label audit
+
+1. `list-retention-labels` → published labels.
+2. `list-file-plan-categories` → file plan categories.
+3. Cross-reference to identify labels without categories or categories without labels.
+
+## Crosswalk
+
+- SharePoint sites with retention → `usecase-sharepointadmin.md`.
+- Sensitivity labels → `usecase-infoprotection.md`.
+- eDiscovery → `usecase-ediscovery.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-security.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-security.md
@@ -1,0 +1,70 @@
+# usecase-security — Alert and incident triage
+
+**When to load:** daily Defender alert triage, incident follow-up, attack simulation monitoring, or any request starting with "alerts", "incidents", "attack sim".
+
+**Upstream references:** [USE_CASES.md §1 Daily security monitoring](../../../docs/USE_CASES.md), [§13 Advanced threat hunting](../../../docs/USE_CASES.md).
+
+## Tools in scope
+
+### Read
+
+| Tool                      | Usage                                                                               |
+| ------------------------- | ----------------------------------------------------------------------------------- |
+| `list-security-alerts`    | Defender XDR alerts. Filter by `severity`, `status`, `lastModifiedDateTime`.        |
+| `get-security-alert`      | Single alert detail. ⚠ Can time out on large alerts — see SKILL.md troubleshooting. |
+| `list-security-incidents` | Incidents (alert groupings).                                                        |
+| `get-security-incident`   | Single incident detail + linked alerts.                                             |
+| `list-attack-simulations` | Phishing simulation campaigns.                                                      |
+| `get-attack-simulation`   | Single simulation — click rate, credential submission rate, affected users.         |
+
+### Write
+
+| Tool                         | Risk   | When                                                                  |
+| ---------------------------- | ------ | --------------------------------------------------------------------- |
+| `update-security-alert`      | medium | Change status (`newAlert`, `inProgress`, `resolved`), classification. |
+| `update-security-incident`   | medium | Same at the incident level.                                           |
+| `add-security-alert-comment` | low    | Annotate an alert with investigation context.                         |
+| `create-attack-simulation`   | high   | Launch a new phishing simulation — coordinate with comms first.       |
+| `update-attack-simulation`   | medium | Modify an existing simulation.                                        |
+| `delete-attack-simulation`   | medium | Removes the simulation record — prefer archival.                      |
+
+## Patterns
+
+### Pattern 1 — Daily triage
+
+> _"Summarize alerts from the last 24 hours."_
+
+1. `list-security-alerts` with `$filter=createdDateTime ge <yesterday>` and `$top=50`.
+2. Group mentally by `severity` and `status`.
+3. For unworked `high` alerts, show a compact summary: title, severity, target user/device, timestamp.
+4. On detail request, `get-security-alert` by ID. On timeout, fall back to fields already returned by `list`.
+5. Cross-reference with `list-security-incidents` for the grouped view.
+
+### Pattern 2 — Incident follow-up
+
+> _"Where are we on incident INC-12345?"_
+
+1. `get-security-incident` by ID.
+2. Enumerate linked alerts, status, assignee, comments.
+3. Propose `add-security-alert-comment` to log an investigation note.
+4. If resolved, propose `update-security-incident` to set `resolved` — medium, confirm.
+
+### Pattern 3 — Attack simulation results
+
+> _"How did the latest phishing simulation go?"_
+
+1. `list-attack-simulations` to identify the recent campaign.
+2. `get-attack-simulation` for metrics (click rate, credential submission rate, affected users).
+3. Offer to export a summary for stakeholders.
+
+## Guardrails
+
+- **Status changes** (`update-security-alert`, `update-security-incident`) are medium — confirm with the operator that the transition is justified. Moving to `resolved` without investigation evidence is risky.
+- **`create-attack-simulation`** is high. A phishing simulation reaching users requires coordination with the comms team — never launch without out-of-band sign-off.
+- **`delete-attack-simulation`** loses historical data useful for KPIs. Prefer archival.
+
+## Crosswalk
+
+- Account named in an alert → load `usecase-response.md` for containment.
+- IOC in the alert (IP, domain) → load `usecase-threatintel.md` for enrichment.
+- Related suspicious sign-in → load `usecase-audit.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-sharepointadmin.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-sharepointadmin.md
@@ -1,0 +1,84 @@
+# usecase-sharepointadmin — SharePoint tenant administration
+
+**When to load:** external sharing audit, oversized sites, tenant SharePoint permission governance.
+
+**Upstream references:** [USE_CASES.md §12 SharePoint administration](../../../docs/USE_CASES.md), [SharePoint exfiltration playbook](../../../docs/playbooks/sharepoint-exfiltration.md).
+
+## Tools in scope
+
+### Read — tenant
+
+| Tool                      | Usage                                                        |
+| ------------------------- | ------------------------------------------------------------ |
+| `get-sharepoint-settings` | Tenant SharePoint settings (external sharing default, etc.). |
+
+### Read — sites
+
+| Tool                                                                                 | Usage                          |
+| ------------------------------------------------------------------------------------ | ------------------------------ |
+| `list-sharepoint-sites`, `get-sharepoint-site`                                       | All sites / single site.       |
+| `list-site-drives`, `get-site-default-drive`                                         | Document libraries.            |
+| `list-site-lists`, `get-site-list`, `list-site-list-items`, `list-site-list-columns` | Lists / items / columns.       |
+| `list-site-columns`, `list-site-content-types`                                       | Site columns / content types.  |
+| `list-site-permissions`, `get-site-permission`                                       | Permissions applied to a site. |
+| `get-site-analytics`                                                                 | Usage analytics.               |
+| `list-site-subsites`                                                                 | Subsites.                      |
+
+### Write
+
+| Tool                     | Risk   |
+| ------------------------ | ------ |
+| `update-sharepoint-site` | medium |
+| `create-site-list`       | low    |
+| `update-site-list`       | low    |
+| `delete-site-list`       | high   |
+| `create-site-list-item`  | low    |
+| `update-site-list-item`  | low    |
+| `delete-site-list-item`  | medium |
+| `create-site-permission` | medium |
+| `update-site-permission` | medium |
+| `delete-site-permission` | high   |
+
+## Pattern 1 — External sharing audit
+
+> _"Which sites share externally?"_
+
+1. `get-sharepoint-settings` → tenant-wide external sharing setting.
+2. `list-sharepoint-sites` (paginate on large tenants) → all sites.
+3. For sensitive sites (operator-defined: Legal, HR, Finance, Security, Executive):
+   - `list-site-permissions` → identify guests, anonymous links.
+   - Flag external permissions.
+4. Present by site criticality.
+
+## Pattern 2 — Top sites by storage
+
+> _"Top 20 sites by size."_
+
+1. `list-sharepoint-sites` sorted by `quota.used` or `siteCollection.usage`.
+2. Cross-reference with `get-site-analytics` for activity (active vs. dormant).
+3. Present: Site | Owner | Storage used | Last activity.
+4. For dormant sites > X months, propose an archive plan.
+
+## Pattern 3 — Permission audit on a sensitive site
+
+> _"Who has access to the `Finance` site?"_
+
+1. `get-sharepoint-site` (siteId).
+2. `list-site-permissions` → root permissions.
+3. `list-site-subsites` + permissions per subsite (broken inheritance?).
+4. For each permission, identify the grantee (user, group, app).
+5. Flag apps with `Sites.FullControl.All` or equivalent.
+
+## Guardrails
+
+- **`delete-site-permission` (high)** can break access to operational content. Always verify dependencies first.
+- **`update-sharepoint-site`** — site-level settings changes (sharing capabilities, sensitivity labels) cascade.
+- **List / item changes via API** — SharePoint has complex logic (calculated fields, workflows, retention). Prefer the UI unless bulk operations are justified.
+- **Tenant settings (`get-sharepoint-settings`)** — no write tool exposed. Modify via SharePoint Admin Center.
+
+## Crosswalk
+
+- Applied sensitivity labels → `usecase-infoprotection.md`.
+- Records management / retention on sites → `usecase-retention.md`.
+- Identities with access → `usecase-identity.md`.
+- End-to-end exfiltration scenario → [`docs/playbooks/sharepoint-exfiltration.md`](../../../docs/playbooks/sharepoint-exfiltration.md).

--- a/agent-skills/ms365-admin-mcp/references/usecase-teamsadmin.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-teamsadmin.md
@@ -1,0 +1,79 @@
+# usecase-teamsadmin — Teams tenant-level administration
+
+**When to load:** Teams / channel / app management at the tenant level, Teams admin policies.
+
+**Upstream references:** Teams is touched in passing throughout [USE_CASES.md](../../../docs/USE_CASES.md); no dedicated section.
+
+## Tools in scope
+
+### Read — teams
+
+| Tool                                                                              | Usage                             |
+| --------------------------------------------------------------------------------- | --------------------------------- |
+| `list-teams`, `get-team`                                                          | Teams.                            |
+| `list-team-admin-channels`, `get-team-admin-channel`                              | Channels.                         |
+| `list-team-admin-members`, `get-team-admin-member`                                | Members.                          |
+| `list-team-installed-apps`, `list-team-operations`, `list-team-permission-grants` | Apps / operations / permissions.  |
+| `list-deleted-teams`                                                              | Soft-deleted teams (recoverable). |
+
+### Write — teams
+
+| Tool                        | Risk                                  |
+| --------------------------- | ------------------------------------- |
+| `create-team`               | medium                                |
+| `update-team`               | medium                                |
+| `delete-team`               | **critical** — out-of-band escalation |
+| `create-team-admin-channel` | low                                   |
+| `delete-team-admin-channel` | high                                  |
+| `add-team-admin-members`    | medium                                |
+| `remove-team-admin-members` | medium                                |
+| `archive-team`              | medium                                |
+| `unarchive-team`            | low                                   |
+| `clone-team`                | medium                                |
+
+### Apps and settings
+
+| Tool                                                                                                                                                    | Usage / Risk |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| `list-teams-catalog-apps`, `get-teams-catalog-app`, `list-teams-app-definitions`                                                                        | read         |
+| `get-teams-app-settings`                                                                                                                                | read         |
+| `update-teams-app-settings`                                                                                                                             | high         |
+| `get-teams-admin-settings`, `list-teams-user-configurations`, `get-teams-admin-policy`, `list-teams-policy-assignments`, `list-teams-phone-assignments` | read         |
+
+## Pattern 1 — Teams inventory
+
+> _"How many active Teams, how many dormant?"_
+
+1. `list-teams` → all.
+2. For each, `get-team` → activity status, member count.
+3. Identify dormant (no activity 90d+).
+4. Cross-reference with `list-deleted-teams` for lifecycle view.
+
+## Pattern 2 — Archive an inactive team
+
+> _"Team `Project-Atlas` is finished — archive it."_
+
+1. `get-team` → confirm.
+2. `list-team-admin-members` → notify owners.
+3. `archive-team` (medium) → confirmation.
+
+## Pattern 3 — Installed third-party apps audit
+
+> _"Which third-party apps are installed in Teams?"_
+
+1. `list-teams-catalog-apps` filtered on `distributionMethod eq 'organization'` or `'sideloaded'`.
+2. For each suspicious app, `get-teams-catalog-app` → permissions, publisher.
+3. `list-team-permission-grants` filtered → teams that granted access.
+4. Flag non-Microsoft apps with elevated permissions.
+
+## Guardrails
+
+- **`delete-team` (critical)** — 30-day soft-delete window, but historical conversations matter. Out-of-band escalation for teams with operational history.
+- **`update-teams-app-settings` (high)** — tenant-wide Teams impact. Requires formal change management.
+- **`add-team-admin-members` / `remove-`** can affect private conversations. Verify the request comes from a legitimate owner.
+
+## Crosswalk
+
+- Member identities → `usecase-identity.md`.
+- Compliance / retention on Teams content → `usecase-retention.md`.
+- eDiscovery on Teams conversations → `usecase-ediscovery.md`.

--- a/agent-skills/ms365-admin-mcp/references/usecase-threatintel.md
+++ b/agent-skills/ms365-admin-mcp/references/usecase-threatintel.md
@@ -1,0 +1,132 @@
+# usecase-threatintel — Threat intelligence and KQL hunting
+
+**When to load:** IOC investigation (IP, domain, hash, certificate), WHOIS / DNS enrichment, KQL queries against Defender Advanced Hunting.
+
+**Upstream references:** [USE_CASES.md §13 Advanced threat hunting](../../../docs/USE_CASES.md).
+
+## Tools in scope
+
+### KQL hunting
+
+| Tool                | Risk                                                              |
+| ------------------- | ----------------------------------------------------------------- |
+| `run-hunting-query` | low — POST but read-only in practice (KQL does not mutate state). |
+
+### Threat intel — hosts and infrastructure
+
+| Tool                                                                                                | Usage                                 |
+| --------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| `list-threat-intel-hosts`, `get-threat-intel-host`                                                  | Hosts (IPs, domains).                 |
+| `get-threat-intel-host-whois`                                                                       | WHOIS.                                |
+| `list-threat-intel-host-pairs`                                                                      | Relationships between hosts.          |
+| `list-threat-intel-host-components`                                                                 | Detected components (web tech, etc.). |
+| `list-threat-intel-host-ports`, `list-threat-intel-host-trackers`, `list-threat-intel-host-cookies` | Ports, trackers, cookies observed.    |
+| `list-threat-intel-ssl-certs`, `list-ssl-certificates`                                              | SSL certificates.                     |
+| `list-threat-intel-subdomains`                                                                      | Subdomains.                           |
+| `list-passive-dns-records`                                                                          | Passive DNS history.                  |
+
+### Threat intel — articles and profiles
+
+| Tool                                                     | Usage                            |
+| -------------------------------------------------------- | -------------------------------- |
+| `list-threat-intel-articles`, `get-threat-intel-article` | Microsoft Threat Intel articles. |
+| `list-threat-intel-article-indicators`                   | IOCs in an article.              |
+| `list-threat-intel-profiles`, `get-threat-intel-profile` | Threat actor profiles.           |
+| `list-threat-intel-profile-indicators`                   | IOCs in a profile.               |
+
+### Threat intel — vulnerabilities and WHOIS records
+
+| Tool                                                                  | Usage                     |
+| --------------------------------------------------------------------- | ------------------------- |
+| `list-threat-intel-vulnerabilities`, `get-threat-intel-vulnerability` | CVEs.                     |
+| `list-threat-intel-whois-records`, `get-threat-intel-whois-record`    | Historical WHOIS records. |
+
+## Pattern 1 — IOC investigation (suspect IP)
+
+> _"IP `203.0.113.42` appears in our logs — investigate."_
+
+### Step 1 — Internal activity
+
+```
+list-sign-ins($filter="ipAddress eq '203.0.113.42' and createdDateTime ge <-14d>")
+```
+
+Identify users / apps with sign-ins from this IP.
+
+### Step 2 — KQL hunting for broader activity
+
+```
+run-hunting-query(query="
+  union
+    (DeviceNetworkEvents | where RemoteIP == '203.0.113.42'),
+    (CloudAppEvents | where IPAddress == '203.0.113.42'),
+    (AADSignInEventsBeta | where IPAddress == '203.0.113.42')
+  | project Timestamp, Type=$table, AccountUpn, DeviceName, ActionType
+  | order by Timestamp desc
+  | take 100
+")
+```
+
+### Step 3 — Threat Intel enrichment
+
+```
+list-threat-intel-hosts($filter="hostname eq '203.0.113.42'")
+get-threat-intel-host-whois(...)
+list-passive-dns-records(...)
+list-threat-intel-articles($filter="indicators contains '203.0.113.42'")
+```
+
+### Step 4 — Synthesis
+
+Present:
+
+- Internal activity (who touched the IP, when, context).
+- External reputation (MS articles, threat actor profiles).
+- WHOIS / passive DNS (historical resolutions, ownership).
+- Recommendation: block (Conditional Access named location), monitor, or ignore.
+
+### Step 5 — If confirmed malicious
+
+- Create or enrich a CA named location for blocking (`usecase-compliance.md`).
+- If users compromised → `usecase-response.md`.
+- File an incident ticket documenting the IOC, investigation, and decision.
+
+## Pattern 2 — Threat intel for an active CVE
+
+> _"CVE-2026-XXXX — are we exposed?"_
+
+1. `list-threat-intel-vulnerabilities` filtered on CVE ID.
+2. `get-threat-intel-vulnerability` → details (severity, products affected).
+3. Cross-reference with:
+   - `list-detected-apps` (Intune) if the affected product is an app.
+   - `list-managed-devices` filtered on OS / version.
+4. If exposure confirmed: file a patching plan with the platform owner.
+
+## Pattern 3 — Threat actor attribution
+
+> _"Has this campaign been attributed to a known actor?"_
+
+1. `list-threat-intel-profiles` → Microsoft profiles.
+2. For relevant profiles, `get-threat-intel-profile` → TTPs, known IOCs.
+3. `list-threat-intel-profile-indicators` → indicators to monitor.
+4. Push indicators into KQL hunting to verify tenant exposure.
+
+## KQL best practices
+
+- **Always limit** — `take 100` or less during exploration.
+- **Index early** — `where Timestamp >= ...` near the top of the query.
+- **No PII in shared comments** — sanitize before sharing the query externally.
+- **Test on a short window** before broadening.
+
+## Guardrails
+
+- `run-hunting-query` is **low risk** (read-only) but can consume Defender resources. Avoid mass queries on repeat.
+- Don't run queries on unvalidated external requests — this is internal investigation.
+- KQL result rows can contain PII (UPN, employee home IP). Distribute carefully.
+
+## Crosswalk
+
+- IOC in a Defender alert → `usecase-security.md`.
+- Compromised user related to IOC → `usecase-response.md`.
+- Related sign-ins → `usecase-audit.md`.
+- Exposed devices → `usecase-intune.md`.


### PR DESCRIPTION
## Summary

Adds an agent skill under `agent-skills/ms365-admin-mcp/` that wraps the server with a structured safety pattern (dry-run → confirm → audit) and routes requests by use case across the 19 tool-category presets. The skill is portable across LLM agent runtimes; install steps for Claude Code are documented in `agent-skills/README.md`.

This is **documentation-only** — no code paths change, no tools change. The skill is a router with guardrails, not a re-explanation of the docs: it links back to `docs/USE_CASES.md` and `docs/playbooks/` rather than duplicating their content.

## Why ship a skill in the repo?

The repo already has thorough docs (USE_CASES, playbooks, RISK_MODEL). What it doesn't have is a **drop-in skill format** for LLM clients — a single `SKILL.md` with frontmatter that an agent runtime auto-loads when an ms365-admin tool is about to be called, plus lazy-loaded `references/usecase-*.md` that constrain the model to one preset's tool surface at a time.

That gap matters because:

- An out-of-the-box ms365-admin install exposes 515 tools. Without a routing layer, the model often picks adjacent tools instead of the right one for the use case.
- Write-heavy domains (`response`, `intune`, `identity`) need an enforced dry-run pattern. The skill makes that pattern the default rather than a per-prompt instruction.
- Anthropic and other LLM vendors are pushing the skill format. Shipping one alongside the server makes the repo "skill-ready" for the next wave of agent runtimes.

## What's in the PR

```
agent-skills/
├── README.md                              # install + contribution guide
└── ms365-admin-mcp/
    ├── SKILL.md                           # main entry (~180 lines)
    └── references/
        ├── tools-catalog.md               # risk-level index for all writes
        ├── graph-permissions.md           # Graph application permissions reference
        └── usecase-*.md                   # 19 slim files, one per preset
```

Plus a single line added to `README.md` to link `agent-skills/` from the Documentation table.

**Total: 24 new files, 2319 lines, no code changes.**

## Design choices

- **English only**, matching the rest of the docs.
- **Anonymized** with `@contoso.com` everywhere — same convention as `docs/USE_CASES.md`.
- **Slim per-domain files** that link to upstream sections rather than re-explain them. When you update `USE_CASES.md` or a playbook, the skill stays correct because it doesn't duplicate.
- **Mandatory dry-run pattern** for every `high` / `critical` write, plus a named list of tools that require out-of-band escalation even with operator confirmation (e.g. `delete-user`, `wipe-managed-device`, `disable-user-account` on privileged accounts).
- **Decision matrix vs. a delegated companion server** (Softeria's `ms-365-mcp-server` is the canonical example) at the top of `SKILL.md` so the model knows when NOT to load this skill.

## Out of scope

- Skill installation hooks for specific runtimes other than Claude Code (briefly mentioned in `agent-skills/README.md`).
- Auto-discovery / packaging on the npm side.
- Skill versioning convention — happy to add a `version:` frontmatter field if you have a preferred scheme.

## Test plan

- [x] `npx prettier --check 'agent-skills/**/*.md' 'README.md'` passes.
- [x] No tenant-specific identifiers, names, or workflow references leaked (final grep clean).
- [x] All tool names referenced exist in `src/endpoints.json` (cross-referenced from upstream USE_CASES.md and the live preset registry).
- [ ] Reviewer to spot-check a couple of usecase files for clarity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)