### PR TITLE
feat(intune): add assignmentFilters + deviceHealthScripts tools (P1 quick wins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,46 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-05-22
+
+### Added — `assignmentFilters` tools (532 tools)
+
+Five new tools for Intune assignment filters (dynamic membership filters scoping policy/app assignments to a sub-set of an Entra group):
+
+- `list-assignment-filters` — GET `/deviceManagement/assignmentFilters`
+- `get-assignment-filter` — GET `/deviceManagement/assignmentFilters/{id}`
+- `create-assignment-filter` — POST (risk: medium)
+- `update-assignment-filter` — PATCH (risk: medium)
+- `delete-assignment-filter` — DELETE (risk: high)
+
+Filters use a KQL-like rule syntax on device properties (e.g. `(device.osVersion -startsWith "14")`) and are referenced by `deviceConfigurations` / `mobileApps` / `deviceCompliancePolicies` assignments to target a sub-set of a group ("Macs Sonoma only", "iPhones supervised", "Windows 11 23H2+"). Reduces the need to maintain dozens of overlapping Entra groups.
+
+Beta-only endpoint (`/beta/deviceManagement/assignmentFilters`) — leveraging the per-endpoint `apiVersion` infrastructure shipped in 0.7.0.
+
+Permission: `DeviceManagementConfiguration.ReadWrite.All` (already required for `deviceConfigurations`).
+
+### Added — `deviceHealthScripts` tools — Intune Remediations / Proactive Remediations
+
+Six new tools for Intune Remediations (paired detection + remediation PowerShell scripts for Windows 10/11 Azure AD joined devices):
+
+- `list-device-health-scripts` — GET `/deviceManagement/deviceHealthScripts`
+- `get-device-health-script` — GET `/deviceManagement/deviceHealthScripts/{id}`
+- `create-device-health-script` — POST (risk: medium)
+- `update-device-health-script` — PATCH (risk: medium)
+- `delete-device-health-script` — DELETE (risk: high)
+- `assign-device-health-script` — POST `/assign` (risk: medium; REPLACES existing assignments; supports daily/hourly/run-once schedules)
+
+The detect-and-fix model — detection script returns 0 (compliant) or 1 (needs remediation); remediation script only runs when detection returns 1. Examples: verify FileVault is on, verify a service is running, verify CIS hardening, verify an agent is installed. Modern replacement for `deviceShellScripts` for "verify + fix" use cases on Windows.
+
+Beta-only endpoint (`/beta/deviceManagement/deviceHealthScripts`). Both scripts are base64-encoded; updating either re-deploys to all assigned devices on next Intune Management Extension sync (24h cadence by default).
+
+Permission: `DeviceManagementScripts.ReadWrite.All` (already required for `deviceShellScripts` since 0.7.0).
+
+### Notes
+
+- This release amortizes the per-endpoint `apiVersion` infrastructure shipped in 0.7.0 — both new resources are beta-only, but no new infrastructure was needed.
+- 195/195 tests pass, no regressions.
+
 ## [0.7.0] — 2026-05-22
 
 ### Added — `deviceShellScripts` tools for macOS Platform Scripts (521 tools)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 
 ## Features
 
-- **521 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
+- **532 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **assignment filters**, **Remediations**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -23,7 +23,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 
 | Document                                                               | Purpose                                                                     |
 | ---------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| [docs/USE_CASES.md](docs/USE_CASES.md)                                 | 16 typical admin scenarios with sample prompts and tool lists               |
+| [docs/USE_CASES.md](docs/USE_CASES.md)                                 | 18 typical admin scenarios with sample prompts and tool lists               |
 | [docs/playbooks/](docs/playbooks/README.md)                            | End-to-end security incident response playbooks                             |
 | [agent-skills/](agent-skills/README.md)                                | Drop-in skills for LLM agents (Claude Code et al.) with safety patterns     |
 | [docs/APP_REGISTRATION.md](docs/APP_REGISTRATION.md)                   | Step-by-step Azure AD app registration and permission consent               |
@@ -563,6 +563,47 @@ Notes:
 - `runAsAccount=user` is required for scripts that interact with the user session (e.g. `osascript` touching System Events).
 - `assign-device-shell-script` **REPLACES** all existing assignments — it is not additive. To add a group without removing others, first GET the current assignments, append the new target, then POST the full merged list.
 - By default `get-device-shell-script` does **not** return `scriptContent`; pass `$select=id,displayName,scriptContent,...` to fetch the base64 body.
+
+### Intune Remediations / Proactive Remediations (6)
+
+Paired detection + remediation PowerShell scripts for Windows 10/11 Azure AD joined devices. **Targets Graph beta** (`/beta/deviceManagement/deviceHealthScripts`). Requires `DeviceManagementScripts.ReadWrite.All`.
+
+| Tool                          | Method | Risk   |
+| ----------------------------- | ------ | ------ |
+| `list-device-health-scripts`  | GET    |        |
+| `get-device-health-script`    | GET    |        |
+| `create-device-health-script` | POST   | medium |
+| `update-device-health-script` | PATCH  | medium |
+| `delete-device-health-script` | DELETE | high   |
+| `assign-device-health-script` | POST   | medium |
+
+Notes:
+
+- Both `detectionScriptContent` and `remediationScriptContent` are **base64-encoded PowerShell** — UTF-8 encoded scripts before base64.
+- Detection script returns exit code 0 (compliant) or 1 (needs remediation). The remediation script only runs when detection returns 1.
+- `assign-device-health-script` **REPLACES** all existing assignments — schedules can be daily / hourly / run-once. Set `runRemediationScript: false` for detect-only deployments.
+- By default `get-device-health-script` does **not** return the script bodies; pass `$select=id,displayName,detectionScriptContent,remediationScriptContent,...`.
+- Modern replacement for `deviceShellScripts` for Windows "verify + fix" use cases (CIS hardening, agent install verification, service state).
+
+### Assignment filters (5)
+
+Dynamic membership filters that scope policy/app assignments to a sub-set of an Entra group. **Targets Graph beta** (`/beta/deviceManagement/assignmentFilters`). Requires `DeviceManagementConfiguration.ReadWrite.All`.
+
+| Tool                       | Method | Risk   |
+| -------------------------- | ------ | ------ |
+| `list-assignment-filters`  | GET    |        |
+| `get-assignment-filter`    | GET    |        |
+| `create-assignment-filter` | POST   | medium |
+| `update-assignment-filter` | PATCH  | medium |
+| `delete-assignment-filter` | DELETE | high   |
+
+Notes:
+
+- Rule syntax is KQL-like on device properties — example: `(device.osVersion -startsWith "14")` for macOS Sonoma only, `(device.deviceOwnership -eq "Corporate")` for corporate-owned devices.
+- Operators: `-eq`, `-ne`, `-startsWith`, `-contains`, `-in`, `-matches`, joined by `-and` / `-or`.
+- Filters are referenced by `deviceConfigurations` / `mobileApps` / `deviceCompliancePolicies` assignments (not by users — you target the assignment to a group, then add a filter to narrow it).
+- `assignmentFilterManagementType`: `devices` for device-scoped assignments, `apps` for app-scoped (some properties differ).
+- Deleting a filter that is in use will silently fall the dependent assignments back to "all members of the group" — audit assignments before deleting.
 
 ### Enrollment & Autopilot (10)
 

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -338,6 +338,76 @@ node dist/index.js --preset intune --allow-writes --max-risk-level high
 
 ---
 
+## 17. Intune Remediations (Windows detect-and-fix)
+
+**Context.** Deploying paired detection + remediation PowerShell scripts to Windows 10/11 Azure AD joined devices: CIS hardening verification, agent install verification, service state checks, BitLocker / TPM checks, registry hardening. Modern replacement for `deviceManagementScripts` (one-shot Windows PS) when the desired pattern is "verify state, fix if broken".
+
+**Startup command.**
+
+```bash
+node dist/index.js --preset intune --allow-writes --max-risk-level high
+```
+
+**Sample prompt (deploy).**
+
+> "Create a Remediation named `Verify-Zabbix-Agent-Running` (publisher LCI). Detection script in `./detect-zabbix.ps1` returns 0 if service is Running, 1 otherwise. Remediation script in `./remediate-zabbix.ps1` (re)starts and re-enables the service. Both base64-encode before submitting. runAsAccount=system. Assign to `Gr-Sec-AAD-INTUNE-WIN-STAFF` with a daily 03:00 schedule, runRemediationScript=true."
+
+**Sample prompt (audit).**
+
+> "List all Remediations in the tenant. For each, fetch `detectionScriptContent` and `remediationScriptContent`, decode the base64, and flag any with hardcoded credentials, plaintext URLs to S3/blob storage, or `Set-ExecutionPolicy Bypass`."
+
+**Sample prompt (detect-only).**
+
+> "Create a detection-only Remediation named `Verify-FileVault-Enabled` — empty remediation script, runRemediationScript=false in the assignment. Use it as a reporting probe across `Gr-Sec-AAD-INTUNE-MAC-ALL`. Then query `getRemediationSummary` after 48h to see how many devices reported non-compliance."
+
+**Key tools.** `list-device-health-scripts`, `get-device-health-script`, `create-device-health-script` (**medium**), `update-device-health-script` (**medium**), `delete-device-health-script` (**high**), `assign-device-health-script` (**medium**).
+
+> **Gotcha — base64 each side.** `detectionScriptContent` AND `remediationScriptContent` are each strict base64 of UTF-8 PowerShell. Both must be valid even if remediation is a no-op (use a single-line `Exit 0`).
+>
+> **Gotcha — runRemediationScript flag.** Set in the **assignment**, not the script. Same script can be deployed as detect-only to one group and detect-and-remediate to another.
+>
+> **Gotcha — schedule kinds.** `deviceHealthScriptDailySchedule`, `deviceHealthScriptHourlySchedule`, `deviceHealthScriptRunOnceSchedule`. Daily is the default Intune portal experience.
+>
+> **Gotcha — Windows only.** macOS uses `deviceShellScripts` (one-shot, no detect-fix pair). Don't try to deploy a Remediation to a Mac group — Intune will silently ignore it.
+
+---
+
+## 18. Intune assignment filters — scope without group sprawl
+
+**Context.** A policy or app needs to target only a sub-set of a group: "Macs Sonoma+ only", "iPhones supervised only", "Windows 11 23H2+ only", "corporate-owned only". Without filters, you'd create a new Entra group for every variant, leading to dozens of overlapping memberships and sync lag from Aquera/Entra. Filters let one group + one filter rule cover the same scope, evaluated at assignment time by Intune.
+
+**Startup command.**
+
+```bash
+node dist/index.js --preset intune --allow-writes --max-risk-level medium
+```
+
+> Deleting a filter currently referenced by an assignment is **high risk** (silently broadens the assignment to "all members") — keep that out of routine runs.
+
+**Sample prompt (create + use).**
+
+> "Create an assignment filter named `macOS-Sonoma-Plus` with platform=macOS and rule `(device.osVersion -startsWith \"14\") -or (device.osVersion -startsWith \"15\")`, assignmentFilterManagementType=devices. Then update the configuration profile `Wallpaper-Staff-FR` to add this filter to its assignment to `Gr-Sec-AAD-INTUNE-MAC-STAFF-FR`."
+
+**Sample prompt (audit).**
+
+> "List all assignment filters. For each, list the policies/apps that currently reference it (search across deviceConfigurations, configurationPolicies, mobileApps assignments). Flag any filter with zero references — those are dead and safe to delete."
+
+**Sample prompt (refactor).**
+
+> "We have 8 groups named `Gr-AAD-MAC-Sonoma`, `Gr-AAD-MAC-Sequoia`, etc. — one per macOS version. Audit which Intune policies use them, then propose a refactor: replace each version-specific group with the parent `Gr-AAD-MAC-ALL` + an assignment filter using `device.osVersion`. Don't apply changes — just produce a migration plan."
+
+**Key tools.** `list-assignment-filters`, `get-assignment-filter`, `create-assignment-filter` (**medium**), `update-assignment-filter` (**medium**), `delete-assignment-filter` (**high**).
+
+> **Gotcha — rule syntax.** KQL-like, but quoting differs. Single quotes inside the rule must be escaped or use `\"`. Test rules in the Intune portal "Preview filter" UI before automating large rollouts.
+>
+> **Gotcha — silent broadening on delete.** Deleting a filter referenced by an assignment doesn't reject the delete or update the assignment — it just removes the filter, so the assignment now targets the whole group. Audit references first.
+>
+> **Gotcha — assignmentFilterManagementType is fixed.** Once created with `devices` or `apps`, you can't switch. Pick based on what the filter will scope (device-scoped policies vs. app-scoped policies have slightly different property sets).
+>
+> **Gotcha — beta endpoint.** Like other Intune resources, lives in `/beta/`. See §16 disclaimer.
+
+---
+
 ## General recommendations
 
 ### Least-privilege preset

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
   "mcpName": "io.github.okapi-ca/ms-365-admin",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -861,6 +861,38 @@
     "apiVersion": "beta"
   },
   {
+    "pathPattern": "/deviceManagement/assignmentFilters",
+    "method": "get",
+    "toolName": "list-assignment-filters",
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Lists Intune assignment filters (dynamic membership filters applied to policy/app assignments). Each filter has displayName, description, platform (android/iOS/macOS/windows10AndLater/etc.), rule (KQL-like expression on device properties: e.g. \"device.osVersion -startsWith \\\"14\\\"\"), assignmentFilterManagementType (devices | apps), and creationSource. Filters scope assignments to a sub-set of a group (e.g. \"only Macs on Sonoma\", \"only iPhones supervised\"). Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
+  },
+  {
+    "pathPattern": "/deviceManagement/assignmentFilters/{deviceAndAppManagementAssignmentFilter-id}",
+    "method": "get",
+    "toolName": "get-assignment-filter",
+    "appPermissions": ["DeviceManagementConfiguration.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Gets a specific Intune assignment filter by ID. Returns full rule expression and metadata. Supports $select and $expand."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceHealthScripts",
+    "method": "get",
+    "toolName": "list-device-health-scripts",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Lists Intune Remediations (Proactive Remediations) — paired detection + remediation PowerShell scripts for Windows 10/11 Azure AD joined devices. Each has displayName, description, publisher, version, runAsAccount (system|user), enforceSignatureCheck, runAs32Bit, roleScopeTagIds, isGlobalScript (Microsoft proprietary read-only), deviceHealthScriptType (deviceHealthScript | managedInstallerScript). detectionScriptContent and remediationScriptContent NOT returned in list responses — fetch a specific script with $select=detectionScriptContent,remediationScriptContent. Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceHealthScripts/{deviceHealthScript-id}",
+    "method": "get",
+    "toolName": "get-device-health-script",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Gets a specific Intune Remediation (Proactive Remediation) by ID. By default detectionScriptContent and remediationScriptContent are NOT returned — pass $select=id,displayName,detectionScriptContent,remediationScriptContent,runAsAccount,... to fetch the base64-encoded PowerShell bodies. Supports $select and $expand."
+  },
+  {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
     "method": "get",
     "toolName": "list-enrollment-configurations",
@@ -2930,6 +2962,69 @@
     "riskLevel": "medium",
     "llmTip": "Assigns a macOS Platform Script to Entra groups. Body: {\"deviceManagementScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"}}]}. IMPORTANT: this endpoint REPLACES all existing assignments — it is not additive. To add a group without removing others, first GET the current assignments, append the new target, then POST the full merged list.",
     "apiVersion": "beta"
