### PR TITLE
feat(security): complete Microsoft Defender for Identity surface (21 tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,72 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.10.0] — 2026-05-25
+
+### Added — Microsoft Defender for Identity full surface (571 tools)
+
+Twenty-one new tools completing the coverage of Microsoft Defender for Identity (DfI) administration via Graph. Builds on the 3 read-only DfI tools shipped in early v0.x releases to bring total DfI tool count to 24.
+
+**Health issues completion (3 tools)** — drill-down by health issue ID, scope to specific sensor:
+
+- `get-identity-health-issue` (GET)
+- `list-sensor-health-issues` (GET)
+- `get-sensor-health-issue` (GET)
+
+**Sensor management (5 tools)** — drill-down, reconfigure, deployment access key lifecycle:
+
+- `get-identity-sensor` (GET)
+- `update-identity-sensor` (PATCH, risk: medium)
+- `get-sensor-deployment-access-key` (GET function — treat returned key as secret)
+- `get-sensor-deployment-package-uri` (GET function)
+- `regenerate-sensor-deployment-access-key` (POST action, risk: high — invalidates previous key)
+
+**Sensor candidates (5 tools)** — auto-discovery of un-sensored DCs / AD FS / AD CS / Entra Connect hosts:
+
+- `list-sensor-candidates` (GET)
+- `get-sensor-candidate` (GET)
+- `get-sensor-candidate-activation-config` (GET)
+- `update-sensor-candidate-activation-config` (PATCH, risk: medium)
+- `activate-sensor-candidates` (POST .../activate, risk: medium)
+
+**Sensor migration (3 tools)** — migration to unified Defender XDR architecture (beta-only endpoints):
+
+- `list-sensor-migrations` (GET, beta)
+- `get-sensor-migration` (GET, beta)
+- `migrate-sensors` (POST .../migrate, risk: high, beta — brief capture gap on DCs)
+
+**Auto-auditing configuration (2 tools)** — enforces Windows advanced audit policies on sensor hosts:
+
+- `get-auto-auditing-config` (GET)
+- `update-auto-auditing-config` (PATCH, risk: medium)
+
+**Identity accounts + break-glass invokeAction (3 tools)** — the highest-impact DfI capability:
+
+- `list-identity-accounts` (GET)
+- `get-identity-account` (GET)
+- `invoke-identity-account-action` (POST .../invokeAction, risk: **critical**)
+
+`invoke-identity-account-action` performs identity-response actions in source systems — disable / enable / forcePasswordReset (AD on-prem), revokeAllSessions (Okta), markUserAsCompromised. Equivalent to a "break-glass" SOC response. Classified as `critical` riskLevel and gated by `Tools.Write.Critical` App Role per the per-caller write gating model (see v0.6.0+).
+
+### New Graph permissions required
+
+Must be consented on the app registration (none of these were declared prior to 0.10.0):
+
+- `SecurityIdentitiesSensors.Read.All`
+- `SecurityIdentitiesSensors.ReadWrite.All`
+- `SecurityIdentitiesSettings.Read.All`
+- `SecurityIdentitiesSettings.ReadWrite.All`
+- `SecurityIdentitiesActions.Read.All`
+- `SecurityIdentitiesActions.ReadWrite.All`
+
+The existing `SecurityIdentitiesHealth.Read.All` (declared since the original `list-identity-health-issues` tool) continues to cover all health-issue reads.
+
+### Notes
+
+- 18 of 21 new tools target Graph v1.0 (stable) — only the 3 `sensorMigration` tools use the beta endpoint.
+- Function paths with parentheses notation (`getDeploymentAccessKey()`, `getDeploymentPackageUri()`) and namespace-prefixed action paths (`microsoft.graph.security.invokeAction`, `microsoft.graph.security.activate`, etc.) are passed through to Graph as-is — the per-endpoint validation test confirms generator + Zodios client handle them.
+- 195/195 tests still pass, no regressions on existing 550 tools.
+
 ## [0.9.0] — 2026-05-25
 
 ### Added — P2 beta-only Intune script families (550 tools)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 
 ## Features
 
