### PR TITLE
feat(security): expand Microsoft Purview surface — eDiscovery v3 + DSPM + retention events (25 tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,77 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-05-25
+
+### Added — Microsoft Purview expansion (596 tools)
+
+Twenty-five new tools across the Microsoft Purview surface — eDiscovery v3 advanced administration, Data Security Posture Management (DSPM), and event-based retention triggers. Builds on the 15 Purview tools shipped prior to bring total Purview tool count to 40.
+
+**eDiscovery v3 — custodian admin (3 tools)** — drill-down, release, force re-index:
+
+- `get-ediscovery-custodian` (GET)
+- `release-ediscovery-custodian` (POST .../release, medium)
+- `update-ediscovery-custodian-index` (POST .../updateIndex, low)
+
+**eDiscovery v3 — noncustodial data sources (5 tools)** — shared mailboxes, departmental sites, M365 group OneDrive:
+
+- `list-ediscovery-noncustodial-data-sources` (GET)
+- `create-ediscovery-noncustodial-data-source` (POST, medium)
+- `get-ediscovery-noncustodial-data-source` (GET)
+- `apply-hold-ediscovery-noncustodial-data-source` (POST .../applyHold, medium)
+- `remove-hold-ediscovery-noncustodial-data-source` (POST .../removeHold, **high**)
+
+**eDiscovery v3 — case operations tracking (2 tools)** — poll long-running ops:
+
+- `list-case-operations` (GET)
+- `get-case-operation` (GET)
+
+**eDiscovery v3 — review sets (4 tools)** — the legal-review workspace:
+
+- `list-review-sets` (GET)
+- `create-review-set` (POST, low)
+- `get-review-set` (GET)
+- `export-review-set` (POST .../export, **high**)
+
+**eDiscovery v3 — review set queries + addToReviewSet (5 tools)** — slice and tag:
+
+- `add-to-review-set` (POST .../addToReviewSet, medium) — moves search hits into a review set
+- `list-review-set-queries` (GET)
+- `create-review-set-query` (POST, low)
+- `get-review-set-query` (GET)
+- `apply-tags-review-set-query` (POST .../applyTags, medium)
+
+**DSPM — root + compute (2 tools)** — Microsoft-native Data Security Posture Management:
+
+- `get-data-security-governance-root` (GET /security/dataSecurityAndGovernance)
+- `compute-protection-scopes` (POST .../protectionScopes/compute, low)
+
+The existing `get-protection-scopes` (GET, declared in earlier v0.x) returns the last-computed scopes; the new `compute-protection-scopes` forces evaluation across all users.
+
+**Retention events expansion (4 tools)** — event-based retention triggers:
+
+- `get-retention-event` (GET)
+- `create-retention-event` (POST, medium)
+- `get-retention-event-type` (GET)
+- `create-retention-event-type` (POST, medium)
+
+Operational pattern: define a `retentionEventType` (e.g. 'project_closed'), author event-based retention labels referencing the eventType, then call `create-retention-event` to trigger the retention period on tagged content when the business event happens.
+
+### New Graph permissions required
+
+Must be admin-consented on the app registration (none of these were declared prior to 0.11.0):
+
+- `ProtectionScopes.Compute.All` — for `compute-protection-scopes`
+- `RecordsManagement.ReadWrite.All` — for `create-retention-event` and `create-retention-event-type`
+
+The existing `eDiscovery.Read.All`, `eDiscovery.ReadWrite.All`, `RecordsManagement.Read.All`, and `InformationProtectionPolicy.Read.All` continue to cover the 18 new eDiscovery + DSPM root tools.
+
+### Notes
+
+- All 25 new tools target Graph v1.0 (stable) — no beta endpoints in this PR.
+- Eight of the new tools are long-running actions returning 202; track via the new `list-case-operations` / `get-case-operation` tools.
+- 195/195 tests still pass, no regressions on existing 571 tools.
+
 ## [0.10.0] — 2026-05-25
 
 ### Added — Microsoft Defender for Identity full surface (571 tools)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 
 ## Features
 
-- **571 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **macOS custom attribute scripts**, **assignment filters**, **Remediations**, **Windows PowerShell scripts**, **custom compliance scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, **Defender for Identity (sensors, candidates, migration, identity accounts, audit policy)**, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, eDiscovery, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
+- **596 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **macOS custom attribute scripts**, **assignment filters**, **Remediations**, **Windows PowerShell scripts**, **custom compliance scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, **Defender for Identity (sensors, candidates, migration, identity accounts, audit policy)**, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, **eDiscovery v3 (cases, custodians, noncustodial data sources, review sets, queries, exports, operations)**, **Purview DSPM (protection scopes)**, **event-based retention triggers**, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -1329,6 +1329,7 @@ OnPremDirectorySynchronization.Read.All
 Organization.Read.All
 Policy.Read.All
 Printer.Read.All
+ProtectionScopes.Compute.All
 PrintConnector.Read.All
 PrintJob.Read.All
 PrivilegedAccess.Read.AzureADGroup
@@ -1393,6 +1394,7 @@ LifecycleWorkflows.ReadWrite.All
 Policy.ReadWrite.AuthenticationMethod
 Policy.ReadWrite.ConditionalAccess
 PrivilegedAccess.ReadWrite.AzureADGroup
+RecordsManagement.ReadWrite.All
 RoleAssignmentSchedule.ReadWrite.Directory
 RoleEligibilitySchedule.ReadWrite.Directory
 RoleManagement.ReadWrite.Directory

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
   "mcpName": "io.github.okapi-ca/ms-365-admin",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4357,5 +4357,35 @@
     "toolName": "get-case-operation",
     "appPermissions": ["eDiscovery.Read.All"],
     "llmTip": "Gets a specific eDiscovery case operation by ID. Returns full status including percentProgress and resultInfo. Use to poll until status=succeeded for operations like export-review-set or update-ediscovery-custodian-index that return 202 + operation ID. For failed operations, resultInfo contains the error message."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets",
+    "method": "get",
+    "toolName": "list-review-sets",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Lists review sets in an eDiscovery case. Review sets are curated collections of items collected from searches — the workspace where legal teams review, tag, and export content for production. Each review set has displayName, description, createdDateTime, createdBy. A case can have multiple review sets (e.g. one per matter or production batch). Items only enter a review set after add-to-review-set is invoked on a search."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets",
+    "method": "post",
+    "toolName": "create-review-set",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Creates a new review set in an eDiscovery case. Body example: {\"displayName\":\"2026 Q1 production\",\"description\":\"Documents responsive to subpoena #123\"}. The review set is empty until populated via add-to-review-set (which moves search hits into it). Multiple review sets per case is the common pattern — one per matter, production batch, or review phase."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets/{ediscoveryReviewSet-id}",
+    "method": "get",
+    "toolName": "get-review-set",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Gets a specific review set by ID. Returns displayName, description, createdDateTime, createdBy, and the list of queries (saved filters) attached to it. Item count is NOT directly returned — use list-review-set-queries and run a query to count items, or wait for export to see the file count."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets/{ediscoveryReviewSet-id}/microsoft.graph.security.export",
+    "method": "post",
+    "toolName": "export-review-set",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Exports the contents of a review set for production / forensic delivery. Body example: {\"outputName\":\"2026Q1-production\",\"description\":\"Subpoena response Jan 2026\",\"exportOptions\":\"originalFiles,fileInfo,tags\",\"exportStructure\":\"directory\"}. exportOptions: 'originalFiles' (native), 'text' (extracted text), 'pdfReplacement' (PDFs), 'tags' (review tags as CSV), 'fileInfo' (metadata CSV), 'summary'. exportStructure: 'none' (flat) | 'directory' (per-custodian) | 'pst' (mailbox-style PST per custodian). Long-running: returns 202; track via list-case-operations. Output is downloaded via the Purview portal once status=succeeded — Graph does not return a direct download URL. HIGH risk: exports may contain privileged / PII content — handle per the case's chain-of-custody."
   }
 ]

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4282,5 +4282,28 @@
     "appPermissions": ["eDiscovery.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a collection search in a case. Body: displayName, description, contentQuery (KQL), dataSourceScopes ('none'|'allTenantMailboxes'|'allTenantSites'|'allCaseCustodians'|'allCaseNoncustodialDataSources')."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/custodians/{ediscoveryCustodian-id}",
+    "method": "get",
+    "toolName": "get-ediscovery-custodian",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Gets a specific custodian by ID in an eDiscovery case. Returns full details: displayName, email, status (active | released | error), holdStatus (notApplied | applied | pending | applying | removing | partial), lastIndexOperation, createdDateTime, lastModifiedDateTime. Use to verify hold status before / after applyHold / removeHold actions, or to inspect indexing progress for a specific custodian."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/custodians/{ediscoveryCustodian-id}/microsoft.graph.security.release",
+    "method": "post",
+    "toolName": "release-ediscovery-custodian",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Releases a custodian from an eDiscovery case — removes them from the case scope and removes any holds applied via this case. Empty request body. IMPORTANT: this only releases the hold applied through THIS case. If the user has holds from other eDiscovery cases or independent retention policies, those are unaffected. Audit other cases / retention before assuming release is total. Use list-ediscovery-cases to identify other cases containing the same custodian."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/custodians/{ediscoveryCustodian-id}/microsoft.graph.security.updateIndex",
+    "method": "post",
+    "toolName": "update-ediscovery-custodian-index",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Forces a re-index of a custodian's data sources (mailbox, OneDrive, SharePoint sites). Empty request body. Use when search results for this custodian are missing recent content — re-indexing pulls in items added since the last index refresh. Long-running: returns 202; track via list-case-operations / get-case-operation. Indexing duration depends on data volume (minutes for small mailboxes, hours for large ones)."
   }
 ]

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4343,5 +4343,19 @@
     "appPermissions": ["eDiscovery.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Releases legal hold on a noncustodial data source. Empty request body. POTENTIALLY DESTRUCTIVE: once hold is removed, deleted items become eligible for permanent purge per the tenant's retention policy (typically 14-30 days for mailbox dumpster, 93 days for SharePoint Site Recycle Bin). Confirm with legal counsel before releasing — items deleted while on hold but past the standard retention window WILL be purged within days of release."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/operations",
+    "method": "get",
+    "toolName": "list-case-operations",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Lists long-running operations on an eDiscovery case — search executions, hold applications, indexing jobs, reviewSet additions, exports. Each operation has action (e.g. 'estimateStatistics', 'addToReviewSet', 'export', 'applyHold'), status (notStarted | running | succeeded | failed | partiallySucceeded), percentProgress, createdDateTime, completedDateTime, resultInfo (error details if failed). Use to track async operations triggered by other tools (create-ediscovery-search, add-to-review-set, export-review-set, etc.)."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/operations/{caseOperation-id}",
+    "method": "get",
+    "toolName": "get-case-operation",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Gets a specific eDiscovery case operation by ID. Returns full status including percentProgress and resultInfo. Use to poll until status=succeeded for operations like export-review-set or update-ediscovery-custodian-index that return 202 + operation ID. For failed operations, resultInfo contains the error message."
   }
 ]

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4440,5 +4440,35 @@
     "appPermissions": ["ProtectionScopes.Compute.All"],
     "riskLevel": "low",
     "llmTip": "Computes the data protection policies and actions applicable across all users in the tenant based on current Purview policy configuration. Empty request body. Returns the list of evaluated scopes — useful for auditing which Purview DLP / sensitivity / retention policies actually apply per user / location / data type at the current point in time. Read-heavy operation (queries policy graph) but classified as POST because it triggers compute on the server side. Pairs with get-protection-scopes which returns the cached / last-computed scopes."
