### PR TITLE
feat(intune): add deviceShellScripts tools + per-endpoint Graph apiVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-22
+
+### Added — `deviceShellScripts` tools for macOS Platform Scripts (521 tools)
+
+Six new tools for Intune macOS Platform Scripts (shell scripts deployed to managed Macs):
+
+- `list-device-shell-scripts` — GET `/deviceManagement/deviceShellScripts`
+- `get-device-shell-script` — GET `/deviceManagement/deviceShellScripts/{id}`
+- `create-device-shell-script` — POST (risk: medium)
+- `update-device-shell-script` — PATCH (risk: medium)
+- `delete-device-shell-script` — DELETE (risk: high)
+- `assign-device-shell-script` — POST `/assign` (risk: medium; REPLACES existing assignments)
+
+Closes a notable gap in Intune coverage: `deviceConfigurations` was already supported, but `deviceShellScripts` was not — making it impossible to automate the deployment of shell scripts to managed macOS devices. The trigger was a multi-segment macOS wallpaper rollout (LCI Education, May 2026) that successfully created/updated 6 Configuration Profiles via the existing tools but had to fall back to manual portal operations for the 7 associated Platform Scripts.
+
+Required Graph permission: **`DeviceManagementScripts.ReadWrite.All`** (new — must be consented on the app registration).
+
+### Added — per-endpoint Graph `apiVersion` override (v1.0 / beta)
+
+`deviceShellScripts` is documented by Microsoft as a beta-only endpoint (never promoted to v1.0). To support it, the server now allows individual entries in `endpoints.json` to opt into `/beta/` via an optional field:
+
+```json
+{
+  "pathPattern": "/deviceManagement/deviceShellScripts",
+  "method": "get",
+  "toolName": "list-device-shell-scripts",
+  "appPermissions": ["DeviceManagementScripts.Read.All"],
+  "apiVersion": "beta"
+}
+```
+
+Without `apiVersion`, endpoints continue to target `/v1.0/` (the safe default).
+
+Implementation notes:
+
+- `bin/modules/download-openapi.mjs` now downloads both the v1.0 and beta Microsoft Graph OpenAPI specs; the beta file lands at `openapi/openapi-beta.yaml`.
+- `bin/modules/simplified-openapi.mjs` merges beta paths and their transitively referenced components (`schemas`, `parameters`, `responses`, `requestBodies`) into the v1.0 spec before validation. v1.0 wins on name collisions.
+- `src/graph-client.ts` `makeRequest` reads `options.apiVersion` and builds the URL as `${graphApi}/${apiVersion ?? 'v1.0'}${endpoint}`.
+- `src/graph-tools.ts` `executeGraphTool` forwards `endpointConfig.apiVersion` to the client.
+
+This is the unlock for the broader Intune Scripts family — `deviceHealthScripts`, `deviceCustomAttributeShellScripts`, `deviceManagementScripts`, `deviceComplianceScripts` are all beta-only and become straightforward to add once the infra is in place.
+
+Tests: existing 195 still green; no count assertions broken.
+
 ## [0.6.1] — 2026-04-23
 
 ### Fixed — device_code polling hit /token rate limit before MFA could complete

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 
 ## Features
 
-- **515 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
+- **521 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -23,7 +23,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 
 | Document                                                               | Purpose                                                                     |
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| [docs/USE_CASES.md](docs/USE_CASES.md)                                 | 15 typical admin scenarios with sample prompts and tool lists               |
+| [docs/USE_CASES.md](docs/USE_CASES.md)                                 | 16 typical admin scenarios with sample prompts and tool lists               |
 | [docs/playbooks/](docs/playbooks/README.md)                            | End-to-end security incident response playbooks                             |
 | [agent-skills/](agent-skills/README.md)                                | Drop-in skills for LLM agents (Claude Code et al.) with safety patterns     |
 | [docs/APP_REGISTRATION.md](docs/APP_REGISTRATION.md)                   | Step-by-step Azure AD app registration and permission consent               |
