### PR TITLE
feat(intune): add 3 P2 beta-only Intune script families (18 tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-05-25
+
+### Added — P2 beta-only Intune script families (550 tools)
+
+Eighteen new tools across three Intune script families, completing the Graph beta scripts coverage initiated in 0.7.0 (`deviceShellScripts`) and 0.8.0 (`deviceHealthScripts`). All three families reuse the per-endpoint `apiVersion: "beta"` infrastructure from 0.7.0 — pure `endpoints.json` additions, no code changes.
+
+**`deviceCustomAttributeShellScripts` (macOS) — 6 tools**
+
+Shell scripts whose STDOUT becomes a named custom attribute on the device record. Useful for surfacing inventory data (FileVault, Gatekeeper, encryption flags) and driving dynamic group filters. `customAttributeType` controls parse mode: `integer`, `string`, `dateTime`. Changing the attribute key or type after deployment breaks downstream dynamic groups — audit references first.
+
+**`deviceManagementScripts` (Windows PowerShell) — 6 tools**
+
+One-shot PowerShell scripts for Windows 10/11. Runs once per device per assignment, retries on failure. Distinct from `deviceHealthScripts` (Remediations) — no detection/remediation pairing, no scheduling, does NOT re-run after successful execution. For detect-and-fix use `deviceHealthScripts` instead.
+
+**`deviceComplianceScripts` (Windows custom compliance) — 6 tools**
+
+PowerShell scripts that emit a JSON object on STDOUT evaluated against rules declared on an associated `windows10CustomComplianceConfiguration` policy. For organization-specific compliance signals beyond built-in checks (BitLocker, Defender, firewall). The script alone has no compliance effect — must be paired with a custom compliance policy that defines matching rules.
+
+**No new Graph permissions required** — `DeviceManagementScripts.ReadWrite.All` (declared since 0.7.0) explicitly covers all five Intune script families per Microsoft's permission reference: `deviceComplianceScripts`, `deviceManagementScripts`, `deviceShellScripts`, `deviceCustomAttributeShellScripts`, `deviceHealthScripts`.
+
+Completes the Intune scripts family coverage. Three follow-ups from PR #113 ("P1 quick wins") are now closed.
+
 ## [0.8.0] — 2026-05-22
 
 ### Added — `assignmentFilters` tools (532 tools)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 
 ## Features
 
-- **532 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **assignment filters**, **Remediations**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
+- **550 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **macOS custom attribute scripts**, **assignment filters**, **Remediations**, **Windows PowerShell scripts**, **custom compliance scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -604,6 +604,69 @@ Notes:
 - Filters are referenced by `deviceConfigurations` / `mobileApps` / `deviceCompliancePolicies` assignments (not by users — you target the assignment to a group, then add a filter to narrow it).
 - `assignmentFilterManagementType`: `devices` for device-scoped assignments, `apps` for app-scoped (some properties differ).
 - Deleting a filter that is in use will silently fall the dependent assignments back to "all members of the group" — audit assignments before deleting.
+
+### macOS custom attribute shell scripts (6)
+
+Intune shell scripts whose STDOUT is stored as a named custom attribute on each device — useful for surfacing inventory data (FileVault, Gatekeeper, encryption flags, custom markers) and driving dynamic group filters. **Targets Graph beta** (`/beta/deviceManagement/deviceCustomAttributeShellScripts`). Requires `DeviceManagementScripts.ReadWrite.All`.
+
+| Tool                                          | Method | Risk   |
+| --------------------------------------------- | ------ | ------ |
+| `list-device-custom-attribute-shell-scripts`  | GET    |        |
+| `get-device-custom-attribute-shell-script`    | GET    |        |
+| `create-device-custom-attribute-shell-script` | POST   | medium |
+| `update-device-custom-attribute-shell-script` | PATCH  | medium |
+| `delete-device-custom-attribute-shell-script` | DELETE | high   |
+| `assign-device-custom-attribute-shell-script` | POST   | medium |
+
+Notes:
+
+- The script's STDOUT becomes the value stored under `customAttributeName` on each device.
+- `customAttributeType` controls how Intune parses STDOUT: `integer`, `string`, or `dateTime` (ISO 8601).
+- `scriptContent` is strict base64 of a script with LF line endings — CRLF breaks execution on Macs.
+- Changing `customAttributeName` or `customAttributeType` after deployment breaks downstream dynamic groups and assignment filters that reference the previous key — audit references first.
+- Deleting a script does NOT clear previously-collected attribute values from device records.
+
+### Windows PowerShell scripts (deviceManagementScripts) (6)
+
+One-shot PowerShell scripts deployed to managed Windows 10/11 devices. Runs once per device per assignment, retries on failure. For detect-and-fix patterns use `deviceHealthScripts` (Remediations) instead. **Targets Graph beta** (`/beta/deviceManagement/deviceManagementScripts`). Requires `DeviceManagementScripts.ReadWrite.All`.
+
+| Tool                              | Method | Risk   |
+| --------------------------------- | ------ | ------ |
+| `list-device-management-scripts`  | GET    |        |
+| `get-device-management-script`    | GET    |        |
+| `create-device-management-script` | POST   | medium |
+| `update-device-management-script` | PATCH  | medium |
+| `delete-device-management-script` | DELETE | high   |
+| `assign-device-management-script` | POST   | medium |
+
+Notes:
+
+- `scriptContent` is base64-encoded UTF-8 PowerShell.
+- Runs ONCE per device on the next Intune Management Extension sync after assignment — does NOT re-run after successful execution (use `deviceHealthScripts` for repeating patterns).
+- Updating `scriptContent` does NOT re-run on devices that already succeeded; delete + recreate to force re-execution.
+- `enforceSignatureCheck=true` requires code-signed scripts (recommended for prod).
+- `runAs32Bit=true` forces 32-bit PowerShell on 64-bit Windows (rarely needed).
+
+### Windows custom compliance scripts (deviceComplianceScripts) (6)
+
+PowerShell scripts that emit a JSON object on STDOUT evaluated against rules declared on an associated `windows10CustomComplianceConfiguration` policy — for organization-specific compliance signals beyond the built-in BitLocker / Defender / firewall checks. **Targets Graph beta** (`/beta/deviceManagement/deviceComplianceScripts`). Requires `DeviceManagementScripts.ReadWrite.All`.
+
+| Tool                              | Method | Risk   |
+| --------------------------------- | ------ | ------ |
+| `list-device-compliance-scripts`  | GET    |        |
+| `get-device-compliance-script`    | GET    |        |
+| `create-device-compliance-script` | POST   | medium |
+| `update-device-compliance-script` | PATCH  | medium |
+| `delete-device-compliance-script` | DELETE | high   |
+| `assign-device-compliance-script` | POST   | medium |
+
+Notes:
+
+- `detectionScriptContent` must emit a JSON object on STDOUT (e.g. `ConvertTo-Json -Compress @{BitLockerEnabled=$true;TpmReady=$true}`).
+- The script alone has no compliance effect — you must also author a `windows10CustomComplianceConfiguration` policy with matching rules.
+- Changing the JSON keys without updating the linked policy's rules silently breaks compliance evaluation.
+- Deleting a script in use causes referencing compliance policies to fail evaluation on next device check-in.
+- Assignment shape reuses `deviceHealthScriptAssignment` (set `runRemediationScript: false` since compliance scripts have no remediation pairing).
 
 ### Enrollment & Autopilot (10)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
   "mcpName": "io.github.okapi-ca/ms-365-admin",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -909,6 +909,22 @@
     "llmTip": "Gets a specific Intune macOS custom attribute shell script by ID. By default scriptContent is NOT returned — pass $select=id,displayName,scriptContent,customAttributeName,customAttributeType,runAsAccount,... to fetch the base64-encoded script body. Supports $select and $expand."
   },
   {
+    "pathPattern": "/deviceManagement/deviceManagementScripts",
+    "method": "get",
+    "toolName": "list-device-management-scripts",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Lists Intune Windows PowerShell scripts (deviceManagementScripts) — one-shot PowerShell scripts deployed to managed Windows 10/11 devices. Distinct from deviceHealthScripts: no detection/remediation pairing, no scheduling — runs once per device per assignment, retries on failure up to retryCount. Each has displayName, description, runAsAccount (system | user), enforceSignatureCheck, runAs32Bit (force 32-bit PS even on 64-bit OS), fileName, roleScopeTagIds. scriptContent is NOT returned in list responses — fetch a specific script with $select=scriptContent. Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceManagementScripts/{deviceManagementScript-id}",
+    "method": "get",
+    "toolName": "get-device-management-script",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Gets a specific Intune Windows PowerShell script by ID. By default scriptContent is NOT returned — pass $select=id,displayName,scriptContent,runAsAccount,enforceSignatureCheck,runAs32Bit,... to fetch the base64-encoded PowerShell body. Supports $select and $expand."
+  },
+  {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
     "method": "get",
     "toolName": "list-enrollment-configurations",
@@ -3077,6 +3093,42 @@
     "riskLevel": "medium",
     "apiVersion": "beta",
     "llmTip": "Assigns a macOS custom attribute shell script to Entra groups. Body: {\"deviceManagementScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"}}]}. IMPORTANT: this endpoint REPLACES all existing assignments — it is not additive. To add a group without removing others, first GET the current assignments, append the new target, then POST the full merged list."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceManagementScripts",
