### PR TITLE
chore(release): align main with published 0.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
   "mcpName": "io.github.okapi-ca/ms-365-admin",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/okapi-ca/ms-365-admin-mcp-server",
     "source": "github"
   },
-  "version": "0.6.2",
+  "version": "0.6.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@okapi-ca/ms-365-admin-mcp-server",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Aligns `package.json` and `server.json` on `main` with the **0.6.3** version that's already live on:

- npm: <https://www.npmjs.com/package/@okapi-ca/ms-365-admin-mcp-server>
- ghcr: <https://github.com/okapi-ca/ms-365-admin-mcp-server/pkgs/container/ms-365-admin-mcp-server>
- MCP Registry: \`io.github.okapi-ca/ms-365-admin@0.6.3\`

## Why this PR exists

The v0.6.3 tag was cut from a local \`npm version patch\` commit. The tag pushed successfully (release.yml builds from the tag ref, so npm + ghcr publish worked), but the underlying commit was rejected from \`main\` by branch protection (PR-only workflow). Result: \`main\` still says \`0.6.2\` even though \`0.6.3\` is the live published version everywhere.

Without this PR, the next \`npm version patch\` on \`main\` would try to produce 0.6.3 again — collision against the already-published npm tarball.

## Changes

- \`package.json\`: \`version\` \`0.6.2\` → \`0.6.3\`
- \`server.json\`: top-level \`version\` and \`packages[0].version\` \`0.6.2\` → \`0.6.3\`

No source code changes.

## Process improvement (out of scope)

For future releases, prefer one of:

1. **PR-based bump**: open a PR that bumps the version, merge it, then tag the merge commit
2. **Tag-only workflow**: drop the local commit from \`npm version\` (use \`--no-git-tag-version\` then tag manually pointing at \`main\`)
3. **Release-please / changesets**: automated PR that proposes the next release bump

Worth a follow-up issue. For now, this PR resolves the immediate drift.

## Test plan

- [ ] CI verify passes on Node 20 + 22
- [ ] After merge, \`git log -1 main -- package.json\` shows the bump
- [ ] Next \`npm version patch\` produces 0.6.4 cleanly