+  },
+  {
+    "pathPattern": "/security/triggers/retentionEvents/{retentionEvent-id}",
+    "method": "get",
+    "toolName": "get-retention-event",
+    "appPermissions": ["RecordsManagement.Read.All"],
+    "llmTip": "Gets a specific retention event by ID. Returns full details: displayName, description, eventTriggerDateTime (when the retention period started for matching labels), retentionEventType (relationship to the event type definition), createdDateTime, lastModifiedDateTime, status. Used to inspect when an event-based retention label became 'active' and started its retention period (e.g. 'employee_leaving' event triggered when an HR system signals a departure)."
+  },
+  {
+    "pathPattern": "/security/triggers/retentionEvents",
+    "method": "post",
+    "toolName": "create-retention-event",
+    "appPermissions": ["RecordsManagement.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Creates a retention event — triggers the retention period for all event-based retention labels of the linked retentionEventType. Body example: {\"displayName\":\"Employee terminated — John Smith\",\"description\":\"HR system signal 2026-05-25\",\"eventTriggerDateTime\":\"2026-05-25T17:00:00Z\",\"retentionEventType@odata.bind\":\"https://graph.microsoft.com/v1.0/security/triggersTypes/retentionEventTypes/<eventType-id>\"}. Once created, any content tagged with an event-based label that references this eventType starts its retention timer from eventTriggerDateTime. Common patterns: 'project closed' triggers retention on project documents; 'contract expired' triggers retention on contract attachments; 'employee terminated' triggers retention on HR records."
+  },
+  {
+    "pathPattern": "/security/triggerTypes/retentionEventTypes/{retentionEventType-id}",
+    "method": "get",
+    "toolName": "get-retention-event-type",
+    "appPermissions": ["RecordsManagement.Read.All"],
+    "llmTip": "Gets a specific retention event type definition by ID. Returns displayName, description, createdBy, createdDateTime, lastModifiedDateTime. Event types are the categories of events that can trigger event-based retention (e.g. 'project_closed', 'contract_terminated', 'employee_left'). Use get-retention-event-types to list available types before creating an event."
+  },
+  {
+    "pathPattern": "/security/triggerTypes/retentionEventTypes",
+    "method": "post",
+    "toolName": "create-retention-event-type",
+    "appPermissions": ["RecordsManagement.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Creates a retention event type — the category definition that event-based retention labels reference. Body example: {\"displayName\":\"Project closed\",\"description\":\"Triggered when an LCI project is marked closed in the PMO system\"}. After creation, label admins can author event-based retention labels that reference this eventType's id. Then operational scripts call create-retention-event with the same eventType to trigger retention on tagged content."
   }
 ]

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4425,5 +4425,20 @@
     "appPermissions": ["eDiscovery.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Applies review tags to all items matching a saved query. Body example: {\"tagsToAdd\":[{\"id\":\"<tag-id-1>\"},{\"id\":\"<tag-id-2>\"}],\"tagsToRemove\":[]}. Used to bulk-tag review-set items (e.g. mark all items matching a KQL filter as 'Responsive' or 'Privileged'). Tag IDs come from the tenant's review tag taxonomy (separate API). Long-running: returns 202; track via list-case-operations."
+  },
+  {
+    "pathPattern": "/security/dataSecurityAndGovernance",
+    "method": "get",
+    "toolName": "get-data-security-governance-root",
+    "appPermissions": ["InformationProtectionPolicy.Read.All"],
+    "llmTip": "Gets the root entity for Microsoft Purview Data Security Posture Management (DSPM). Returns metadata about the tenant's DSPM configuration: enabled state, last scan timestamps, related links to protectionScopes and sensitivityLabels. This is the entry point for navigating the DSPM surface — the Microsoft equivalent of third-party DSPM tools (Varonis, Defender for Cloud DSPM)."
+  },
+  {
+    "pathPattern": "/security/dataSecurityAndGovernance/protectionScopes/compute",
+    "method": "post",
+    "toolName": "compute-protection-scopes",
+    "appPermissions": ["ProtectionScopes.Compute.All"],
+    "riskLevel": "low",
+    "llmTip": "Computes the data protection policies and actions applicable across all users in the tenant based on current Purview policy configuration. Empty request body. Returns the list of evaluated scopes — useful for auditing which Purview DLP / sensitivity / retention policies actually apply per user / location / data type at the current point in time. Read-heavy operation (queries policy graph) but classified as POST because it triggers compute on the server side. Pairs with get-protection-scopes which returns the cached / last-computed scopes."
   }
 ]

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4387,5 +4387,43 @@
     "appPermissions": ["eDiscovery.ReadWrite.All"],
     "riskLevel": "high",
     "llmTip": "Exports the contents of a review set for production / forensic delivery. Body example: {\"outputName\":\"2026Q1-production\",\"description\":\"Subpoena response Jan 2026\",\"exportOptions\":\"originalFiles,fileInfo,tags\",\"exportStructure\":\"directory\"}. exportOptions: 'originalFiles' (native), 'text' (extracted text), 'pdfReplacement' (PDFs), 'tags' (review tags as CSV), 'fileInfo' (metadata CSV), 'summary'. exportStructure: 'none' (flat) | 'directory' (per-custodian) | 'pst' (mailbox-style PST per custodian). Long-running: returns 202; track via list-case-operations. Output is downloaded via the Purview portal once status=succeeded — Graph does not return a direct download URL. HIGH risk: exports may contain privileged / PII content — handle per the case's chain-of-custody."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/searches/{ediscoverySearch-id}/microsoft.graph.security.addToReviewSet",