+    "method": "post",
+    "toolName": "create-device-management-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Creates a new Intune Windows PowerShell script (one-shot). Body example: {\"@odata.type\":\"#microsoft.graph.deviceManagementScript\",\"displayName\":\"Install agent\",\"description\":\"Install internal monitoring agent\",\"scriptContent\":\"<base64-encoded PowerShell script>\",\"runAsAccount\":\"system\",\"enforceSignatureCheck\":false,\"runAs32Bit\":false,\"fileName\":\"install-agent.ps1\",\"roleScopeTagIds\":[\"0\"]}. scriptContent MUST be base64-encoded UTF-8 PowerShell. Runs ONCE per device on next IME sync after assignment; retries on failure (max 3 attempts). For detect-and-fix patterns use deviceHealthScripts instead. Set enforceSignatureCheck=true to require code-signed scripts (recommended for prod). runAs32Bit=true forces 32-bit PowerShell on 64-bit Windows (rarely needed)."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceManagementScripts/{deviceManagementScript-id}",
+    "method": "patch",
+    "toolName": "update-device-management-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Updates an Intune Windows PowerShell script (partial update). Same body shape as create-device-management-script — only fields included in the body are changed. Updating scriptContent does NOT re-run the script on devices that have already executed it successfully — Intune tracks per-device success state. To force re-execution, delete and recreate the script (or use deviceHealthScripts for re-runnable patterns)."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceManagementScripts/{deviceManagementScript-id}",
+    "method": "delete",
+    "toolName": "delete-device-management-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "high",
+    "apiVersion": "beta",
+    "llmTip": "Deletes an Intune Windows PowerShell script. All assigned devices immediately stop receiving the script on their next IME sync. This does NOT undo what the script already did on devices — it only removes future execution. Confirm with the user before calling on a script with active assignments."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceManagementScripts/{deviceManagementScript-id}/assign",
+    "method": "post",
+    "toolName": "assign-device-management-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Assigns a Windows PowerShell script to Entra groups. Body: {\"deviceManagementScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"}}]}. IMPORTANT: this endpoint REPLACES all existing assignments — it is not additive. To add a group without removing others, first GET the current assignments, append the new target, then POST the full merged list. Adding a new group triggers script execution on devices that haven't yet run it (existing successful devices are not re-run)."
   },
   {
     "pathPattern": "/sites/{site-id}/permissions",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -893,6 +893,22 @@
     "llmTip": "Gets a specific Intune Remediation (Proactive Remediation) by ID. By default detectionScriptContent and remediationScriptContent are NOT returned — pass $select=id,displayName,detectionScriptContent,remediationScriptContent,runAsAccount,... to fetch the base64-encoded PowerShell bodies. Supports $select and $expand."
   },
   {
+    "pathPattern": "/deviceManagement/deviceCustomAttributeShellScripts",
+    "method": "get",
+    "toolName": "list-device-custom-attribute-shell-scripts",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Lists Intune macOS custom attribute shell scripts. Each script's STDOUT is stored as a named custom attribute on the device record — useful for surfacing inventory data (FileVault state, Gatekeeper, encryption flags, custom markers) and driving dynamic group filters. Each has displayName, description, customAttributeName (the attribute key), customAttributeType (integer | string | dateTime), runAsAccount (system | user), fileName, roleScopeTagIds. scriptContent is NOT returned in list responses — fetch a specific script with $select=scriptContent. Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCustomAttributeShellScripts/{deviceCustomAttributeShellScript-id}",
+    "method": "get",
+    "toolName": "get-device-custom-attribute-shell-script",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Gets a specific Intune macOS custom attribute shell script by ID. By default scriptContent is NOT returned — pass $select=id,displayName,scriptContent,customAttributeName,customAttributeType,runAsAccount,... to fetch the base64-encoded script body. Supports $select and $expand."
+  },
+  {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
     "method": "get",
     "toolName": "list-enrollment-configurations",
@@ -3025,6 +3041,42 @@
     "riskLevel": "medium",
     "apiVersion": "beta",
     "llmTip": "Assigns an Intune Remediation to Entra groups with a schedule. Body: {\"deviceHealthScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"},\"runRemediationScript\":true,\"runSchedule\":{\"@odata.type\":\"#microsoft.graph.deviceHealthScriptDailySchedule\",\"interval\":1,\"time\":\"03:00:00\",\"useUtc\":false}}]}. IMPORTANT: this endpoint REPLACES all existing assignments — not additive. Schedule options: deviceHealthScriptDailySchedule, deviceHealthScriptHourlySchedule, deviceHealthScriptRunOnceSchedule. Set runRemediationScript=false to make it a detect-only deployment."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCustomAttributeShellScripts",
