### PR TITLE
fix(http): rate-limit per IP before body parsing (SEC-005)

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -156,6 +156,24 @@ export async function startHttpServer(options: HttpServerOptions): Promise<void>
 
   app.set('trust proxy', 1);
   app.use(securityHeaders);
+
+  // SEC-005: outer per-IP rate limiter runs BEFORE the body parsers so an
+  // unauthenticated attacker cannot force 100 KB JSON parses at full request
+  // rate. The inner /mcp limiter (below) still gates authenticated traffic
+  // at 100/min. 200 req/min is a generous cap that covers /health, OAuth
+  // proxy and /mcp combined for a single IP — adjust upward if a legitimate
+  // admin cohort shares a NAT.
+  app.use(
+    rateLimit({
+      windowMs: 60_000,
+      max: 200,
+      standardHeaders: true,
+      legacyHeaders: false,
+      keyGenerator: (req) => req.ip ?? 'unknown',
+      message: { error: 'Too many requests, please try again later' },
+    })
+  );
+
   app.use(express.json({ limit: '100kb' }));
   app.use(express.urlencoded({ extended: true, limit: '100kb' }));
 


### PR DESCRIPTION
## Summary

Fixes #72 — adds an outer per-IP rate limiter (200 req/min) ahead of \`express.json\` / \`express.urlencoded\` so unauthenticated body parsing is bounded.

## Before

\`\`\`ts
app.set('trust proxy', 1);
app.use(securityHeaders);
app.use(express.json({ limit: '100kb' }));         // ← parsed BEFORE auth/limit
app.use(express.urlencoded({ extended: true, limit: '100kb' }));
app.use('/mcp', rateLimit({ max: 100 }));          // ← gates AFTER parse
\`\`\`

An unauthenticated attacker could force 100 KB JSON parses at request-line rate; the 100/min cap on \`/mcp\` only kicked in after Express had already burned the parsing.

## After

\`\`\`ts
app.set('trust proxy', 1);
app.use(securityHeaders);

// Outer per-IP rate limiter — 200 req/min/IP, runs BEFORE body parsing
app.use(rateLimit({
  windowMs: 60_000, max: 200,
  keyGenerator: (req) => req.ip ?? 'unknown',
  ...
}));

app.use(express.json({ limit: '100kb' }));
app.use(express.urlencoded({ extended: true, limit: '100kb' }));

// Inner /mcp limiter unchanged — 100 req/min on the authenticated path
app.use('/mcp', rateLimit({ max: 100, ... }));
\`\`\`

## Tuning rationale

- **200 req/min/IP outer** covers \`/health\` (~2 req/min from Container Apps probe), OAuth proxy (~1-3 req/auth flow), and \`/mcp\` (~100 req/min nominal) for a single source IP. Generous enough to not break legitimate single-admin usage.
- **100 req/min /mcp inner** preserved — defence in depth against authenticated callers.
- If a legitimate admin cohort shares a single NAT IP and hits the 200 cap, raise it (configurable later via CLI flag if needed).

## Test plan

- [x] \`npm run verify\` passes 195/195
- [x] No new tests needed — outer limiter is exercised implicitly by every test that makes a request to \`/mcp\`. The behavioural change is a single \`app.use(...)\` ahead of body parsing; failure mode would be that all tests start returning 429 (would be immediately obvious)
- [ ] After merge: confirm \`/health\` still returns 200 from Container Apps probe (no false 429 in revision health)

🤖 Generated with [Claude Code](https://claude.com/claude-code)