### PR TITLE
docs(vscode): add VS Code MCP setup example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,11 @@ src/generated/client.ts
 .idea
 .vscode-test
 
+# VS Code MCP config — resolved secrets from input prompts must never be
+# committed. Only the sanitized example file is checked in.
+.vscode/mcp.json
+!.vscode/mcp.json.example
+
 # Claude
 CLAUDE.md
 .claude/

--- a/.vscode/mcp.json.example
+++ b/.vscode/mcp.json.example
@@ -1,0 +1,108 @@
+// Example VS Code MCP configuration for ms-365-admin-mcp-server.
+//
+// Copy this file to .vscode/mcp.json and fill in your tenant / app values.
+// The real .vscode/mcp.json is gitignored so secrets resolved from prompts
+// never end up in git history.
+//
+// VS Code 1.102+ supports MCP servers natively. Three deployment shapes are
+// shown below — uncomment the one that matches your setup.
+//
+// Reference: https://code.visualstudio.com/docs/copilot/chat/mcp-servers
+{
+  // "inputs" are prompted once on first start and stored in VS Code's
+  // secret store. They are NOT written to this file.
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "ms365-tenant-id",
+      "description": "Azure AD tenant ID (specific GUID, not 'common')"
+    },
+    {
+      "type": "promptString",
+      "id": "ms365-client-id",
+      "description": "App registration client ID"
+    },
+    {
+      "type": "promptString",
+      "id": "ms365-client-secret",
+      "description": "App registration client secret",
+      "password": true
+    }
+  ],
+
+  "servers": {
+    // -------------------------------------------------------------------
+    // Variant 1 — stdio, globally installed (recommended)
+    // Prereq: npm install -g @okapi-ca/ms-365-admin-mcp-server
+    // -------------------------------------------------------------------
+    "ms365-admin": {
+      "type": "stdio",
+      "command": "ms-365-admin-mcp-server",
+      "args": [
+        "--preset",
+        "security,audit,identity,health"
+        // Add "--allow-writes" only when you want incident-response,
+        // device remote actions, or other mutating tools available.
+      ],
+      "env": {
+        "MS365_ADMIN_MCP_TENANT_ID": "${input:ms365-tenant-id}",
+        "MS365_ADMIN_MCP_CLIENT_ID": "${input:ms365-client-id}",
+        "MS365_ADMIN_MCP_CLIENT_SECRET": "${input:ms365-client-secret}"
+      }
+    }
+
+    // -------------------------------------------------------------------
+    // Variant 2 — stdio, no global install (npx)
+    // Tradeoff: 2–3 s cold start at every VS Code launch.
+    // -------------------------------------------------------------------
+    // "ms365-admin": {
+    //   "type": "stdio",
+    //   "command": "npx",
+    //   "args": [
+    //     "-y",
+    //     "@okapi-ca/ms-365-admin-mcp-server@latest",
+    //     "--preset", "security,audit,identity,health"
+    //   ],
+    //   "env": {
+    //     "MS365_ADMIN_MCP_TENANT_ID":     "${input:ms365-tenant-id}",
+    //     "MS365_ADMIN_MCP_CLIENT_ID":     "${input:ms365-client-id}",
+    //     "MS365_ADMIN_MCP_CLIENT_SECRET": "${input:ms365-client-secret}"
+    //   }
+    // }
+
+    // -------------------------------------------------------------------
+    // Variant 3a — Remote HTTP, VS Code native OAuth (1.103+)
+    // Server runs with --transport http behind a reverse proxy that
+    // serves OAuth 2.0 DCR (Dynamic Client Registration). VS Code opens
+    // the browser, handles the callback, and stores the token in its
+    // secret store. No inputs needed — credentials live server-side.
+    // -------------------------------------------------------------------
+    // "ms365-admin-remote": {
+    //   "type": "http",
+    //   "url": "https://your-mcp-host.example.com/mcp"
+    // }
+
+    // -------------------------------------------------------------------
+    // Variant 3b — Remote HTTP via mcp-remote bridge
+    // Use when the native HTTP flow can't open a browser on localhost
+    // (e.g. macOS Platform SSO intercepting the WebKit OAuth callback,
+    // headless / SSH dev envs, or VS Code older than 1.103).
+    //
+    // Bootstrap once per workstation, on any trusted device:
+    //   npx @okapi-ca/ms-365-admin-mcp-server@latest auth \
+    //     --server https://your-mcp-host.example.com/mcp
+    //
+    // The helper pre-seeds ~/.mcp-auth/mcp-remote-*/ so mcp-remote
+    // finds the cached tokens without ever opening a browser.
+    // -------------------------------------------------------------------
+    // "ms365-admin-remote": {
+    //   "type": "stdio",
+    //   "command": "npx",
+    //   "args": [
+    //     "-y",
+    //     "mcp-remote",
+    //     "https://your-mcp-host.example.com/mcp"
+    //   ]
+    // }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -105,6 +105,49 @@ npm run build
 }
 ```
 
+### VS Code (1.102+)
+
+VS Code consumes the same MCP protocol but uses a different config layout —
+`servers` instead of `mcpServers`, an explicit `type` field, and `inputs` for
+secret prompts. A ready-to-copy sample lives at
+[`.vscode/mcp.json.example`](.vscode/mcp.json.example); copy it to
+`.vscode/mcp.json` and VS Code will prompt for the tenant / client / secret on
+first start, then store them in its secret store (the real `mcp.json` is
+gitignored so resolved secrets never reach the repo).
+
+Minimal stdio setup:
+
+```jsonc
+{
+  "inputs": [
+    { "type": "promptString", "id": "ms365-tenant-id",     "description": "Tenant ID" },
+    { "type": "promptString", "id": "ms365-client-id",     "description": "Client ID" },
+    { "type": "promptString", "id": "ms365-client-secret", "description": "Client secret", "password": true }
+  ],
+  "servers": {
+    "ms365-admin": {
+      "type": "stdio",
+      "command": "ms-365-admin-mcp-server",
+      "args": ["--preset", "security,audit,identity,health"],
+      "env": {
+        "MS365_ADMIN_MCP_TENANT_ID":     "${input:ms365-tenant-id}",
+        "MS365_ADMIN_MCP_CLIENT_ID":     "${input:ms365-client-id}",
+        "MS365_ADMIN_MCP_CLIENT_SECRET": "${input:ms365-client-secret}"
+      }
+    }
+  }
+}
+```
+
+For remote HTTP deployments, use `"type": "http"` with a `url` field (VS Code
+1.103+ handles OAuth 2.0 Dynamic Client Registration natively) or fall back to
+the `mcp-remote` bridge when the native browser flow is unavailable — see the
+example file for both shapes.
+
+Tools surface in **Agent mode** (GitHub Copilot Chat). VS Code asks for
+per-tool approval; the `--preset` flag above keeps the catalog manageable.
+Use `Cmd/Ctrl+Shift+P` → `MCP: List Servers` → `Show Output` to see logs.
+
 ### Remote HTTP server: device_code authentication (RFC 8628)
 
 If the server runs in HTTP / OAuth mode on a remote host (e.g. Azure Container Apps) and the client connects via [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), the standard flow requires a browser to reach `localhost:14543/oauth/callback`. When that isn't possible — macOS Platform SSO hijacks the WebKit flow, Claude Code runs in a headless Docker container, the user is on a remote SSH dev env — use the `ms-365-admin-mcp-auth` bootstrap to pre-seed `mcp-remote`'s token cache instead.

--- a/README.md
+++ b/README.md
@@ -120,9 +120,14 @@ Minimal stdio setup:
 ```jsonc
 {
   "inputs": [
-    { "type": "promptString", "id": "ms365-tenant-id",     "description": "Tenant ID" },
-    { "type": "promptString", "id": "ms365-client-id",     "description": "Client ID" },
-    { "type": "promptString", "id": "ms365-client-secret", "description": "Client secret", "password": true }
+    { "type": "promptString", "id": "ms365-tenant-id", "description": "Tenant ID" },
+    { "type": "promptString", "id": "ms365-client-id", "description": "Client ID" },
+    {
+      "type": "promptString",
+      "id": "ms365-client-secret",
+      "description": "Client secret",
+      "password": true,
+    },
   ],
   "servers": {
     "ms365-admin": {
@@ -130,12 +135,12 @@ Minimal stdio setup:
       "command": "ms-365-admin-mcp-server",
       "args": ["--preset", "security,audit,identity,health"],
       "env": {
-        "MS365_ADMIN_MCP_TENANT_ID":     "${input:ms365-tenant-id}",
-        "MS365_ADMIN_MCP_CLIENT_ID":     "${input:ms365-client-id}",
-        "MS365_ADMIN_MCP_CLIENT_SECRET": "${input:ms365-client-secret}"
-      }
-    }
-  }
+        "MS365_ADMIN_MCP_TENANT_ID": "${input:ms365-tenant-id}",
+        "MS365_ADMIN_MCP_CLIENT_ID": "${input:ms365-client-id}",
+        "MS365_ADMIN_MCP_CLIENT_SECRET": "${input:ms365-client-secret}",
+      },
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
## Summary