+    "method": "post",
+    "toolName": "add-to-review-set",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Adds the results of an eDiscovery search to a review set — the canonical workflow for moving search hits into a curated review workspace. Body: {\"reviewSet\":{\"id\":\"<reviewSet-id>\"},\"additionalDataOptions\":\"linkedFiles\"}. additionalDataOptions: 'linkedFiles' (include attachments / linked SharePoint docs) | 'allItemsInFolder' (include sibling items) | 'subfolderContents'. Long-running: returns 202; track via list-case-operations (action='addToReviewSet'). Once succeeded, items are immutable in the review set — they snapshot the source content at the time of add."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets/{ediscoveryReviewSet-id}/queries",
+    "method": "get",
+    "toolName": "list-review-set-queries",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Lists saved queries (filters) on a review set. Each query has displayName, contentQuery (KQL filtering review-set items), createdDateTime. Queries are the persistent way to slice a review set — examples: 'all items tagged Responsive', 'docs from a specific custodian', 'communications matching keyword X'."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets/{ediscoveryReviewSet-id}/queries",
+    "method": "post",
+    "toolName": "create-review-set-query",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "low",
+    "llmTip": "Creates a saved query on a review set. Body example: {\"displayName\":\"Responsive items only\",\"contentQuery\":\"Tags:\\\"Responsive\\\"\"}. contentQuery is a KQL expression filtering review-set items by property (Tags, From, Subject, Author, Date, etc.) or fulltext. Use to persist a filter for repeated review / export operations."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets/{ediscoveryReviewSet-id}/queries/{ediscoveryReviewSetQuery-id}",
+    "method": "get",
+    "toolName": "get-review-set-query",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Gets a specific review-set query by ID. Returns displayName, contentQuery, createdDateTime, lastModifiedDateTime."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets/{ediscoveryReviewSet-id}/queries/{ediscoveryReviewSetQuery-id}/microsoft.graph.security.applyTags",
+    "method": "post",
+    "toolName": "apply-tags-review-set-query",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Applies review tags to all items matching a saved query. Body example: {\"tagsToAdd\":[{\"id\":\"<tag-id-1>\"},{\"id\":\"<tag-id-2>\"}],\"tagsToRemove\":[]}. Used to bulk-tag review-set items (e.g. mark all items matching a KQL filter as 'Responsive' or 'Privileged'). Tag IDs come from the tenant's review tag taxonomy (separate API). Long-running: returns 202; track via list-case-operations."
   }
 ]

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4389,12 +4389,12 @@
     "llmTip": "Exports the contents of a review set for production / forensic delivery. Body example: {\"outputName\":\"2026Q1-production\",\"description\":\"Subpoena response Jan 2026\",\"exportOptions\":\"originalFiles,fileInfo,tags\",\"exportStructure\":\"directory\"}. exportOptions: 'originalFiles' (native), 'text' (extracted text), 'pdfReplacement' (PDFs), 'tags' (review tags as CSV), 'fileInfo' (metadata CSV), 'summary'. exportStructure: 'none' (flat) | 'directory' (per-custodian) | 'pst' (mailbox-style PST per custodian). Long-running: returns 202; track via list-case-operations. Output is downloaded via the Purview portal once status=succeeded — Graph does not return a direct download URL. HIGH risk: exports may contain privileged / PII content — handle per the case's chain-of-custody."
   },
   {
-    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/searches/{ediscoverySearch-id}/microsoft.graph.security.addToReviewSet",
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets/{ediscoveryReviewSet-id}/microsoft.graph.security.addToReviewSet",
     "method": "post",
     "toolName": "add-to-review-set",
     "appPermissions": ["eDiscovery.ReadWrite.All"],
     "riskLevel": "medium",
-    "llmTip": "Adds the results of an eDiscovery search to a review set — the canonical workflow for moving search hits into a curated review workspace. Body: {\"reviewSet\":{\"id\":\"<reviewSet-id>\"},\"additionalDataOptions\":\"linkedFiles\"}. additionalDataOptions: 'linkedFiles' (include attachments / linked SharePoint docs) | 'allItemsInFolder' (include sibling items) | 'subfolderContents'. Long-running: returns 202; track via list-case-operations (action='addToReviewSet'). Once succeeded, items are immutable in the review set — they snapshot the source content at the time of add."
+    "llmTip": "Adds the results of an eDiscovery search to a review set — the canonical workflow for moving search hits into a curated review workspace. Body: {\"search\":{\"id\":\"<ediscoverySearch-id>\"},\"additionalDataOptions\":\"linkedFiles\",\"itemsToInclude\":\"searchHits\",\"cloudAttachmentVersion\":\"latest\",\"documentVersion\":\"latest\"}. additionalDataOptions: 'linkedFiles' (include attachments / linked SharePoint docs) | 'allItemsInFolder' (include sibling items) | 'subfolderContents'. Long-running: returns 202; track via list-case-operations (action='addToReviewSet'). Once succeeded, items are immutable in the review set — they snapshot the source content at the time of add. NOTE: this is an action on the REVIEW SET (parent path), not on the search — the search is referenced in the body."
   },
   {
     "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/reviewSets/{ediscoveryReviewSet-id}/queries",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4305,5 +4305,43 @@
     "appPermissions": ["eDiscovery.ReadWrite.All"],
     "riskLevel": "low",
     "llmTip": "Forces a re-index of a custodian's data sources (mailbox, OneDrive, SharePoint sites). Empty request body. Use when search results for this custodian are missing recent content — re-indexing pulls in items added since the last index refresh. Long-running: returns 202; track via list-case-operations / get-case-operation. Indexing duration depends on data volume (minutes for small mailboxes, hours for large ones)."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/noncustodialDataSources",
+    "method": "get",
+    "toolName": "list-ediscovery-noncustodial-data-sources",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Lists noncustodial data sources in an eDiscovery case — mailbox / SharePoint site / OneDrive locations that are part of the case scope WITHOUT an assigned custodian (no human user owner). Examples: shared mailboxes, departmental SharePoint sites, group OneDrive locations. Each has displayName, dataSource (the underlying location), holdStatus, lastIndexOperation, status. Use to scope a case to organizational data not tied to a specific employee. Supports $filter, $top, $skip, $select, $expand, $orderby."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/noncustodialDataSources",
+    "method": "post",
+    "toolName": "create-ediscovery-noncustodial-data-source",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Adds a noncustodial data source to an eDiscovery case. Body example: {\"applyHoldToSource\":true,\"dataSource\":{\"@odata.type\":\"#microsoft.graph.security.siteSource\",\"site\":{\"webUrl\":\"https://contoso.sharepoint.com/sites/legal\"}}} for a SharePoint site, or {\"dataSource\":{\"@odata.type\":\"#microsoft.graph.security.unifiedGroupSource\",\"group\":{\"id\":\"<group-id>\"}}} for an M365 group. dataSource @odata.type: siteSource | unifiedGroupSource | userSource (shared mailbox). applyHoldToSource=true puts the source on legal hold immediately upon creation."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/noncustodialDataSources/{ediscoveryNoncustodialDataSource-id}",
+    "method": "get",
+    "toolName": "get-ediscovery-noncustodial-data-source",
+    "appPermissions": ["eDiscovery.Read.All"],
+    "llmTip": "Gets a specific noncustodial data source by ID. Returns full details: dataSource (underlying location with @odata.type), holdStatus (notApplied | applied | pending | applying | removing | partial), status, lastIndexOperation, createdDateTime, releasedDateTime. Use to verify hold status before / after applyHold / removeHold actions."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/noncustodialDataSources/{ediscoveryNoncustodialDataSource-id}/microsoft.graph.security.applyHold",
+    "method": "post",
+    "toolName": "apply-hold-ediscovery-noncustodial-data-source",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Places a noncustodial data source on legal hold — preserves all content in the source from deletion / modification until release. Empty request body (or omit). Audit user-visible behavior: items the user attempts to delete are kept in the recoverable items folder (mailbox) or preservation hold library (SharePoint/OneDrive) — accessible to admin / eDiscovery searches but invisible to the user. Required for legal preservation per Sedona Conference / FRCP rules."
+  },
+  {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/noncustodialDataSources/{ediscoveryNoncustodialDataSource-id}/microsoft.graph.security.removeHold",
+    "method": "post",
+    "toolName": "remove-hold-ediscovery-noncustodial-data-source",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "high",
+    "llmTip": "Releases legal hold on a noncustodial data source. Empty request body. POTENTIALLY DESTRUCTIVE: once hold is removed, deleted items become eligible for permanent purge per the tenant's retention policy (typically 14-30 days for mailbox dumpster, 93 days for SharePoint Site Recycle Bin). Confirm with legal counsel before releasing — items deleted while on hold but past the standard retention window WILL be purged within days of release."
   }
 ]