+    "method": "post",
+    "toolName": "create-device-custom-attribute-shell-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Creates a new Intune macOS custom attribute shell script. Body example: {\"@odata.type\":\"#microsoft.graph.deviceCustomAttributeShellScript\",\"displayName\":\"FileVault status\",\"description\":\"Reports FileVault enabled state\",\"customAttributeName\":\"filevault_enabled\",\"customAttributeType\":\"string\",\"scriptContent\":\"<base64-encoded shell script, LF line endings>\",\"runAsAccount\":\"system\",\"fileName\":\"filevault-status.sh\",\"roleScopeTagIds\":[\"0\"]}. scriptContent MUST be strict base64 of a script with LF line endings — CRLF will break execution on Macs. The script's STDOUT becomes the value stored under customAttributeName on each device. customAttributeType controls how Intune parses STDOUT: 'integer' (parsed as int), 'string' (raw), or 'dateTime' (ISO 8601). Use runAsAccount=user only for scripts that need to read user-context data."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCustomAttributeShellScripts/{deviceCustomAttributeShellScript-id}",
+    "method": "patch",
+    "toolName": "update-device-custom-attribute-shell-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Updates an Intune macOS custom attribute shell script (partial update). Same body shape as create-device-custom-attribute-shell-script — only fields included in the body are changed. WARNING: changing customAttributeName or customAttributeType after deployment breaks downstream dynamic groups and assignment filters that reference the previous attribute key — audit references before updating those fields. To update only scriptContent, send just that field as base64."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCustomAttributeShellScripts/{deviceCustomAttributeShellScript-id}",
+    "method": "delete",
+    "toolName": "delete-device-custom-attribute-shell-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "high",
+    "apiVersion": "beta",
+    "llmTip": "Deletes an Intune macOS custom attribute shell script. All assigned Macs immediately stop collecting the attribute on their next check-in. Previously-collected attribute values on devices are NOT automatically cleared from the device record. Any dynamic groups or assignment filters referencing this customAttributeName will return empty for new evaluations. Confirm with the user before calling on a script with active assignments or downstream references."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceCustomAttributeShellScripts/{deviceCustomAttributeShellScript-id}/assign",
+    "method": "post",
+    "toolName": "assign-device-custom-attribute-shell-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Assigns a macOS custom attribute shell script to Entra groups. Body: {\"deviceManagementScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"}}]}. IMPORTANT: this endpoint REPLACES all existing assignments — it is not additive. To add a group without removing others, first GET the current assignments, append the new target, then POST the full merged list."
   },
   {
     "pathPattern": "/sites/{site-id}/permissions",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -925,6 +925,22 @@
     "llmTip": "Gets a specific Intune Windows PowerShell script by ID. By default scriptContent is NOT returned — pass $select=id,displayName,scriptContent,runAsAccount,enforceSignatureCheck,runAs32Bit,... to fetch the base64-encoded PowerShell body. Supports $select and $expand."
   },
   {
+    "pathPattern": "/deviceManagement/deviceComplianceScripts",
+    "method": "get",
+    "toolName": "list-device-compliance-scripts",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Lists Intune custom compliance PowerShell scripts (deviceComplianceScripts) for Windows 10/11. Each script emits a JSON object on STDOUT (e.g. {\"BitLockerEnabled\":true,\"TpmReady\":true}) which is then evaluated against rules declared on an associated compliance policy with @odata.type=#microsoft.graph.windows10CustomComplianceConfiguration. Each has displayName, description, publisher, version, runAsAccount (system | user), enforceSignatureCheck, runAs32Bit, roleScopeTagIds. detectionScriptContent is NOT returned in list responses. Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceComplianceScripts/{deviceComplianceScript-id}",
+    "method": "get",
+    "toolName": "get-device-compliance-script",
+    "appPermissions": ["DeviceManagementScripts.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Gets a specific Intune custom compliance script by ID. By default detectionScriptContent is NOT returned — pass $select=id,displayName,detectionScriptContent,runAsAccount,enforceSignatureCheck,runAs32Bit,... to fetch the base64-encoded PowerShell body. Supports $select and $expand."
+  },
+  {
     "pathPattern": "/deviceManagement/deviceEnrollmentConfigurations",
     "method": "get",
     "toolName": "list-enrollment-configurations",
@@ -3129,6 +3145,42 @@
     "riskLevel": "medium",
     "apiVersion": "beta",
     "llmTip": "Assigns a Windows PowerShell script to Entra groups. Body: {\"deviceManagementScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"}}]}. IMPORTANT: this endpoint REPLACES all existing assignments — it is not additive. To add a group without removing others, first GET the current assignments, append the new target, then POST the full merged list. Adding a new group triggers script execution on devices that haven't yet run it (existing successful devices are not re-run)."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceComplianceScripts",