+  },
+  {
+    "pathPattern": "/deviceManagement/assignmentFilters",
+    "method": "post",
+    "toolName": "create-assignment-filter",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Creates a new Intune assignment filter. Body example: {\"@odata.type\":\"#microsoft.graph.deviceAndAppManagementAssignmentFilter\",\"displayName\":\"Macs Sonoma only\",\"description\":\"...\",\"platform\":\"macOS\",\"rule\":\"(device.osVersion -startsWith \\\"14\\\")\",\"assignmentFilterManagementType\":\"devices\",\"roleScopeTags\":[\"0\"]}. Rule syntax: KQL-like, operators -eq/-ne/-startsWith/-contains/-in/-matches, joined by -and/-or. Supported device properties depend on platform (see Intune docs). assignmentFilterManagementType: 'devices' for device-scoped assignments, 'apps' for app-scoped."
+  },
+  {
+    "pathPattern": "/deviceManagement/assignmentFilters/{deviceAndAppManagementAssignmentFilter-id}",
+    "method": "patch",
+    "toolName": "update-assignment-filter",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Updates an Intune assignment filter (partial update). Same body shape as create-assignment-filter — only fields included in the body are changed. Changing 'rule' may cause devices currently in-scope to fall out (and vice versa) on the next Intune evaluation cycle."
+  },
+  {
+    "pathPattern": "/deviceManagement/assignmentFilters/{deviceAndAppManagementAssignmentFilter-id}",
+    "method": "delete",
+    "toolName": "delete-assignment-filter",
+    "appPermissions": ["DeviceManagementConfiguration.ReadWrite.All"],
+    "riskLevel": "high",
+    "apiVersion": "beta",
+    "llmTip": "Deletes an Intune assignment filter. ANY policy/app assignment currently referencing this filter will fall back to the unfiltered group (i.e. ALL members of the targeted group will receive the assignment, not just the filtered subset). Check with `getAssignmentFiltersStatusDetails` or audit assignments before deleting."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceHealthScripts",
+    "method": "post",
+    "toolName": "create-device-health-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Creates a new Intune Remediation (paired detection + remediation PowerShell scripts) for Windows. Body example: {\"@odata.type\":\"#microsoft.graph.deviceHealthScript\",\"displayName\":\"Verify FileVault\",\"description\":\"...\",\"publisher\":\"LCI\",\"detectionScriptContent\":\"<base64 of PS script>\",\"remediationScriptContent\":\"<base64 of PS script>\",\"runAsAccount\":\"system\",\"enforceSignatureCheck\":false,\"runAs32Bit\":false,\"roleScopeTagIds\":[\"0\"]}. BOTH scripts are required, both as base64 PowerShell. Detection script returns exit code 0 (compliant) or 1 (needs remediation). Remediation script is only run when detection returns 1."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceHealthScripts/{deviceHealthScript-id}",
+    "method": "patch",
+    "toolName": "update-device-health-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Updates an Intune Remediation (partial update). Same body shape as create-device-health-script. To update only one of the two scripts, send only the relevant *ScriptContent field (base64). Assigned devices receive the updated scripts on their next Intune Management Extension sync (every 24h, or forced via portal)."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceHealthScripts/{deviceHealthScript-id}",
+    "method": "delete",
+    "toolName": "delete-device-health-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "high",
+    "apiVersion": "beta",
+    "llmTip": "Deletes an Intune Remediation. All assigned devices immediately stop receiving detection runs on their next sync. This does NOT undo previous remediations that already ran on devices. Confirm with the user before calling on a script with active assignments."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceHealthScripts/{deviceHealthScript-id}/assign",
+    "method": "post",
+    "toolName": "assign-device-health-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Assigns an Intune Remediation to Entra groups with a schedule. Body: {\"deviceHealthScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"},\"runRemediationScript\":true,\"runSchedule\":{\"@odata.type\":\"#microsoft.graph.deviceHealthScriptDailySchedule\",\"interval\":1,\"time\":\"03:00:00\",\"useUtc\":false}}]}. IMPORTANT: this endpoint REPLACES all existing assignments — not additive. Schedule options: deviceHealthScriptDailySchedule, deviceHealthScriptHourlySchedule, deviceHealthScriptRunOnceSchedule. Set runRemediationScript=false to make it a detect-only deployment."
   },
   {
     "pathPattern": "/sites/{site-id}/permissions",


### PR DESCRIPTION
Two new Intune resource families, both beta-only, leveraging the per-endpoint `apiVersion` infrastructure shipped in 0.7.0 (PR #112) — **zero new infrastructure** needed.

## Summary

- **5 new tools for `assignmentFilters`** (dynamic membership filters)
- **6 new tools for `deviceHealthScripts`** (Intune Remediations / Proactive Remediations)
- Risk levels: medium (create/update/assign), high (delete)
- No new Graph permissions required — both reuse permissions already declared for existing tools (`DeviceManagementConfiguration.ReadWrite.All` and `DeviceManagementScripts.ReadWrite.All`)

## Motivation

These two resources are the highest-ROI follow-ups to 0.7.0 (`deviceShellScripts`):

- `assignmentFilters` replaces the antipattern of maintaining dozens of overlapping Entra groups (one per OS version / device variant). One group + one filter rule covers the same scope, evaluated at assignment time by Intune.
- `deviceHealthScripts` is the modern detect-and-fix pattern for Windows — much better than the one-shot `deviceManagementScripts` for any "verify state, fix if broken" use case (CIS hardening, agent verification, service state checks).

Both are beta-only Microsoft Graph resources; both are called by the Intune portal under the hood. Treat as production-validated, just like `deviceShellScripts`.

## Implementation

Same pattern as 0.7.0 `deviceShellScripts`: each new entry in `endpoints.json` declares `apiVersion: "beta"`, and the existing infrastructure handles spec merging, URL routing, and per-endpoint API version selection. The diff is literally just JSON entries — no code changes.

## 11 new tools

### `assignmentFilters` (5)

| Tool                          | Method | Risk   |
| ----------------------------- | ------ | ------ |
| `list-assignment-filters`     | GET    |        |
| `get-assignment-filter`       | GET    |        |
| `create-assignment-filter`    | POST   | medium |
| `update-assignment-filter`    | PATCH  | medium |
| `delete-assignment-filter`    | DELETE | high   |

Filter rules use a KQL-like syntax on device properties (e.g. `(device.osVersion -startsWith "14")` for macOS Sonoma only). `assignmentFilterManagementType` is `devices` or `apps` (fixed at creation). Filters are referenced by `deviceConfigurations` / `mobileApps` / `deviceCompliancePolicies` assignments.

**Gotchas** (documented in tool `llmTip`s and in `docs/USE_CASES.md` §18):
- Rule syntax is KQL-like — operators `-eq`, `-ne`, `-startsWith`, `-contains`, `-in`, `-matches`, joined by `-and`/`-or`
- `assignmentFilterManagementType` is fixed at creation — pick `devices` vs. `apps` upfront
- Deleting a filter currently referenced by an assignment silently broadens the assignment to "all members of the group" — audit references first

### `deviceHealthScripts` (6)

| Tool                          | Method | Risk   |
| ----------------------------- | ------ | ------ |
| `list-device-health-scripts`  | GET    |        |
| `get-device-health-script`    | GET    |        |
| `create-device-health-script` | POST   | medium |
| `update-device-health-script` | PATCH  | medium |
| `delete-device-health-script` | DELETE | high   |
| `assign-device-health-script` | POST   | medium |

Paired detection + remediation PowerShell scripts. Detection script returns 0 (compliant) or 1 (needs remediation); remediation script only runs when detection returns 1. Windows 10/11 Azure AD joined devices only.

**Gotchas** (documented in tool `llmTip`s and in `docs/USE_CASES.md` §17):
- Both `detectionScriptContent` and `remediationScriptContent` are strict base64 of UTF-8 PowerShell
- `runRemediationScript` flag is set in the **assignment**, not the script — same script can be detect-only for one group and detect+remediate for another
- `assign-device-health-script` REPLACES all existing assignments — not additive
- Schedule kinds: `deviceHealthScriptDailySchedule`, `deviceHealthScriptHourlySchedule`, `deviceHealthScriptRunOnceSchedule`
- Windows-only — Intune will silently ignore deployments to Mac groups
- By default `get-device-health-script` does NOT return the script bodies; pass `$select=id,displayName,detectionScriptContent,remediationScriptContent,...`

## Graph permissions

No new permissions. Both new tools reuse scopes already declared:

- `DeviceManagementConfiguration.ReadWrite.All` — already required for `deviceConfigurations`
- `DeviceManagementScripts.ReadWrite.All` — required since 0.7.0 for `deviceShellScripts`

## Testing

- `npm run verify` passes: 195 tests, lint clean, prettier clean, build OK
- Local sanity: all 11 new tool aliases present in `src/generated/client.ts`
- No tenant-side validation in this PR — will happen post-merge in deployment cycle

## Backward compatibility

- No breaking changes
- All existing tools unaffected
- 195/195 existing tests pass

## Version

`0.7.0` → `0.8.0` (minor, additive).

## Follow-ups (out of scope)

Other P2 beta-only resources that would follow the same pattern:

- `deviceCustomAttributeShellScripts` (macOS custom attributes) — same shape as `deviceShellScripts`
- `deviceManagementScripts` (Windows one-shot PowerShell parity) — same shape
- `deviceComplianceScripts` (custom compliance Windows) — same shape

Tracked separately on the contributor's side.