### PR DESCRIPTION
Continues the P3 family-by-family expansion (DfI → **Purview** → Teams advanced → Copilot admin, one PR each). Builds on PR #116 (P3-DfI).

Expands Microsoft Purview administration coverage from 15 tools to **40 tools** — adds 25 new tools across 4 sub-themes covering advanced eDiscovery v3 case management, Data Security Posture Management (DSPM), and event-based retention triggers.

## Summary

- **25 new tools** for `/security/cases/ediscoveryCases/*`, `/security/dataSecurityAndGovernance/*`, `/security/triggers/*`, `/security/triggerTypes/*`
- **9 commits** organized by sub-theme (7 features + 1 fix + 1 docs/version)
- **2 new Graph permissions** required (must be admin-consented before tools work end-to-end)
- All 25 tools target Graph v1.0 (stable)
- Function path notation with `()` and namespace-prefixed actions (`microsoft.graph.security.applyHold`, `addToReviewSet`, `export`, etc.) pass through to Graph as-is
- `npm run verify` passes: 195/195 tests, lint clean, prettier clean, build OK
- Version: `0.10.0` → `0.11.0` (minor, additive)

## Motivation

Purview was 15 tools — basic eDiscovery cases CRUD + custodians + searches + 2 list-only retention events tools. Missing:

- Drill into a specific custodian and release / re-index it
- Add noncustodial data sources (shared mailboxes, departmental sites, group OneDrive)
- Track long-running operations (search executions, exports, holds)
- Manage review sets (create, get, export)
- Author review-set queries and bulk-tag matching items
- Trigger DSPM policy compute (Microsoft-native DSPM is the Varonis / Defender for Cloud DSPM equivalent)
- Get specific retention events / event types
- Create event-based retention triggers

This PR closes those gaps and brings the eDiscovery v3 workflow to feature parity with the Purview portal: case → custodians + noncustodial sources → search → reviewSet → query → tags → export.

## Commits (atomic by sub-theme)

| Commit | Sub-theme | Tools | Highest risk |
|---|---|---|---|
| `8fc2c1a` | eDiscovery custodian advanced | 3 | medium (release) |
| `ab5c924` | eDiscovery noncustodial data sources | 5 | **high** (remove-hold) |
| `37eff6e` | eDiscovery case operations | 2 | (read-only) |
| `1845e2e` | eDiscovery review sets | 4 | **high** (export-review-set) |
| `25bce7d` | eDiscovery review set queries + addToReviewSet | 5 | medium |
| `f19149b` | fix: correct add-to-review-set path | — | — |
| `e26294d` | DSPM compute + root | 2 | low |
| `8f5fdf4` | Retention events expansion | 4 | medium |
| `2c84d27` | docs + bump 0.11.0 | — | — |