@@ -543,6 +543,26 @@ node dist/index.js --verify-login
 | `list-device-configurations`               | GET    |
 | `get-device-configuration`                 | GET    |
 | `get-device-configuration-status-overview` | GET    |
+
+### macOS Platform Scripts (6)
+
+Intune shell scripts deployed to managed macOS devices. **Targets Graph beta** (`/beta/deviceManagement/deviceShellScripts`) — Microsoft has never promoted this endpoint to v1.0. Requires `DeviceManagementScripts.ReadWrite.All`.
+
+| Tool                         | Method | Risk   |
+| ---------------------------- | ------ | ------ |
+| `list-device-shell-scripts`  | GET    |        |
+| `get-device-shell-script`    | GET    |        |
+| `create-device-shell-script` | POST   | medium |
+| `update-device-shell-script` | PATCH  | medium |
+| `delete-device-shell-script` | DELETE | high   |
+| `assign-device-shell-script` | POST   | medium |
+
+Notes:
+
+- `scriptContent` is **strict base64** (not URL-safe) of a script with LF line endings — CRLF will break execution on Macs.
+- `runAsAccount=user` is required for scripts that interact with the user session (e.g. `osascript` touching System Events).
+- `assign-device-shell-script` **REPLACES** all existing assignments — it is not additive. To add a group without removing others, first GET the current assignments, append the new target, then POST the full merged list.
+- By default `get-device-shell-script` does **not** return `scriptContent`; pass `$select=id,displayName,scriptContent,...` to fetch the base64 body.
 
 ### Enrollment & Autopilot (10)
 

--- a/bin/generate-graph-client.mjs
+++ b/bin/generate-graph-client.mjs
@@ -2,7 +2,7 @@
 
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { downloadGraphOpenAPI } from './modules/download-openapi.mjs';
+import { downloadGraphOpenAPI, downloadGraphBetaOpenAPI } from './modules/download-openapi.mjs';
 import { generateMcpTools } from './modules/generate-mcp-tools.mjs';
 import { createAndSaveSimplifiedOpenAPI } from './modules/simplified-openapi.mjs';
 
@@ -13,6 +13,7 @@ const openapiDir = path.join(rootDir, 'openapi');
 const srcDir = path.join(rootDir, 'src');
 
 const openapiFile = path.join(openapiDir, 'openapi.yaml');
+const openapiBetaFile = path.join(openapiDir, 'openapi-beta.yaml');
 const openapiTrimmedFile = path.join(openapiDir, 'openapi-trimmed.yaml');
 const endpointsFile = path.join(srcDir, 'endpoints.json');
 
