### PR TITLE
fix(registry): meet MCP Registry validation requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
+  "mcpName": "io.github.okapi-ca/ms-365-admin",
   "version": "0.6.2",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.okapi-ca/ms-365-admin",
   "title": "Microsoft 365 Admin",
-  "description": "MCP server for Microsoft 365 administration via Graph API application permissions (client credentials). Security monitoring, identity audits, incident response, Intune device management, and service health — read-only by default, with risk-classified write operations behind an explicit --allow-writes flag.",
+  "description": "Microsoft 365 administration via Graph API application permissions (read-only by default).",
   "websiteUrl": "https://github.com/okapi-ca/ms-365-admin-mcp-server",
   "repository": {
     "url": "https://github.com/okapi-ca/ms-365-admin-mcp-server",


### PR DESCRIPTION
## Summary

Follow-up to #109. The MCP Registry publish API surfaced two validation errors when I tested with `mcp-publisher publish` against the live registry:

### 1. Description too long (HTTP 422)

```
expected length <= 100
location: body._meta.io.description
```

The previous description ran to ~330 characters. The registry caps it at 100. Shortened to:

> Microsoft 365 administration via Graph API application permissions (read-only by default).

(90 chars.) Long-form context lives in the README and on the npm landing page.

### 2. Missing `mcpName` field on the npm package (HTTP 400)

```
NPM package '@okapi-ca/ms-365-admin-mcp-server' is missing required 'mcpName' field.
Add this to your package.json: "mcpName": "io.github.okapi-ca/ms-365-admin"
```

This is the registry's ownership-verification hook: it reads `mcpName` from the published npm `package.json` and checks it matches the manifest's `name`. Added the field.

## Release coordination

After merge, a new npm release (>= 0.6.3) must be cut so the registry can read the updated `package.json`. Then re-run `mcp-publisher publish` from a checkout that has the new `server.json`.

## Test plan

- [ ] CI verify passes (Node 20 + 22)
- [ ] `node -e "console.log(require('./server.json').description.length)"` returns ≤ 100
- [ ] `node -e "console.log(require('./package.json').mcpName)"` returns `io.github.okapi-ca/ms-365-admin`
- [ ] After merge + npm release, `mcp-publisher publish` succeeds and the entry appears at https://registry.modelcontextprotocol.io/servers/io.github.okapi-ca/ms-365-admin