`f19149b` was caught by `npm run generate` validation — the previous commit had the `addToReviewSet` action on the search parent path, but it's actually on the review set parent (the search is passed in the body). Fix kept as a separate commit per the repo convention (never amend committed work).

## Highest-impact tools

**`remove-hold-ediscovery-noncustodial-data-source`** (high) — once hold is removed, deleted items become eligible for permanent purge per the retention window (14-30 days mailbox dumpster, 93 days SharePoint Recycle Bin). Confirm with legal counsel before releasing.

**`export-review-set`** (high) — exports native files / extracted text / PDFs / metadata CSVs / review tags. Output may contain privileged or PII content; handle per the case's chain-of-custody. Long-running async; output downloaded via the Purview portal.

## New Graph permissions required

Must be admin-consented on the app registration **before any of the new write tools work end-to-end**:

- `ProtectionScopes.Compute.All` — for `compute-protection-scopes`
- `RecordsManagement.ReadWrite.All` — for `create-retention-event` and `create-retention-event-type`

Already-declared permissions covering most of the new tools:

- `eDiscovery.Read.All` — 18 of the new eDiscovery reads
- `eDiscovery.ReadWrite.All` — 7 of the new eDiscovery writes
- `InformationProtectionPolicy.Read.All` — `get-data-security-governance-root`
- `RecordsManagement.Read.All` — `get-retention-event` + `get-retention-event-type`