-- **550 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **macOS custom attribute scripts**, **assignment filters**, **Remediations**, **Windows PowerShell scripts**, **custom compliance scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, Defender for Identity, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
+- **571 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **macOS custom attribute scripts**, **assignment filters**, **Remediations**, **Windows PowerShell scripts**, **custom compliance scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, **Defender for Identity (sensors, candidates, migration, identity accounts, audit policy)**, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -1074,13 +1074,10 @@ Notes:
 | ---------------------------------------- | ------ | ---- |
 | `list-service-principal-risk-detections` | GET    |      |
 
-### Security advanced (14)
+### Security advanced (9)
 
 | Tool                                     | Method | Risk |
 | ---------------------------------------- | ------ | ---- |
-| `list-identity-health-issues`            | GET    |      |
-| `list-identity-sensors`                  | GET    |      |
-| `get-identity-security-settings`         | GET    |      |
 | `list-retention-events`                  | GET    |      |
 | `list-retention-event-types`             | GET    |      |
 | `list-subject-rights-requests`           | GET    |      |
@@ -1090,6 +1087,54 @@ Notes:
 | `list-simulation-end-user-notifications` | GET    |      |
 | `list-simulation-landing-pages`          | GET    |      |
 | `list-simulation-login-pages`            | GET    |      |
+
+### Defender for Identity (24)
+
+Full surface coverage of Microsoft Defender for Identity (DfI) administration via Graph: sensors, sensor candidates (auto-discovery), sensor migration to unified Defender XDR architecture, identity accounts (with break-glass invokeAction for AD on-prem / Okta), audit policy enforcement, and health alerts. Most endpoints are Graph v1.0; `sensorMigration` is beta-only.
+
+| Tool                                        | Method | Risk     |
+| ------------------------------------------- | ------ | -------- |
+| `list-identity-health-issues`               | GET    |          |
+| `get-identity-health-issue`                 | GET    |          |
+| `list-sensor-health-issues`                 | GET    |          |
+| `get-sensor-health-issue`                   | GET    |          |
+| `list-identity-sensors`                     | GET    |          |
+| `get-identity-sensor`                       | GET    |          |
+| `update-identity-sensor`                    | PATCH  | medium   |
+| `get-sensor-deployment-access-key`          | GET    |          |
+| `get-sensor-deployment-package-uri`         | GET    |          |
+| `regenerate-sensor-deployment-access-key`   | POST   | high     |
+| `list-sensor-candidates`                    | GET    |          |
+| `get-sensor-candidate`                      | GET    |          |
+| `get-sensor-candidate-activation-config`    | GET    |          |
+| `update-sensor-candidate-activation-config` | PATCH  | medium   |
+| `activate-sensor-candidates`                | POST   | medium   |
+| `list-sensor-migrations`                    | GET    |          |
+| `get-sensor-migration`                      | GET    |          |
+| `migrate-sensors`                           | POST   | high     |
+| `get-identity-security-settings`            | GET    |          |
+| `get-auto-auditing-config`                  | GET    |          |
+| `update-auto-auditing-config`               | PATCH  | medium   |
+| `list-identity-accounts`                    | GET    |          |
+| `get-identity-account`                      | GET    |          |
+| `invoke-identity-account-action`            | POST   | critical |
+
+Notes:
+
+- **`invoke-identity-account-action`** is the highest-impact write — performs identity-response actions (disable, enable, forcePasswordReset, revokeAllSessions, requireUserToSignInAgain, markUserAsCompromised) on accounts in their source system (AD on-prem, Okta). Action / provider compatibility: `disable`/`enable` for AD + Okta, `forcePasswordReset` for AD only, `revokeAllSessions` for Okta only.
+- **`regenerate-sensor-deployment-access-key`** invalidates the previous key immediately — coordinate with anyone rolling out new sensors before calling.
+- **`migrate-sensors`** restarts the sensor service on the target DC during migration to unified Defender XDR — brief capture gap (~minutes). Schedule maintenance windows for production DCs. Beta-only.
+- **`activate-sensor-candidates`** triggers sensor installation on detected hosts using the deployment access key flow. Verify with `get-sensor-candidate` first — wrong serverId installs on the wrong host.
+- **`update-auto-auditing-config`** with `enabled=true` makes DfI enforce the recommended Windows advanced audit policies on every sensor host (revert local admin overrides on next heartbeat) — recommended for production.
+
+New Graph permissions required since v0.10.0 (must be consented on the app registration):
+
+- `SecurityIdentitiesSensors.Read.All`
+- `SecurityIdentitiesSensors.ReadWrite.All`
+- `SecurityIdentitiesSettings.Read.All`
+- `SecurityIdentitiesSettings.ReadWrite.All`
+- `SecurityIdentitiesActions.Read.All`
+- `SecurityIdentitiesActions.ReadWrite.All`
 
 ### Threat intelligence+ (7)
 
