### PR TITLE
feat(registry): add server.json manifest for MCP Registry

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.okapi-ca/ms-365-admin",
+  "title": "Microsoft 365 Admin",
+  "description": "MCP server for Microsoft 365 administration via Graph API application permissions (client credentials). Security monitoring, identity audits, incident response, Intune device management, and service health — read-only by default, with risk-classified write operations behind an explicit --allow-writes flag.",
+  "websiteUrl": "https://github.com/okapi-ca/ms-365-admin-mcp-server",
+  "repository": {
+    "url": "https://github.com/okapi-ca/ms-365-admin-mcp-server",
+    "source": "github"
+  },
+  "version": "0.6.2",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@okapi-ca/ms-365-admin-mcp-server",
+      "version": "0.6.2",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "MS365_ADMIN_MCP_TENANT_ID",
+          "description": "Azure AD tenant ID (specific GUID, not 'common').",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "MS365_ADMIN_MCP_CLIENT_ID",
+          "description": "App registration client ID with the required application permissions.",
+          "isRequired": true,
+          "isSecret": false
+        },
+        {
+          "name": "MS365_ADMIN_MCP_CLIENT_SECRET",
+          "description": "App registration client secret. Prefer Azure Key Vault via MS365_ADMIN_MCP_KEYVAULT_URL for production.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "MS365_ADMIN_MCP_KEYVAULT_URL",
+          "description": "Optional Azure Key Vault URL. When set, secrets are pulled from the vault and override the env-var values above.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "MS365_ADMIN_MCP_CLOUD_TYPE",
+          "description": "Cloud environment: 'global' (default) or 'china' (21Vianet).",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "MS365_ADMIN_MCP_MAX_TOP",
+          "description": "Cap on the $top query parameter to limit result size.",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "READ_ONLY",
+          "description": "Set to 'true' or '1' to force read-only mode (default behavior; mutations require --allow-writes).",
+          "isRequired": false,
+          "isSecret": false
+        },
+        {
+          "name": "ENABLED_TOOLS",
+          "description": "Regex to filter the catalog of available tools.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ],
+  "_meta": {
+    "io.modelcontextprotocol.registry/publisher-provided": {
+      "categories": ["security", "identity", "device-management", "audit", "compliance"],
+      "tags": [
+        "microsoft-365",
+        "azure-ad",
+        "entra-id",
+        "graph-api",
+        "intune",
+        "defender",
+        "conditional-access",
+        "secure-score",
+        "incident-response"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the canonical `server.json` manifest (schema [2025-12-11](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json)) so this server can be submitted to the official [Model Context Protocol Registry](https://registry.modelcontextprotocol.io).

The Registry is the discovery hub for MCP servers — once published, any MCP-aware client (VS Code, Claude Desktop, Cursor, custom agents) can find and install the server by name without out-of-band configuration.

## Manifest details

- **Namespace**: `io.github.okapi-ca/ms-365-admin` (GitHub-owned, ownership verified via OIDC at submit time)
- **Package**: `@okapi-ca/ms-365-admin-mcp-server` on npm
- **Transport**: `stdio`
- **Version**: tracks `package.json` (currently `0.6.2`)
- **Environment variables**: all eight `MS365_ADMIN_MCP_*` documented, with `isSecret: true` on `CLIENT_SECRET` only
- **`_meta`**: publisher-provided categories and tags for Registry discovery filtering

## Submission flow (out of scope for this PR)

The actual submission happens out-of-band via the [`mcp-publisher`](https://github.com/modelcontextprotocol/registry) Go CLI:

```bash
go install github.com/modelcontextprotocol/registry/cmd/publisher@latest
mcp-publisher login github   # OAuth as okapi-ca org member
mcp-publisher publish        # reads ./server.json
```

A future PR can add a GitHub Action to auto-submit on `release: published` so the Registry version always tracks the npm version.

## Test plan

- [ ] `server.json` parses as valid JSON (`jq . server.json`)
- [ ] Validates against the schema: `npx ajv-cli validate -s https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json -d server.json`
- [ ] Prettier `format:check` passes (already part of `verify` CI)
- [ ] After merge, run `mcp-publisher publish` locally and verify the entry appears at `registry.modelcontextprotocol.io/servers/io.github.okapi-ca/ms-365-admin`