### PR TITLE
fix(security): correct DfI permission names that don't exist in Graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,45 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.11.1] — 2026-05-26
+
+### Fixed — correct DfI permission names that don't exist in Microsoft Graph
+
+Three permission names declared in `endpoints.json` were not real Microsoft Graph application permissions — discovered while running the admin-consent script against the LCI prod tenant. The MCP server uses these strings for `--list-permissions` output only (actual gating is server-side on Graph against the consented permissions), so the affected tools were already working in prod after the correct permissions were consented out-of-band.
+
+Corrections (4 tools, 3 permission name changes):
+
+| Tool                          | Before (invalid)                           | After (real Graph permission)                |
+| ----------------------------- | ------------------------------------------ | -------------------------------------------- |
+| `get-auto-auditing-config`    | `SecurityIdentitiesSettings.Read.All`      | `SecurityIdentitiesAutoConfig.Read.All`      |
+| `update-auto-auditing-config` | `SecurityIdentitiesSettings.ReadWrite.All` | `SecurityIdentitiesAutoConfig.ReadWrite.All` |
+| `list-identity-accounts`      | `SecurityIdentitiesActions.Read.All`       | `SecurityIdentitiesAccount.Read.All`         |
+| `get-identity-account`        | `SecurityIdentitiesActions.Read.All`       | `SecurityIdentitiesAccount.Read.All`         |
+
+### Refactored — use precise SecurityIdentitiesMigration.\* permissions for sensorMigration tools
+
+The 3 sensorMigration tools shipped in 0.10.0 declared the broader `SecurityIdentitiesSensors.*` permissions. Microsoft publishes the more precise `SecurityIdentitiesMigration.*` scopes specifically for `/security/identities/sensorMigration` endpoints — switching to those reduces the permission surface granted to the app.
+
+| Tool                     | Before (broad)                            | After (precise)                             |
+| ------------------------ | ----------------------------------------- | ------------------------------------------- |
+| `list-sensor-migrations` | `SecurityIdentitiesSensors.Read.All`      | `SecurityIdentitiesMigration.Read.All`      |
+| `get-sensor-migration`   | `SecurityIdentitiesSensors.Read.All`      | `SecurityIdentitiesMigration.Read.All`      |
+| `migrate-sensors`        | `SecurityIdentitiesSensors.ReadWrite.All` | `SecurityIdentitiesMigration.ReadWrite.All` |
+
+The `SecurityIdentitiesSensors.*` permissions remain declared on the other 5 sensor tools (drill-down, update, deployment-key get/regenerate) which legitimately operate on the sensors collection itself.
+
+### Net new Graph permissions required (vs 0.11.0)
+
+To support the 7 fixed/refactored tools, these additional application permissions must be admin-consented on the app registration:
+
+- `SecurityIdentitiesAutoConfig.Read.All`
+- `SecurityIdentitiesAutoConfig.ReadWrite.All`
+- `SecurityIdentitiesAccount.Read.All`
+- `SecurityIdentitiesMigration.Read.All`
+- `SecurityIdentitiesMigration.ReadWrite.All`
+
+(The non-existent `SecurityIdentitiesSettings.*` and `SecurityIdentitiesActions.Read.All` listed in 0.10.0 release notes were never grantable in the first place and are removed from the requirements.)
+
 ## [0.11.0] — 2026-05-25
 
 ### Added — Microsoft Purview expansion (596 tools)

--- a/README.md
+++ b/README.md
@@ -1127,14 +1127,13 @@ Notes:
 - **`activate-sensor-candidates`** triggers sensor installation on detected hosts using the deployment access key flow. Verify with `get-sensor-candidate` first — wrong serverId installs on the wrong host.
 - **`update-auto-auditing-config`** with `enabled=true` makes DfI enforce the recommended Windows advanced audit policies on every sensor host (revert local admin overrides on next heartbeat) — recommended for production.
 
-New Graph permissions required since v0.10.0 (must be consented on the app registration):
+New Graph permissions required since v0.10.0 / 0.11.1 (must be consented on the app registration):
 