+    "method": "post",
+    "toolName": "create-device-compliance-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Creates a new Intune custom compliance script for Windows 10/11. Body example: {\"@odata.type\":\"#microsoft.graph.deviceComplianceScript\",\"displayName\":\"Verify BitLocker + TPM\",\"description\":\"Custom compliance: BitLocker + TPM ready\",\"publisher\":\"LCI\",\"detectionScriptContent\":\"<base64 of PS script>\",\"runAsAccount\":\"system\",\"enforceSignatureCheck\":false,\"runAs32Bit\":false,\"roleScopeTagIds\":[\"0\"]}. The PS script MUST emit a JSON object on STDOUT (e.g. ConvertTo-Json -Compress @{BitLockerEnabled=$true;TpmReady=$true}). The JSON keys are then evaluated against rules in an associated #microsoft.graph.windows10CustomComplianceConfiguration policy (separate API). The script alone has no compliance effect — you also need to author the compliance policy with matching detection settings."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceComplianceScripts/{deviceComplianceScript-id}",
+    "method": "patch",
+    "toolName": "update-device-compliance-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Updates an Intune custom compliance script (partial update). Same body shape as create-device-compliance-script. Changing the JSON keys emitted by detectionScriptContent without updating the associated compliance policy's rules will silently break compliance evaluation — audit the linked windows10CustomComplianceConfiguration policy before changing the script's output shape. Bump 'version' field to invalidate device caches."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceComplianceScripts/{deviceComplianceScript-id}",
+    "method": "delete",
+    "toolName": "delete-device-compliance-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "high",
+    "apiVersion": "beta",
+    "llmTip": "Deletes an Intune custom compliance script. ANY windows10CustomComplianceConfiguration compliance policy referencing this script will fail evaluation on next device check-in (devices will be marked non-compliant or revert to the unknown state, depending on the policy's settings). Audit referencing compliance policies before deleting."
+  },
+  {
+    "pathPattern": "/deviceManagement/deviceComplianceScripts/{deviceComplianceScript-id}/assign",
+    "method": "post",
+    "toolName": "assign-device-compliance-script",
+    "appPermissions": ["DeviceManagementScripts.ReadWrite.All"],
+    "riskLevel": "medium",
+    "apiVersion": "beta",
+    "llmTip": "Assigns a custom compliance script to Entra groups. Body: {\"deviceHealthScriptAssignments\":[{\"target\":{\"@odata.type\":\"#microsoft.graph.groupAssignmentTarget\",\"groupId\":\"<entra-group-uuid>\"},\"runRemediationScript\":false,\"runSchedule\":{\"@odata.type\":\"#microsoft.graph.deviceHealthScriptDailySchedule\",\"interval\":1,\"time\":\"03:00:00\",\"useUtc\":false}}]}. IMPORTANT: REPLACES existing assignments — not additive. Note: deviceComplianceScripts reuses the deviceHealthScriptAssignment shape (runRemediationScript should be false since compliance scripts have no remediation pairing). The schedule controls how often Windows re-evaluates the script's JSON output against the linked compliance policy."
   },
   {
     "pathPattern": "/sites/{site-id}/permissions",


### PR DESCRIPTION
Closes the three follow-ups from PR #113 ("P1 quick wins"): `deviceCustomAttributeShellScripts`, `deviceManagementScripts`, `deviceComplianceScripts`. Completes the Intune scripts family coverage (5 of 5: shell / health / custom-attribute / management / compliance).

## Summary

- **18 new tools** across 3 Intune resource families, all beta-only Graph endpoints
- **Zero new infrastructure** — reuses the per-endpoint `apiVersion: "beta"` plumbing shipped in 0.7.0 (PR #112)
- **Zero new Graph permissions** — Microsoft's `DeviceManagementScripts.ReadWrite.All` (declared since 0.7.0) explicitly covers all 5 Intune script families per the permission reference
- One commit per family, plus a release commit (docs + version bump)
- `npm run verify` passes: 195/195 tests, lint clean, prettier clean, build OK
- Version: `0.8.0` → `0.9.0` (minor, additive)

## Motivation

These three families round out the Intune scripts ecosystem. Together with the families shipped in 0.7.0 and 0.8.0, the server can now manage every script-driven Intune capability via Graph:

| Family | Platform | Shipped | Use case |
|---|---|---|---|
| `deviceShellScripts` | macOS | 0.7.0 | One-shot shell scripts |
| `deviceHealthScripts` | Windows | 0.8.0 | Detect + remediate (Remediations) |
| `deviceCustomAttributeShellScripts` | macOS | **0.9.0** | STDOUT → custom device attribute |
| `deviceManagementScripts` | Windows | **0.9.0** | One-shot PowerShell |
| `deviceComplianceScripts` | Windows | **0.9.0** | JSON output for custom compliance |

## What each family does

### `deviceCustomAttributeShellScripts` (6 tools, macOS)

Shell scripts whose STDOUT becomes a named custom attribute on the device record. Useful for surfacing inventory data (FileVault state, Gatekeeper, encryption flags, organization-specific markers) and driving dynamic group filters. `customAttributeType` controls parse mode: `integer`, `string`, `dateTime` (ISO 8601).

**Gotchas** (documented in `llmTip`s and README):

- Changing `customAttributeName` or `customAttributeType` after deployment breaks downstream dynamic groups and assignment filters that reference the previous key.
- Deleting a script does NOT clear previously-collected attribute values from device records.
- `scriptContent` is strict base64 with LF line endings — CRLF breaks execution on Macs.

### `deviceManagementScripts` (6 tools, Windows)

One-shot PowerShell scripts for Windows 10/11. Runs once per device per assignment, retries on failure. Distinct from `deviceHealthScripts` (Remediations) — no detection/remediation pairing, no scheduling, does NOT re-run after successful execution. For detect-and-fix patterns use `deviceHealthScripts` instead.

**Gotchas**:

- Updating `scriptContent` does NOT re-run on devices that already succeeded — delete + recreate to force re-execution.
- `enforceSignatureCheck=true` requires code-signed scripts (recommended for prod).
- `runAs32Bit=true` forces 32-bit PowerShell on 64-bit Windows (rarely needed).

### `deviceComplianceScripts` (6 tools, Windows)

PowerShell scripts that emit a JSON object on STDOUT, evaluated against rules declared on an associated `windows10CustomComplianceConfiguration` policy. For organization-specific compliance signals beyond the built-in BitLocker / Defender / firewall checks (e.g. proprietary agent installed, custom registry keys, line-of-business app version).

**Gotchas**:

- The script alone has no compliance effect — must be paired with a custom compliance policy that defines matching rules against the JSON keys.
- Changing the JSON keys without updating the linked policy's rules silently breaks compliance evaluation.
- Deleting a script in use causes referencing compliance policies to fail evaluation on next device check-in.
- Assignment shape reuses `deviceHealthScriptAssignment` (set `runRemediationScript: false` — compliance scripts have no remediation pairing).

## Graph permissions

**No new permissions required.** Microsoft's permission reference for `DeviceManagementScripts.ReadWrite.All` explicitly states it covers all five families:

> Allows the app to read and write Microsoft Intune device compliance scripts, device management scripts, device shell scripts, device custom attribute shell scripts and device health scripts, without a signed-in user.

This scope has been declared on the app registration since 0.7.0.

## Risk levels

| Operation | Risk |
|---|---|
| `list-*`, `get-*` | (none) |
| `create-*`, `update-*`, `assign-*` | medium |
| `delete-*` | high |

Risk levels match the pattern established in PRs #112 / #113 for the existing script families.

## Commits

1. `feat(intune): add deviceCustomAttributeShellScripts tools (P2 part 1/3)` — 6 tools, +52 lines
2. `feat(intune): add deviceManagementScripts tools (P2 part 2/3)` — 6 tools, +52 lines
3. `feat(intune): add deviceComplianceScripts tools (P2 part 3/3)` — 6 tools, +52 lines
4. `docs(release): bump to 0.9.0 with P2 changelog + README sections` — version bump, CHANGELOG, README

Each family commit is atomic and self-contained — can be cherry-picked independently if a single family needs to be released ahead of the others.

## Testing

- `npm run verify` passes (generate + lint + format + build + test): 195/195 tests pass
- Local sanity: all 18 new tool aliases present in `src/generated/client.ts`
- No tenant-side validation in this PR — will happen post-merge in the LCI deployment cycle

## Backward compatibility

- No breaking changes
- All existing tools unaffected
- 195/195 existing tests pass

## Follow-ups (out of scope)

P2 closes the Intune scripts family. Future endpoint expansions are no longer numbered (the P1/P2 sequencing was created to track the scripts gap discovery from PR #112's follow-up list, which is now exhausted).

Areas still worth considering for future PRs (not committed):

- Defender for Identity sensors and configurations
- Purview eDiscovery v3, DSPM
- Teams advanced (call analytics, meeting recordings beyond what 0.x already covers)
- Microsoft 365 Copilot admin (beyond the 2 settings tools currently shipped)