VS Code 1.102+ supports MCP servers natively, but uses a different config layout than Claude Desktop — `servers` instead of `mcpServers`, an explicit `type` field, and `inputs` for secret prompts. This PR adds first-class VS Code documentation and a sanitized example file.

## Changes

- **`.vscode/mcp.json.example`** — three deployment shapes documented inline:
  - **Variant 1**: stdio with `npm install -g` (recommended)
  - **Variant 2**: stdio via `npx -y` (no global install, ~2–3 s cold start)
  - **Variant 3a**: remote HTTP with VS Code 1.103+ native OAuth (Dynamic Client Registration)
  - **Variant 3b**: remote HTTP via the `mcp-remote` bridge, for envs where the native browser flow is blocked (macOS Platform SSO intercepting the WebKit callback, headless/SSH, older VS Code)
- **`README.md`** — new `### VS Code (1.102+)` subsection between the Claude Desktop config and the device-code section, with a minimal stdio example and notes on Agent mode tool approval.
- **`.gitignore`** — keeps `.vscode/mcp.json` out of git so resolved secrets from `${input:...}` prompts never reach history; the `.example` stays versioned.

No source code touched. No new dependencies. No changes to the MCP protocol surface or tool catalog.

## Test plan

- [ ] Copy `.vscode/mcp.json.example` to `.vscode/mcp.json` in a fresh VS Code workspace
- [ ] Open `Cmd/Ctrl+Shift+P` → `MCP: List Servers` → confirm `ms365-admin` appears
- [ ] Verify the three `${input:...}` prompts fire on first server start and are stored in VS Code's secret store (not the JSON file)
- [ ] Confirm tools are reachable in Agent mode (GitHub Copilot Chat) with `--preset security,audit,identity,health`
- [ ] Validate that `.vscode/mcp.json` is correctly gitignored (`git status` after creating the real config)