-- `SecurityIdentitiesSensors.Read.All`
-- `SecurityIdentitiesSensors.ReadWrite.All`
-- `SecurityIdentitiesSettings.Read.All`
-- `SecurityIdentitiesSettings.ReadWrite.All`
-- `SecurityIdentitiesActions.Read.All`
-- `SecurityIdentitiesActions.ReadWrite.All`
+- `SecurityIdentitiesSensors.Read.All` + `SecurityIdentitiesSensors.ReadWrite.All` (sensors mgmt)
+- `SecurityIdentitiesAutoConfig.Read.All` + `SecurityIdentitiesAutoConfig.ReadWrite.All` (autoAuditingConfiguration)
+- `SecurityIdentitiesAccount.Read.All` (identityAccounts list/get)
+- `SecurityIdentitiesActions.ReadWrite.All` (identityAccounts invokeAction — break-glass)
+- `SecurityIdentitiesMigration.Read.All` + `SecurityIdentitiesMigration.ReadWrite.All` (sensorMigration, beta)
 
 ### Threat intelligence+ (7)
 
@@ -1341,10 +1340,11 @@ RoleManagement.Read.Directory
 RoleManagementPolicy.Read.Directory
 SecurityAlert.Read.All
 SecurityEvents.Read.All
-SecurityIdentitiesActions.Read.All
+SecurityIdentitiesAccount.Read.All
+SecurityIdentitiesAutoConfig.Read.All
 SecurityIdentitiesHealth.Read.All
+SecurityIdentitiesMigration.Read.All
 SecurityIdentitiesSensors.Read.All
-SecurityIdentitiesSettings.Read.All
 SecurityIncident.Read.All
 ServiceHealth.Read.All
 ServiceMessage.Read.All
@@ -1401,8 +1401,9 @@ RoleManagement.ReadWrite.Directory
 RoleManagementPolicy.ReadWrite.Directory
 SecurityAlert.ReadWrite.All
 SecurityIdentitiesActions.ReadWrite.All
+SecurityIdentitiesAutoConfig.ReadWrite.All
+SecurityIdentitiesMigration.ReadWrite.All
 SecurityIdentitiesSensors.ReadWrite.All
-SecurityIdentitiesSettings.ReadWrite.All
 SecurityIncident.ReadWrite.All
 Sites.ReadWrite.All
 Team.Create

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
   "mcpName": "io.github.okapi-ca/ms-365-admin",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2220,14 +2220,14 @@
     "pathPattern": "/security/identities/settings/autoAuditingConfiguration",
     "method": "get",
     "toolName": "get-auto-auditing-config",