Without consent of the 2 new permissions, `compute-protection-scopes` and the 2 retention-event creates return `403 Insufficient privileges`. The other 22 new tools work with the already-declared permissions.

## Tools added (25)

### eDiscovery custodian admin (3)

- `get-ediscovery-custodian` (GET)
- `release-ediscovery-custodian` (POST .../release, medium)
- `update-ediscovery-custodian-index` (POST .../updateIndex, low)

### eDiscovery noncustodial data sources (5)

- `list-ediscovery-noncustodial-data-sources` (GET)
- `create-ediscovery-noncustodial-data-source` (POST, medium)
- `get-ediscovery-noncustodial-data-source` (GET)
- `apply-hold-ediscovery-noncustodial-data-source` (POST .../applyHold, medium)
- `remove-hold-ediscovery-noncustodial-data-source` (POST .../removeHold, **high**)

### eDiscovery case operations tracking (2)

- `list-case-operations` (GET)
- `get-case-operation` (GET)

### eDiscovery review sets (4)

- `list-review-sets` (GET)
- `create-review-set` (POST, low)
- `get-review-set` (GET)
- `export-review-set` (POST .../export, **high**)

### eDiscovery review set queries + addToReviewSet (5)

- `add-to-review-set` (POST .../addToReviewSet, medium)
- `list-review-set-queries` (GET)
- `create-review-set-query` (POST, low)
- `get-review-set-query` (GET)
- `apply-tags-review-set-query` (POST .../applyTags, medium)