@@ -26,22 +27,25 @@ async function main() {
   console.log('------------------------------------');
 
   try {
-    console.log('\n📥 Step 1: Downloading OpenAPI specification');
-    const downloaded = await downloadGraphOpenAPI(
+    console.log('\n📥 Step 1a: Downloading v1.0 OpenAPI specification');
+    const v1Downloaded = await downloadGraphOpenAPI(
       openapiDir,
       openapiFile,
       undefined,
       forceDownload
     );
+    console.log(v1Downloaded ? '✅ v1.0 spec downloaded' : '⏭️  v1.0 spec already present');
 
-    if (downloaded) {
-      console.log('\n✅ OpenAPI specification successfully downloaded');
-    } else {
-      console.log('\n⏭️ Download skipped (file exists)');
-    }
+    console.log('\n📥 Step 1b: Downloading beta OpenAPI specification');
+    const betaDownloaded = await downloadGraphBetaOpenAPI(
+      openapiDir,
+      openapiBetaFile,
+      forceDownload
+    );
+    console.log(betaDownloaded ? '✅ beta spec downloaded' : '⏭️  beta spec already present');
 
     console.log('\n🔧 Step 2: Creating simplified OpenAPI specification');
-    createAndSaveSimplifiedOpenAPI(endpointsFile, openapiFile, openapiTrimmedFile);
+    createAndSaveSimplifiedOpenAPI(endpointsFile, openapiFile, openapiTrimmedFile, openapiBetaFile);
     console.log('✅ Successfully created simplified OpenAPI specification');
 
     console.log('\n🚀 Step 3: Generating client code using openapi-zod-client');

--- a/bin/modules/download-openapi.mjs
+++ b/bin/modules/download-openapi.mjs
@@ -1,12 +1,14 @@
 import fs from 'fs';
 
-const DEFAULT_OPENAPI_URL =
+const DEFAULT_V1_OPENAPI_URL =
   'https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/refs/heads/master/openapi/v1.0/openapi.yaml';
+const DEFAULT_BETA_OPENAPI_URL =
+  'https://raw.githubusercontent.com/microsoftgraph/msgraph-metadata/refs/heads/master/openapi/beta/openapi.yaml';
 
 export async function downloadGraphOpenAPI(
   targetDir,
   targetFile,
-  openapiUrl = DEFAULT_OPENAPI_URL,
+  openapiUrl = DEFAULT_V1_OPENAPI_URL,
   forceDownload = false
 ) {
   if (!fs.existsSync(targetDir)) {
@@ -37,4 +39,8 @@ export async function downloadGraphOpenAPI(
     console.error('Error downloading OpenAPI specification:', error.message);
     throw error;
   }
+}
+
+export async function downloadGraphBetaOpenAPI(targetDir, targetFile, forceDownload = false) {
+  return downloadGraphOpenAPI(targetDir, targetFile, DEFAULT_BETA_OPENAPI_URL, forceDownload);
 }

--- a/bin/modules/simplified-openapi.mjs
+++ b/bin/modules/simplified-openapi.mjs
@@ -1,12 +1,29 @@
 import fs from 'fs';
 import yaml from 'js-yaml';
 
-export function createAndSaveSimplifiedOpenAPI(endpointsFile, openapiFile, openapiTrimmedFile) {
+export function createAndSaveSimplifiedOpenAPI(
+  endpointsFile,
+  openapiFile,
+  openapiTrimmedFile,
+  betaOpenapiFile
+) {
   const allEndpoints = JSON.parse(fs.readFileSync(endpointsFile, 'utf8'));
   const endpoints = allEndpoints.filter((endpoint) => !endpoint.disabled);
 
   const spec = fs.readFileSync(openapiFile, 'utf8');
   const openApiSpec = yaml.load(spec);
+
+  const betaEndpoints = endpoints.filter((e) => e.apiVersion === 'beta');
+  if (betaEndpoints.length > 0) {
+    if (!betaOpenapiFile || !fs.existsSync(betaOpenapiFile)) {
+      throw new Error(
+        `${betaEndpoints.length} endpoint(s) declare apiVersion="beta" but beta OpenAPI file not found at ${betaOpenapiFile}. Run \`npm run generate -- --force\` to download both specs.`
+      );
+    }
+    console.log(`📡 Merging ${betaEndpoints.length} beta endpoint(s) from ${betaOpenapiFile}`);
+    const betaSpec = yaml.load(fs.readFileSync(betaOpenapiFile, 'utf8'));
+    mergeBetaIntoV1(openApiSpec, betaSpec, betaEndpoints);
+  }
 
   for (const endpoint of endpoints) {
     if (!openApiSpec.paths[endpoint.pathPattern]) {
@@ -60,6 +77,71 @@ export function createAndSaveSimplifiedOpenAPI(endpointsFile, openapiFile, opena
   pruneUnusedSchemas(openApiSpec, usedSchemas);
 
   fs.writeFileSync(openapiTrimmedFile, yaml.dump(openApiSpec));
+}
+
+function mergeBetaIntoV1(v1Spec, betaSpec, betaEndpoints) {
+  v1Spec.paths = v1Spec.paths || {};
+  v1Spec.components = v1Spec.components || {};
+
+  const betaPathPatterns = new Set(betaEndpoints.map((e) => e.pathPattern));
+  for (const pathPattern of betaPathPatterns) {
+    const betaPath = betaSpec.paths?.[pathPattern];
+    if (!betaPath) {
+      throw new Error(`Beta path "${pathPattern}" not found in beta OpenAPI spec.`);
+    }
+    v1Spec.paths[pathPattern] = betaPath;
+
+    const refs = collectRefs(betaPath);
+    for (const ref of refs) {
+      copyBetaComponent(v1Spec, betaSpec, ref);
+    }
+  }
+}
+
+function collectRefs(obj, refs = new Set(), visited = new Set()) {
+  if (!obj || typeof obj !== 'object' || visited.has(obj)) return refs;
+  visited.add(obj);
+
+  if (Array.isArray(obj)) {
+    obj.forEach((item) => collectRefs(item, refs, visited));
+    return refs;
+  }
+
+  for (const [key, val] of Object.entries(obj)) {
+    if (key === '$ref' && typeof val === 'string' && val.startsWith('#/components/')) {
+      refs.add(val);
+    } else if (typeof val === 'object') {
+      collectRefs(val, refs, visited);
+    }
+  }
+  return refs;
+}
+
+function copyBetaComponent(v1Spec, betaSpec, ref) {
+  const m = ref.match(/^#\/components\/(schemas|parameters|responses|requestBodies)\/(.+)$/);
+  if (!m) return;
+  const [, kind, name] = m;
+
+  v1Spec.components[kind] = v1Spec.components[kind] || {};
+
+  if (v1Spec.components[kind][name]) {
+    return;
+  }
+
+  const betaComponent = betaSpec.components?.[kind]?.[name];
+  if (!betaComponent) {
+    console.warn(`   ⚠️  Beta component not found in beta spec: ${ref}`);
+    return;
+  }
+
+  v1Spec.components[kind][name] = betaComponent;
+
+  const nestedRefs = collectRefs(betaComponent);
+  for (const nestedRef of nestedRefs) {
+    if (nestedRef !== ref) {
+      copyBetaComponent(v1Spec, betaSpec, nestedRef);
+    }
+  }
 }
 
 function removeODataTypeRecursively(obj) {

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -304,6 +304,40 @@ node dist/index.js --preset identity --allow-writes
 
 ---
 
+## 16. Intune macOS Platform Scripts — automated deployment
+
+**Context.** Deploying shell scripts to managed Macs via Intune: wallpaper segmentation, CIS hardening, agent install (Zabbix, BeyondTrust), troubleshooting helpers. Previously required manual portal operations because `deviceShellScripts` is beta-only and not exposed by most Graph clients.
+
+**Startup command.**
+
+```bash
+node dist/index.js --preset intune --allow-writes --max-risk-level high
+```
+
+> `delete-device-shell-script` is **high** risk. If you only need to push and assign new scripts, run with `--max-risk-level medium` and elevate only when intentionally removing.
+
+**Sample prompt (deploy).**
+
+> "Create a Platform Script named `download-wallpaper-staff-fr` that runs as the user, executes once (`PT0S`), retries 3 times, with `blockExecutionNotifications: true`. The script body is in `./scripts/wallpaper-fr-staff.sh` — base64-encode it before submitting. Once created, assign it to the Entra group `Gr-Sec-AAD-INTUNE-MAC-STAFF-FR`."
+
+**Sample prompt (audit).**
+
+> "List all macOS Platform Scripts in the tenant. For each, fetch the script content (`$select=id,displayName,scriptContent,fileName,runAsAccount`), decode the base64, and flag any that contain `sudo`, `curl | bash`, or hardcoded credentials."
+
+**Sample prompt (rotate).**
+
+> "The script `download-wallpaper-staff-fr` needs an updated payload. Read the new version from `./scripts/wallpaper-fr-staff-v2.sh`, base64-encode it, and PATCH the existing script via `update-device-shell-script`. Do not touch the assignments — they stay as-is."
+
+**Key tools.** `list-device-shell-scripts`, `get-device-shell-script`, `create-device-shell-script` (**medium**), `update-device-shell-script` (**medium**), `delete-device-shell-script` (**high**), `assign-device-shell-script` (**medium**).
+
+> **Gotcha — assign is REPLACE, not ADD.** `assign-device-shell-script` overwrites all existing assignments with the body's list. To add a group without removing others, first GET the current assignments (via the script's `groupAssignments` navigation property), append your new target, then POST the merged list.
+>
+> **Gotcha — base64 + LF.** `scriptContent` is strict base64 of a script with LF line endings. CRLF will break execution on the Mac. Encode with `Buffer.from(fs.readFileSync(path,'utf8').replace(/\r\n/g,'\n')).toString('base64')`.
+>
+> **Gotcha — beta endpoint.** This family lives in `/beta/deviceManagement/...`. Microsoft documents the beta endpoint as "not intended for production" but the Intune portal itself calls it under the hood. Treat as production-validated; track Microsoft's API changelog for surprises.
+
+---
+
 ## General recommendations
 
 ### Least-privilege preset

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
   "mcpName": "io.github.okapi-ca/ms-365-admin",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -845,6 +845,22 @@
     "llmTip": "Gets device status overview for a configuration profile. Returns aggregate counts: pendingCount, notApplicableCount, successCount, errorCount, failedCount, conflictCount, lastUpdateDateTime."
   },
   {
+    "pathPattern": "/deviceManagement/deviceShellScripts",
+    "method": "get",
+    "toolName": "list-device-shell-scripts",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "llmTip": "Lists Intune macOS Platform Scripts (shell scripts deployed to managed Macs). Each has displayName, description, runAsAccount (system|user), executionFrequency (ISO 8601 duration; PT0S=run once, P1D=daily), retryCount, blockExecutionNotifications, fileName, roleScopeTagIds. scriptContent is NOT returned in list responses — fetch a specific script with $select=scriptContent. Supports $filter, $top, $skip, $select, $expand, $orderby, $count.",
+    "apiVersion": "beta"
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceShellScripts/{deviceShellScript-id}",
+    "method": "get",
+    "toolName": "get-device-shell-script",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "llmTip": "Gets a specific Intune macOS Platform Script by ID. By default scriptContent is NOT returned — pass $select=id,displayName,scriptContent,runAsAccount,executionFrequency,... to fetch the base64-encoded script body. Supports $select and $expand.",
+    "apiVersion": "beta"
+  },
+  {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
     "method": "get",
     "toolName": "list-enrollment-configurations",
@@ -2878,6 +2894,42 @@
     "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Deletes a device configuration profile. Devices assigned to this profile will no longer receive these settings."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceShellScripts",
+    "method": "post",
+    "toolName": "create-device-shell-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Creates a new Intune macOS Platform Script. Body example: {\"@odata.type\":\"#microsoft.graph.deviceShellScript\",\"displayName\":\"Install agent\",\"description\":\"...\",\"scriptContent\":\"<base64-encoded shell script, LF line endings>\",\"runAsAccount\":\"system\",\"executionFrequency\":\"PT0S\",\"retryCount\":3,\"blockExecutionNotifications\":true,\"fileName\":\"install-agent.sh\",\"roleScopeTagIds\":[\"0\"]}. scriptContent MUST be strict base64 (not URL-safe) of a script with LF line endings — CRLF will break execution on Macs. Use runAsAccount=user for scripts that interact with the user session (e.g. osascript touching System Events).",
+    "apiVersion": "beta"
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceShellScripts/{deviceShellScript-id}",
+    "method": "patch",
+    "toolName": "update-device-shell-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates a macOS Platform Script (partial update). Same body shape as create-device-shell-script — only fields included in the body are changed. To update scriptContent, send the full new base64-encoded body. Assigned Macs receive the new version on their next Intune check-in.",
+    "apiVersion": "beta"
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceShellScripts/{deviceShellScript-id}",
+    "method": "delete",
+    "toolName": "delete-device-shell-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Deletes an Intune macOS Platform Script. All assigned Macs immediately stop receiving the script on their next check-in. This does NOT undo what the script already did on devices — it only unassigns. Confirm with the user before calling on a script with active assignments.",
+    "apiVersion": "beta"
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceShellScripts/{deviceShellScript-id}/assign",
+    "method": "post",
+    "toolName": "assign-device-shell-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Assigns a macOS Platform Script to Entra groups. Body: {\"deviceManagementScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"}}]}. IMPORTANT: this endpoint REPLACES all existing assignments — it is not additive. To add a group without removing others, first GET the current assignments, append the new target, then POST the full merged list.",
+    "apiVersion": "beta"
   },
   {
     "pathPattern": "/sites/{site-id}/permissions",

--- a/src/graph-client.ts
+++ b/src/graph-client.ts
@@ -8,6 +8,7 @@ interface GraphRequestOptions {
   body?: string;
   rawResponse?: boolean;
   excludeResponse?: boolean;
+  apiVersion?: 'v1.0' | 'beta';
 }
 
 interface ContentItem {
@@ -48,7 +49,8 @@ class GraphClient {
   private async makeRequest(endpoint: string, options: GraphRequestOptions = {}): Promise<unknown> {
     const accessToken = await this.getAccessToken();
     const cloudEndpoints = getCloudEndpoints(this.secrets.cloudType);
-    const url = `${cloudEndpoints.graphApi}/v1.0${endpoint}`;
+    const apiVersion = options.apiVersion ?? 'v1.0';
+    const url = `${cloudEndpoints.graphApi}/${apiVersion}${endpoint}`;
 
     // SEC: strip query string — can contain PII/UPN/secret IDs via $filter, etc.
     logger.debug(`[GRAPH CLIENT] Final URL: ${url.split('?')[0]}`);

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -23,6 +23,7 @@ interface EndpointConfig {
   contentType?: string;
   acceptType?: string;
   returnDownloadUrl?: boolean;
+  apiVersion?: 'v1.0' | 'beta';
 }
 
 // SEC-A (SEC-001): allowlist for skip-encoded path parameters. The previous
@@ -243,6 +244,10 @@ async function executeGraphTool(
       rawResponse: !!config?.acceptType || !!config?.returnDownloadUrl,
       excludeResponse: !!params.excludeResponse,
     };
+
+    if (config?.apiVersion) {
+      requestOptions.apiVersion = config.apiVersion;
+    }
 
     if (body !== null) {
       requestOptions.body = JSON.stringify(body);


### PR DESCRIPTION
Adds 6 MCP tools for managing macOS Platform Scripts (Intune Shell Scripts) via Microsoft Graph API, plus the supporting infrastructure for **per-endpoint Graph `apiVersion` selection** — needed because `deviceShellScripts` is beta-only.

## Summary

- 6 new tools (`list`/`get`/`create`/`update`/`delete`/`assign`) for `/beta/deviceManagement/deviceShellScripts`
- New per-endpoint `apiVersion` field in `endpoints.json` — opt-in to `/beta/`, `/v1.0/` remains the default
- Generator now downloads both v1.0 and beta OpenAPI specs and merges beta paths + transitively-referenced components into the simplified spec
- Risk levels: medium (create/update/assign), high (delete)
- New Graph permission: `DeviceManagementScripts.ReadWrite.All`

## Motivation

Triggered by a multi-segment macOS wallpaper rollout (LCI Education, May 2026) where the existing `deviceConfigurations` tools handled 6 Configuration Profiles successfully, but the 7 associated Platform Scripts had to be created and assigned by hand in the Intune admin center — `deviceShellScripts` is beta-only and not exposed by most Graph clients.

## Why beta?

Microsoft has documented `deviceShellScripts` as a beta-only endpoint since 2020. The Intune portal itself calls the beta endpoint under the hood, so the "beta = not for production" warning is technically applicable but in practice this is the only way to manage Platform Scripts programmatically.

## Implementation — per-endpoint `apiVersion`

A small but generally-useful primitive: each endpoint can declare which Microsoft Graph version it targets.

```json
{
  "pathPattern": "/deviceManagement/deviceShellScripts",
  "method": "get",
  "toolName": "list-device-shell-scripts",
  "appPermissions": ["DeviceManagementScripts.Read.All"],
  "apiVersion": "beta"
}
```

Without `apiVersion`, endpoints continue to target `/v1.0/` (no existing tools affected).

Plumbing:

- `bin/modules/download-openapi.mjs`: new `downloadGraphBetaOpenAPI` export pulling beta spec from microsoftgraph/msgraph-metadata
- `bin/modules/simplified-openapi.mjs`: `mergeBetaIntoV1` copies beta paths + transitively-referenced components (schemas, parameters, responses, requestBodies); v1.0 wins on name collisions
- `bin/generate-graph-client.mjs`: orchestrates both downloads, passes both file paths to the simplifier
- `src/graph-client.ts`: `GraphRequestOptions.apiVersion` drives URL construction (default v1.0)
- `src/graph-tools.ts`: `EndpointConfig.apiVersion` forwarded from endpoints.json to `graphRequest`

This unlocks the broader Intune Scripts family (`deviceHealthScripts`, `deviceCustomAttributeShellScripts`, `deviceComplianceScripts`, `deviceManagementScripts`) — all beta-only — as trivial follow-ups.

## 6 new tools

| Tool                          | Method | Risk   |
| ----------------------------- | ------ | ------ |
| `list-device-shell-scripts`   | GET    |        |
| `get-device-shell-script`     | GET    |        |
| `create-device-shell-script`  | POST   | medium |
| `update-device-shell-script`  | PATCH  | medium |
| `delete-device-shell-script`  | DELETE | high   |
| `assign-device-shell-script`  | POST   | medium |

Gotchas documented in tool `llmTip`s and in `docs/USE_CASES.md` §16:

- `scriptContent` is strict base64 (not URL-safe) of a script with LF line endings — CRLF will break execution on the Mac
- `runAsAccount=user` required for scripts that touch the user session (`osascript` + System Events)
- `assign-device-shell-script` REPLACES all existing assignments — not additive. To add a group without removing others, GET → append → POST merged
- By default `get-device-shell-script` does NOT return `scriptContent`; pass `$select=id,displayName,scriptContent,...` to fetch it

## Graph permissions required

Operators must consent two new application permissions on the app registration:

- `DeviceManagementScripts.Read.All` (for list/get)
- `DeviceManagementScripts.ReadWrite.All` (for create/update/delete/assign)

(`DeviceManagementConfiguration.ReadWrite.All`, already required for `deviceConfigurations`, is unchanged.)

## Testing

- `npm run verify` passes: 195 tests, lint clean, prettier clean, build OK
- Local sanity: `--list-tools` shows the new GETs, `--list-permissions` includes both new scopes
- Consent of `DeviceManagementScripts.ReadWrite.All` confirmed working in the contributor's tenant at 2026-05-22 13:51 UTC; live smoke test deferred to post-merge deployment cycle

## Backward compatibility

- No breaking changes to existing tools or endpoints
- New `apiVersion` field is optional; absence preserves v1.0 default
- Schema collisions during beta-merge resolve in favor of v1.0
- 195/195 existing tests pass

## Version

`0.6.3` → `0.7.0` (minor, additive).

## Follow-ups (out of scope for this PR)

These beta-only Intune scripts resources follow the exact same pattern and would be ~50-line additions each once this PR merges:

- `deviceHealthScripts` (Intune Remediations)
- `deviceCustomAttributeShellScripts` (macOS Custom Attributes)
- `deviceComplianceScripts` (Custom Compliance Windows)
- `deviceManagementScripts` (Windows PowerShell parity)