@@ -1295,7 +1340,10 @@ RoleManagement.Read.Directory
 RoleManagementPolicy.Read.Directory
 SecurityAlert.Read.All
 SecurityEvents.Read.All
+SecurityIdentitiesActions.Read.All
 SecurityIdentitiesHealth.Read.All
+SecurityIdentitiesSensors.Read.All
+SecurityIdentitiesSettings.Read.All
 SecurityIncident.Read.All
 ServiceHealth.Read.All
 ServiceMessage.Read.All
@@ -1350,6 +1398,9 @@ RoleEligibilitySchedule.ReadWrite.Directory
 RoleManagement.ReadWrite.Directory
 RoleManagementPolicy.ReadWrite.Directory
 SecurityAlert.ReadWrite.All
+SecurityIdentitiesActions.ReadWrite.All
+SecurityIdentitiesSensors.ReadWrite.All
+SecurityIdentitiesSettings.ReadWrite.All
 SecurityIncident.ReadWrite.All
 Sites.ReadWrite.All
 Team.Create

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
   "mcpName": "io.github.okapi-ca/ms-365-admin",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2155,6 +2155,43 @@
     "llmTip": "Generates a NEW Defender for Identity deployment access key, invalidating the previous key immediately. Used when the previous key is suspected compromised, has leaked, or as part of periodic rotation. BREAKING IMPACT: any in-progress sensor installations using the OLD key will fail and must be retried with the new key. Already-installed sensors are unaffected (they use registered service principals, not the deployment key). After regeneration, retrieve the new key with get-sensor-deployment-access-key. Empty request body. Confirm with the user before calling — coordinate with anyone currently rolling out sensors."
   },
   {
+    "pathPattern": "/security/identities/sensorCandidates",
+    "method": "get",
+    "toolName": "list-sensor-candidates",
+    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "llmTip": "Lists Microsoft Defender for Identity sensor candidates — servers detected on the network that appear to be domain controllers, AD FS, AD CS, or Entra Connect hosts but do NOT yet have a DfI sensor installed. Each has dnsName, ipAddress, osVersion, lastSeenDateTime, candidateType (e.g. domainController, adfs, adcs, entraConnect), isActivated (boolean), and detectedBy (which existing sensor detected this candidate). Use to discover blind spots in DfI coverage and target new sensor deployments. Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
+  },
+  {
+    "pathPattern": "/security/identities/sensorCandidates/{sensorCandidate-id}",
+    "method": "get",
+    "toolName": "get-sensor-candidate",
+    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "llmTip": "Gets a specific sensor candidate by ID. Returns full discovery metadata: dnsName, ipAddress, osVersion, candidateType, lastSeenDateTime, isActivated, detectedBy, additionalInformation (server role hints). Use before calling activate-sensor-candidates to confirm the candidate matches the expected server."
+  },
+  {
+    "pathPattern": "/security/identities/sensorCandidateActivationConfiguration",
+    "method": "get",
+    "toolName": "get-sensor-candidate-activation-config",
+    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "llmTip": "Gets the global sensor candidate activation configuration — controls how DfI handles newly-detected sensor candidates. Returns the autoActivation flag (whether candidates are auto-promoted to sensors), automation rules (criteria for auto-activation), and notification settings."
+  },
+  {
+    "pathPattern": "/security/identities/sensorCandidateActivationConfiguration",
+    "method": "patch",
+    "toolName": "update-sensor-candidate-activation-config",
+    "appPermissions": ["SecurityIdentitiesSensors.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates the global sensor candidate activation configuration (partial update). Body example: {\"autoActivation\":false,\"notifyOnDiscovery\":true}. Set autoActivation=true with caution — it auto-promotes any newly-detected DC/AD FS host to a sensor on the deployment-key path, which may include hosts you do not intend to monitor (lab environments, decommissioned servers still on the network)."
+  },
+  {
+    "pathPattern": "/security/identities/sensorCandidates/microsoft.graph.security.activate",
+    "method": "post",
+    "toolName": "activate-sensor-candidates",
+    "appPermissions": ["SecurityIdentitiesSensors.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Activates one or more Defender for Identity sensor candidates — initiates sensor installation on the named servers using the deployment access key flow. Body: {\"serverIds\":[\"<candidate-id-1>\",\"<candidate-id-2>\"]}. The activation is asynchronous: returns 202 then DfI pushes the installer to each server. Track progress via list-identity-sensors (new entries appear) and list-sensor-candidates (activated candidates flip isActivated=true). Verify with get-sensor-candidate before activating to confirm host identity — activating the wrong serverId installs a sensor on an unintended host."
+  },
+  {
     "pathPattern": "/security/triggers/retentionEvents",
     "method": "get",
     "toolName": "list-retention-events",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2097,6 +2097,27 @@
     "llmTip": "Gets Microsoft Defender for Identity global settings. Returns configuration for identity-based threat detection."
   },
   {
+    "pathPattern": "/security/identities/healthIssues/{healthIssue-id}",
+    "method": "get",
+    "toolName": "get-identity-health-issue",
+    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
+    "llmTip": "Gets a specific Microsoft Defender for Identity health issue by ID. Returns full details including healthIssueType, severity (low | medium | high), status (open | closed | suppressed), displayName, description, recommendedActions, recommendedActionCommands (PowerShell remediation snippets), createdDateTime, lastModifiedDateTime, domainNames, sensorDNSNames, additionalInformation, issueTypeId. Use after list-identity-health-issues to drill into a specific health alert and get the remediation commands."
+  },
+  {
+    "pathPattern": "/security/identities/sensors/{sensor-id}/healthIssues",
+    "method": "get",
+    "toolName": "list-sensor-health-issues",
+    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
+    "llmTip": "Lists all health issues for a specific Defender for Identity sensor. Returns the per-sensor view of healthIssues — same shape as list-identity-health-issues but scoped to a single sensor. Useful for triaging the health of one specific domain controller or AD FS / AD CS server. Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
+  },
+  {
+    "pathPattern": "/security/identities/sensors/{sensor-id}/healthIssues/{healthIssue-id}",
+    "method": "get",
+    "toolName": "get-sensor-health-issue",
+    "appPermissions": ["SecurityIdentitiesHealth.Read.All"],
+    "llmTip": "Gets a specific health issue scoped to a sensor. Equivalent to get-identity-health-issue but verified to belong to the named sensor — useful when correlating an alert to a specific DC."
+  },
+  {
     "pathPattern": "/security/triggers/retentionEvents",
     "method": "get",
     "toolName": "list-retention-events",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2192,6 +2192,31 @@
     "llmTip": "Activates one or more Defender for Identity sensor candidates — initiates sensor installation on the named servers using the deployment access key flow. Body: {\"serverIds\":[\"<candidate-id-1>\",\"<candidate-id-2>\"]}. The activation is asynchronous: returns 202 then DfI pushes the installer to each server. Track progress via list-identity-sensors (new entries appear) and list-sensor-candidates (activated candidates flip isActivated=true). Verify with get-sensor-candidate before activating to confirm host identity — activating the wrong serverId installs a sensor on an unintended host."
   },
   {
+    "pathPattern": "/security/identities/sensorMigration",
+    "method": "get",
+    "toolName": "list-sensor-migrations",
+    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Lists Microsoft Defender for Identity sensor migration jobs — tracks upgrades of sensors from legacy AATP (Azure Advanced Threat Protection) workspace to the unified Defender XDR sensor architecture. Each migration has sensorId, sourceVersion, targetVersion, status (pending | inProgress | completed | failed), startedDateTime, completedDateTime. Use to monitor an in-flight migration wave. Beta-only endpoint."
+  },
+  {
+    "pathPattern": "/security/identities/sensorMigration/{sensorMigration-id}",
+    "method": "get",
+    "toolName": "get-sensor-migration",
+    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "apiVersion": "beta",
+    "llmTip": "Gets a specific sensor migration job by ID. Returns the full migration trace: source/target versions, current step, errors (if status=failed), per-step timestamps. Use to investigate why a specific migration is stuck or failed. Beta-only endpoint."
+  },
+  {
+    "pathPattern": "/security/identities/sensorMigration/microsoft.graph.security.migrate",
+    "method": "post",
+    "toolName": "migrate-sensors",
+    "appPermissions": ["SecurityIdentitiesSensors.ReadWrite.All"],
+    "riskLevel": "high",
+    "apiVersion": "beta",
+    "llmTip": "Triggers migration of one or more Defender for Identity sensors to the unified Defender XDR architecture. Body: {\"sensorIds\":[\"<sensor-id-1>\",\"<sensor-id-2>\"]}. POTENTIALLY DISRUPTIVE: the migration restarts the sensor service on the target host — there's a brief window (~minutes) where the DC's network traffic is not being captured. Schedule during a maintenance window for production DCs. Track via list-sensor-migrations / get-sensor-migration. Failed migrations require manual remediation on the host. Beta-only endpoint."
+  },
+  {
     "pathPattern": "/security/triggers/retentionEvents",
     "method": "get",
     "toolName": "list-retention-events",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2217,6 +2217,21 @@
     "llmTip": "Triggers migration of one or more Defender for Identity sensors to the unified Defender XDR architecture. Body: {\"sensorIds\":[\"<sensor-id-1>\",\"<sensor-id-2>\"]}. POTENTIALLY DISRUPTIVE: the migration restarts the sensor service on the target host — there's a brief window (~minutes) where the DC's network traffic is not being captured. Schedule during a maintenance window for production DCs. Track via list-sensor-migrations / get-sensor-migration. Failed migrations require manual remediation on the host. Beta-only endpoint."
   },
   {
+    "pathPattern": "/security/identities/settings/autoAuditingConfiguration",
+    "method": "get",
+    "toolName": "get-auto-auditing-config",
+    "appPermissions": ["SecurityIdentitiesSettings.Read.All"],
+    "llmTip": "Gets the Defender for Identity auto-auditing configuration. Auto-auditing controls whether DfI automatically configures the recommended Windows audit policies (advanced audit policies on DCs: 'Audit Directory Service Changes', 'Audit Computer Account Management', etc.) on sensors and reverts them if changed locally. Returns enabled (boolean) and lastUpdatedDateTime. Recommended state for production tenants: enabled=true (prevents drift in audit configuration that degrades detection coverage)."
+  },
+  {
+    "pathPattern": "/security/identities/settings/autoAuditingConfiguration",
+    "method": "patch",
+    "toolName": "update-auto-auditing-config",
+    "appPermissions": ["SecurityIdentitiesSettings.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates the Defender for Identity auto-auditing configuration (partial update). Body example: {\"enabled\":true}. Setting enabled=true causes DfI to enforce the recommended Windows advanced audit policies on every sensor host — if a local admin changes them on the DC, DfI reverts the change on its next sync. Disable only for tenants with custom audit policy frameworks (where DfI's enforcement would conflict). Changes propagate to sensors on their next heartbeat."
+  },
+  {
     "pathPattern": "/security/triggers/retentionEvents",
     "method": "get",
     "toolName": "list-retention-events",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2118,6 +2118,43 @@
     "llmTip": "Gets a specific health issue scoped to a sensor. Equivalent to get-identity-health-issue but verified to belong to the named sensor — useful when correlating an alert to a specific DC."
   },
   {
+    "pathPattern": "/security/identities/sensors/{sensor-id}",
+    "method": "get",
+    "toolName": "get-identity-sensor",
+    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "llmTip": "Gets a specific Microsoft Defender for Identity sensor by ID. Returns full details: displayName, sensorType (adConnectIntegrated | adcsIntegrated | adfsIntegrated | domainControllerIntegrated | entraConnectIntegrated), healthStatus (healthy | notHealthy | offline | failed), openHealthIssuesCount, domainName, version, deploymentStatus, sensorSettings, createdDateTime, settings (capture mode, delayed updates), and the underlying server's DNS / IP / OS info. Use after list-identity-sensors to drill into a specific DC / AD FS / AD CS / Entra Connect server."
+  },
+  {
+    "pathPattern": "/security/identities/sensors/{sensor-id}",
+    "method": "patch",
+    "toolName": "update-identity-sensor",
+    "appPermissions": ["SecurityIdentitiesSensors.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Updates a Microsoft Defender for Identity sensor configuration (partial update). Body example: {\"settings\":{\"description\":\"DC1 — primary domain controller\",\"domainControllerIsAdvertised\":true,\"sensorMode\":\"sensor\"}}. Common updates: rename a sensor, change capture mode (sensor vs. standalone), toggle network adapters used, enable/disable delayed updates. Sensor configuration changes propagate to the sensor on its next service heartbeat (typically <5 min)."
+  },
+  {
+    "pathPattern": "/security/identities/sensors/microsoft.graph.security.getDeploymentAccessKey()",
+    "method": "get",
+    "toolName": "get-sensor-deployment-access-key",
+    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "llmTip": "Gets the Microsoft Defender for Identity deployment access key for the tenant — required to install NEW sensors (the installer prompts for this key on first run). SECURITY: This key is a credential that allows any host on the network to register itself as a DfI sensor — treat it as a secret, do NOT log it, do NOT expose in tickets or screenshots. Anyone with this key can install a rogue sensor that may impersonate traffic capture. If suspected compromised, use regenerate-sensor-deployment-access-key to rotate (invalidates the old key immediately)."
+  },
+  {
+    "pathPattern": "/security/identities/sensors/microsoft.graph.security.getDeploymentPackageUri()",
+    "method": "get",
+    "toolName": "get-sensor-deployment-package-uri",
+    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "llmTip": "Gets the Microsoft Defender for Identity sensor deployment package URL and version. The URL is a time-limited Azure Blob link to the latest .exe installer. Use to download the installer programmatically when deploying new sensors. The version field tells you the installer build that will be installed."
+  },
+  {
+    "pathPattern": "/security/identities/sensors/microsoft.graph.security.regenerateDeploymentAccessKey",
+    "method": "post",
+    "toolName": "regenerate-sensor-deployment-access-key",
+    "appPermissions": ["SecurityIdentitiesSensors.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Generates a NEW Defender for Identity deployment access key, invalidating the previous key immediately. Used when the previous key is suspected compromised, has leaked, or as part of periodic rotation. BREAKING IMPACT: any in-progress sensor installations using the OLD key will fail and must be retried with the new key. Already-installed sensors are unaffected (they use registered service principals, not the deployment key). After regeneration, retrieve the new key with get-sensor-deployment-access-key. Empty request body. Confirm with the user before calling — coordinate with anyone currently rolling out sensors."
+  },
+  {
     "pathPattern": "/security/triggers/retentionEvents",
     "method": "get",
     "toolName": "list-retention-events",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2232,6 +2232,28 @@
     "llmTip": "Updates the Defender for Identity auto-auditing configuration (partial update). Body example: {\"enabled\":true}. Setting enabled=true causes DfI to enforce the recommended Windows advanced audit policies on every sensor host — if a local admin changes them on the DC, DfI reverts the change on its next sync. Disable only for tenants with custom audit policy frameworks (where DfI's enforcement would conflict). Changes propagate to sensors on their next heartbeat."
   },
   {
+    "pathPattern": "/security/identities/identityAccounts",
+    "method": "get",
+    "toolName": "list-identity-accounts",
+    "appPermissions": ["SecurityIdentitiesActions.Read.All"],
+    "llmTip": "Lists identity accounts observed by Microsoft Defender for Identity — synced AD / Entra ID / Okta accounts that DfI has correlated with detected activity. Each has accountId, displayName, identityProvider (entraID | activeDirectory | okta), upn / sAMAccountName, domain, isSensitive (privileged), and lastActivityDateTime. Use to identify the canonical DfI account-id needed for invoke-identity-account-action (which requires the DfI identityAccountsId, NOT the AD objectGuid). Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
+  },
+  {
+    "pathPattern": "/security/identities/identityAccounts/{identityAccounts-id}",
+    "method": "get",
+    "toolName": "get-identity-account",
+    "appPermissions": ["SecurityIdentitiesActions.Read.All"],
+    "llmTip": "Gets a specific identity account by DfI identityAccounts id. Returns full details including identityProvider, sourceId (the AD objectGuid / Entra objectId / Okta id), upn, displayName, lastActivityDateTime, sensitivity flags, group memberships observed by DfI. Use to confirm an account's identityProvider before calling invoke-identity-account-action — the action set differs by provider (e.g. forcePasswordReset works for activeDirectory only)."
+  },
+  {
+    "pathPattern": "/security/identities/identityAccounts/{identityAccounts-id}/microsoft.graph.security.invokeAction",
+    "method": "post",
+    "toolName": "invoke-identity-account-action",
+    "appPermissions": ["SecurityIdentitiesActions.ReadWrite.All"],
+    "riskLevel": "critical",
+    "llmTip": "Performs an identity-response action on an account observed by Defender for Identity. Body: {\"accountId\":\"<source-id>\",\"action\":\"disable|enable|forcePasswordReset|revokeAllSessions|requireUserToSignInAgain|markUserAsCompromised\",\"identityProvider\":\"entraID|activeDirectory|okta\"}. ACTION/PROVIDER COMPATIBILITY: disable/enable supported on activeDirectory and okta; forcePasswordReset supported on activeDirectory only; revokeAllSessions on okta only. The accountId in the body is the source-system identifier (AD objectGuid, Okta id), NOT the DfI identityAccountsId in the URL — get both via get-identity-account first. DESTRUCTIVE: this disables AD on-prem accounts, forces password resets, or revokes sessions — equivalent to an incident-response action. Confirm with the user before invoking, ESPECIALLY on production accounts. Audit trail: action is logged in DfI activity logs AND in AD (if AD is the provider)."
+  },
+  {
     "pathPattern": "/security/triggers/retentionEvents",
     "method": "get",
     "toolName": "list-retention-events",


### PR DESCRIPTION
Expands Microsoft Defender for Identity (DfI) administration coverage from 3 tools to **24 tools** — adds 21 new tools across 6 sub-themes covering sensors, sensor candidates (auto-discovery), sensor migration (Defender XDR unification), audit policy enforcement, and identity accounts (with break-glass `invokeAction`).

This is the start of the P3 family-by-family expansion (DfI → Purview → Teams advanced → Copilot admin, one PR each).

## Summary

- **21 new tools** for `/security/identities/*` (Microsoft Defender for Identity)
- **6 commits** organized by sub-theme, each self-contained
- **6 new Graph permissions** required (must be admin-consented before tools work end-to-end)
- 18 of 21 tools target Graph v1.0 (stable); only `sensorMigration` (3 tools) is beta-only
- Function path notation with `()` and namespace-prefixed actions (`microsoft.graph.security.*`) pass through to Graph as-is — confirmed by per-endpoint validation test
- `npm run verify` passes: 195/195 tests, lint clean, prettier clean, build OK
- Version: `0.9.0` → `0.10.0` (minor, additive)

## Motivation

DfI was 3 tools — read-only list of health issues, list of sensors, and a single settings GET. No way to:

- Drill into a specific health issue and get the remediation commands.
- Manage sensors (read individual sensor, reconfigure, manage the deployment access key).
- Discover un-sensored DCs / AD FS / AD CS / Entra Connect hosts and remotely trigger installation.
- Track or trigger sensor migrations to the unified Defender XDR architecture.
- Enforce or audit the auto-auditing configuration (Windows advanced audit policies on DCs).
- Perform identity-response actions on AD on-prem / Okta accounts observed by DfI.

This PR closes those gaps and brings DfI to feature parity with Defender XDR's Identity portal — without bypassing audit (every action is logged in DfI activity logs AND in the source system).

## Commits (atomic by sub-theme)

| Commit | Sub-theme | Tools | Highest risk |
|---|---|---|---|
| `0d0023c` | Health issues completion | 3 | (read-only) |
| `d03fd35` | Sensors management | 5 | high (regenerate access key) |
| `28e09f2` | Sensor candidates | 5 | medium (activate-sensor-candidates) |
| `7cf6162` | Sensor migration (beta) | 3 | high (migrate-sensors — brief capture gap) |
| `df7b382` | Auto-auditing configuration | 2 | medium (update-auto-auditing-config) |
| `481a8da` | Identity accounts + invokeAction | 3 | **critical** (invoke-identity-account-action) |
| `a04774c` | docs + bump 0.10.0 | — | — |

## Tools added (21)

### Health issues completion (3)

- `get-identity-health-issue` (GET)
- `list-sensor-health-issues` (GET)
- `get-sensor-health-issue` (GET)

### Sensors management (5)

- `get-identity-sensor` (GET)
- `update-identity-sensor` (PATCH, medium)
- `get-sensor-deployment-access-key` (GET function — treat returned key as secret)
- `get-sensor-deployment-package-uri` (GET function)
- `regenerate-sensor-deployment-access-key` (POST action, high)

### Sensor candidates (5)

- `list-sensor-candidates` (GET)
- `get-sensor-candidate` (GET)
- `get-sensor-candidate-activation-config` (GET)
- `update-sensor-candidate-activation-config` (PATCH, medium)
- `activate-sensor-candidates` (POST .../activate, medium)

### Sensor migration — beta only (3)

- `list-sensor-migrations` (GET, beta)
- `get-sensor-migration` (GET, beta)
- `migrate-sensors` (POST .../migrate, high, beta)

### Auto-auditing configuration (2)

- `get-auto-auditing-config` (GET)
- `update-auto-auditing-config` (PATCH, medium)

### Identity accounts + break-glass invokeAction (3)

- `list-identity-accounts` (GET)
- `get-identity-account` (GET)
- `invoke-identity-account-action` (POST .../invokeAction, **critical**)

## Highest-impact tool — `invoke-identity-account-action`

Performs identity-response actions on accounts observed by DfI in their source systems:

| Action | Provider compatibility |
|---|---|
| `disable` | activeDirectory, okta |
| `enable` | activeDirectory, okta |
| `forcePasswordReset` | activeDirectory only |
| `revokeAllSessions` | okta only |
| `requireUserToSignInAgain` | (varies) |
| `markUserAsCompromised` | (varies) |

Classified `riskLevel: critical` — gated by `Tools.Write.Critical` App Role per the per-caller write gating model from v0.6.0+. Audit trail: every invocation appears in DfI activity logs AND in the source system (AD security log for `activeDirectory`).

## New Graph permissions required

Must be admin-consented on the app registration **before any of the 21 new tools work end-to-end**:

- `SecurityIdentitiesSensors.Read.All`
- `SecurityIdentitiesSensors.ReadWrite.All`
- `SecurityIdentitiesSettings.Read.All`
- `SecurityIdentitiesSettings.ReadWrite.All`
- `SecurityIdentitiesActions.Read.All`
- `SecurityIdentitiesActions.ReadWrite.All`

The existing `SecurityIdentitiesHealth.Read.All` (declared since the original `list-identity-health-issues` tool) still covers all health-issue reads.

Without consent, the 21 new tools return `403 Insufficient privileges`. The 3 pre-existing DfI tools continue to work.

## v1.0 vs beta breakdown

- **v1.0 (stable)**: 18 tools — health issues, sensors, sensor candidates, autoAuditing, identity accounts
- **beta**: 3 tools — sensor migration only (Microsoft has not yet promoted to v1.0)

The per-endpoint `apiVersion: "beta"` infrastructure from v0.7.0 handles the mix transparently.

## Testing

- `npm run verify` passes (generate + lint + format + build + test): 195/195 tests
- Local sanity: all 21 new tool aliases present in `src/generated/client.ts`
- Function-path notation with `()` and namespace-prefixed actions validated by `endpoints-validation.test.ts`
- No tenant-side validation in this PR — will happen post-merge in the LCI deployment cycle (and gated by consent of the 6 new permissions)

## Backward compatibility

- No breaking changes
- All existing tools unaffected (the 3 pre-existing DfI tools keep their `SecurityIdentitiesHealth.Read.All` scope)
- 195/195 existing tests pass

## Next P3 PRs (follow-ups in separate PRs)

- Purview (eDiscovery v3 + DSPM + info governance expansion)
- Teams advanced (call analytics, meeting recordings, attendance reports)
- Copilot admin (audit, usage analytics, prompt analytics, agent gating)

Each will follow this PR's pattern: atomic commits by sub-theme, separate Graph permission declarations as needed.