-    "appPermissions": ["SecurityIdentitiesSettings.Read.All"],
+    "appPermissions": ["SecurityIdentitiesAutoConfig.Read.All"],
     "llmTip": "Gets the Defender for Identity auto-auditing configuration. Auto-auditing controls whether DfI automatically configures the recommended Windows audit policies (advanced audit policies on DCs: 'Audit Directory Service Changes', 'Audit Computer Account Management', etc.) on sensors and reverts them if changed locally. Returns enabled (boolean) and lastUpdatedDateTime. Recommended state for production tenants: enabled=true (prevents drift in audit configuration that degrades detection coverage)."
   },
   {
     "pathPattern": "/security/identities/settings/autoAuditingConfiguration",
     "method": "patch",
     "toolName": "update-auto-auditing-config",
-    "appPermissions": ["SecurityIdentitiesSettings.ReadWrite.All"],
+    "appPermissions": ["SecurityIdentitiesAutoConfig.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Updates the Defender for Identity auto-auditing configuration (partial update). Body example: {\"enabled\":true}. Setting enabled=true causes DfI to enforce the recommended Windows advanced audit policies on every sensor host — if a local admin changes them on the DC, DfI reverts the change on its next sync. Disable only for tenants with custom audit policy frameworks (where DfI's enforcement would conflict). Changes propagate to sensors on their next heartbeat."
   },
@@ -2235,14 +2235,14 @@
     "pathPattern": "/security/identities/identityAccounts",
     "method": "get",
     "toolName": "list-identity-accounts",
-    "appPermissions": ["SecurityIdentitiesActions.Read.All"],
+    "appPermissions": ["SecurityIdentitiesAccount.Read.All"],
     "llmTip": "Lists identity accounts observed by Microsoft Defender for Identity — synced AD / Entra ID / Okta accounts that DfI has correlated with detected activity. Each has accountId, displayName, identityProvider (entraID | activeDirectory | okta), upn / sAMAccountName, domain, isSensitive (privileged), and lastActivityDateTime. Use to identify the canonical DfI account-id needed for invoke-identity-account-action (which requires the DfI identityAccountsId, NOT the AD objectGuid). Supports $filter, $top, $skip, $select, $expand, $orderby, $count."
   },
   {
     "pathPattern": "/security/identities/identityAccounts/{identityAccounts-id}",
     "method": "get",
     "toolName": "get-identity-account",
-    "appPermissions": ["SecurityIdentitiesActions.Read.All"],
+    "appPermissions": ["SecurityIdentitiesAccount.Read.All"],
     "llmTip": "Gets a specific identity account by DfI identityAccounts id. Returns full details including identityProvider, sourceId (the AD objectGuid / Entra objectId / Okta id), upn, displayName, lastActivityDateTime, sensitivity flags, group memberships observed by DfI. Use to confirm an account's identityProvider before calling invoke-identity-account-action — the action set differs by provider (e.g. forcePasswordReset works for activeDirectory only)."
   },
   {

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2195,7 +2195,7 @@
     "pathPattern": "/security/identities/sensorMigration",
     "method": "get",
     "toolName": "list-sensor-migrations",
-    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "appPermissions": ["SecurityIdentitiesMigration.Read.All"],
     "apiVersion": "beta",
     "llmTip": "Lists Microsoft Defender for Identity sensor migration jobs — tracks upgrades of sensors from legacy AATP (Azure Advanced Threat Protection) workspace to the unified Defender XDR sensor architecture. Each migration has sensorId, sourceVersion, targetVersion, status (pending | inProgress | completed | failed), startedDateTime, completedDateTime. Use to monitor an in-flight migration wave. Beta-only endpoint."
   },
@@ -2203,7 +2203,7 @@
     "pathPattern": "/security/identities/sensorMigration/{sensorMigration-id}",
     "method": "get",
     "toolName": "get-sensor-migration",
-    "appPermissions": ["SecurityIdentitiesSensors.Read.All"],
+    "appPermissions": ["SecurityIdentitiesMigration.Read.All"],
     "apiVersion": "beta",
     "llmTip": "Gets a specific sensor migration job by ID. Returns the full migration trace: source/target versions, current step, errors (if status=failed), per-step timestamps. Use to investigate why a specific migration is stuck or failed. Beta-only endpoint."
   },
@@ -2211,7 +2211,7 @@
     "pathPattern": "/security/identities/sensorMigration/microsoft.graph.security.migrate",
     "method": "post",
     "toolName": "migrate-sensors",
-    "appPermissions": ["SecurityIdentitiesSensors.ReadWrite.All"],
+    "appPermissions": ["SecurityIdentitiesMigration.ReadWrite.All"],
     "riskLevel": "high",
     "apiVersion": "beta",
     "llmTip": "Triggers migration of one or more Defender for Identity sensors to the unified Defender XDR architecture. Body: {\"sensorIds\":[\"<sensor-id-1>\",\"<sensor-id-2>\"]}. POTENTIALLY DISRUPTIVE: the migration restarts the sensor service on the target host — there's a brief window (~minutes) where the DC's network traffic is not being captured. Schedule during a maintenance window for production DCs. Track via list-sensor-migrations / get-sensor-migration. Failed migrations require manual remediation on the host. Beta-only endpoint."


### PR DESCRIPTION
Three application permission names declared in `endpoints.json` were not real Microsoft Graph application permissions — discovered while running the admin-consent script for v0.11.0 against the LCI prod tenant.

## Impact

**Runtime: none.** The MCP server uses the `appPermissions` strings in `endpoints.json` for `--list-permissions` output only — actual gating is server-side on Graph, against the permissions consented on the app registration. Tools whose declared permission didn't exist still worked in prod after the correct permissions were consented out-of-band.