### DSPM (2)

- `get-data-security-governance-root` (GET)
- `compute-protection-scopes` (POST .../compute, low)

### Retention events expansion (4)

- `get-retention-event` (GET)
- `create-retention-event` (POST, medium)
- `get-retention-event-type` (GET)
- `create-retention-event-type` (POST, medium)

## Out of scope (deferred)

Intentionally not included in this PR to keep the diff reviewable:

- Sub-resources of custodians: `siteSources` / `userSources` / `unifiedGroupSources` CRUD per custodian (~12-15 additional tools — usually managed implicitly via the dataSource @odata.type on `create-ediscovery-noncustodial-data-source` or via the Purview portal)
- `export-review-set-query` (POST on a specific query's `/export` — most users export the full review set instead)
- DSPM `processContentAsync` (DLP content scanning) — complex async API with file upload semantics, separate PR
- DSPM `sensitivityLabels` via `/security/dataSecurityAndGovernance/sensitivityLabels` — redundant with the existing 5 sensitivity-label tools under `/security/informationProtection`

## Testing

- `npm run verify` passes (generate + lint + format + build + test): 195/195 tests
- Local sanity: all 25 new tool aliases present in `src/generated/client.ts`
- One path correction caught by validation, fixed in a separate commit (kept history clean — never amend per repo convention)
- No tenant-side validation in this PR — will happen post-merge in the LCI deployment cycle (and gated by consent of the 2 new permissions)

## Backward compatibility

- No breaking changes
- All existing tools unaffected — the 15 pre-existing Purview tools keep their permissions
- 195/195 existing tests pass

## Next P3 PRs (follow-ups in separate PRs)

- Teams advanced (call analytics, meeting recordings, attendance reports, ~10-15 tools)
- Copilot admin (audit, usage analytics, prompt analytics, agent gating, ~5-10 tools)

Each will follow the same pattern: atomic commits by sub-theme, separate Graph permission declarations as needed.