**Documentation: stale.** Any operator generating a consent list from `--list-permissions` would have asked for permissions Microsoft refuses to grant. This PR realigns the docs with reality.

**Permission surface: tightened.** The 3 sensorMigration tools previously asked for the broad `SecurityIdentitiesSensors.*` scope; Microsoft publishes a narrower `SecurityIdentitiesMigration.*` scope specifically for these endpoints. Switching shrinks the granted surface.

## Corrections

### Fixed permission names (4 tools, 3 invalid → valid)

| Tool | Before (invalid) | After (real Graph permission) |
|---|---|---|
| `get-auto-auditing-config` | `SecurityIdentitiesSettings.Read.All` | `SecurityIdentitiesAutoConfig.Read.All` |
| `update-auto-auditing-config` | `SecurityIdentitiesSettings.ReadWrite.All` | `SecurityIdentitiesAutoConfig.ReadWrite.All` |
| `list-identity-accounts` | `SecurityIdentitiesActions.Read.All` | `SecurityIdentitiesAccount.Read.All` |
| `get-identity-account` | `SecurityIdentitiesActions.Read.All` | `SecurityIdentitiesAccount.Read.All` |

`invoke-identity-account-action` keeps `SecurityIdentitiesActions.ReadWrite.All` which IS a real permission.

### Refactored to precise Migration scope (3 tools, 2 broad → narrow)

| Tool | Before (broad) | After (precise) |
|---|---|---|
| `list-sensor-migrations` | `SecurityIdentitiesSensors.Read.All` | `SecurityIdentitiesMigration.Read.All` |
| `get-sensor-migration` | `SecurityIdentitiesSensors.Read.All` | `SecurityIdentitiesMigration.Read.All` |
| `migrate-sensors` | `SecurityIdentitiesSensors.ReadWrite.All` | `SecurityIdentitiesMigration.ReadWrite.All` |

The `SecurityIdentitiesSensors.*` scopes remain declared on the other 5 sensor tools (drill-down, update, deployment-key get/regenerate) which legitimately operate on the sensors collection.

## Net new Graph permissions required (vs 0.11.0)

To support the 7 fixed/refactored tools, these additional application permissions must be admin-consented:

- `SecurityIdentitiesAutoConfig.Read.All`
- `SecurityIdentitiesAutoConfig.ReadWrite.All`
- `SecurityIdentitiesAccount.Read.All`
- `SecurityIdentitiesMigration.Read.All`
- `SecurityIdentitiesMigration.ReadWrite.All`

The 3 stale names (`Settings.*`, `Actions.Read.All`) listed in 0.10.0's release notes were never grantable in the first place and are removed from the requirements.

On the **LCI prod app registration** (`86f46c1e-c99c-4ea7-bd2e-4e90da46ae21`), all 5 of these correct permissions have already been admin-consented as part of the operational deployment cycle for v0.10.0 / 0.11.0 — so the 7 affected tools function end-to-end in prod despite the previous misnaming.

## Commits (atomic)

1. `62af3f7` — `fix(security): correct DfI permission names that don't exist in Graph` (4 tools)
2. `779249f` — `refactor(security): use precise SecurityIdentitiesMigration.* perms` (3 tools)
3. `eca08cd` — `docs(release): bump to 0.11.1 with permission name corrections` (CHANGELOG + README + package.json)

## Testing

- `npm run verify` passes: 195/195 tests, lint clean, prettier clean, build OK
- Validated the 5 corrected permission names exist on the Microsoft Graph SP by enumerating `$graphSp.appRoles` from `Invoke-MgGraphRequest`
- Validated they are admin-consented on LCI prod app reg via the deployment script's `appRoleAssignments` enumeration

## Backward compatibility

- No runtime breaking change — tools that were working continue to work
- No new tools added or removed
- Operators consenting on a fresh app registration must include the 5 new permissions (the 3 stale names removed)
- 195/195 existing tests pass

## Version

`0.11.0` → `0.11.1` (patch — documentation correction + permission surface tightening, no new functionality)