### PR TITLE
feat(teams): Teams advanced — meeting attendance + deleted chats (7 tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ Tool counts in parentheses indicate the cumulative total after the change.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-05-26
+
+### Added — Teams advanced: meeting attendance + deleted chats (603 tools)
+
+Seven new tools for Teams admin scenarios that are NOT covered by the user-delegated productivity flow (e.g. the sibling `ms365-advanced` MCP). Both sub-themes operate on data the calling admin is NOT a participant of — meetings of arbitrary users, chats deleted tenant-wide.
+
+**Online meeting drill-down + attendance reports (4 tools)** — for HR audits, GDPR / Loi 25 subject-rights requests, compliance investigations:
+
+- `get-user-online-meeting` (GET `/users/{user-id}/onlineMeetings/{onlineMeeting-id}`)
+- `list-user-meeting-attendance-reports` (GET .../attendanceReports)
+- `get-user-meeting-attendance-report` (GET .../attendanceReports/{id})
+- `list-user-meeting-attendance-records` (GET .../attendanceRecords)
+
+**Deleted chats restore (3 tools)** — admin-only recovery flow:
+
+- `list-deleted-chats` (GET /teamwork/deletedChats)
+- `get-deleted-chat` (GET by ID)
+- `undo-delete-chat` (POST .../undoDelete, medium)
+
+### IMPORTANT — Application Access Policy required for meeting tools
+
+The 4 meeting tools target the app-only path `/users/{user-id}/onlineMeetings/*` which requires a tenant-level **Application Access Policy** explicitly granted to each target user via PowerShell:
+
+```powershell
+New-CsApplicationAccessPolicy -Identity "ms365-admin-mcp" -AppIds "<app-id>" -Description "Targeted meeting access"
+Grant-CsApplicationAccessPolicy -PolicyName "ms365-admin-mcp" -Identity <target-user-upn>
+```
+
+Without that policy, requests return 403 even with `OnlineMeetings.Read.All` + `OnlineMeetingArtifact.Read.All` consented. This is intentional: it gates access at the user level rather than tenant-wide, supporting targeted-investigation patterns without broad surveillance capability.
+
+For LCI's use case, the recommended pattern is to grant the policy only on demand during a specific investigation (HR, legal, compliance), and revoke after.
+
+### New Graph permissions required
+
+Must be admin-consented on the app registration (none of these were declared prior to 0.12.0):
+
+- `OnlineMeetings.Read.All` — for the meeting object metadata
+- `OnlineMeetingArtifact.Read.All` — for attendance reports + records
+- `Chat.ManageDeletion.All` — for listing / restoring deleted chats
+
+### Notes
+
+- All 7 new tools target Graph v1.0 (stable).
+- `undo-delete-chat` is classified `medium` (not `high`) because the operation is reversible — the chat returns to its original state with all original participants, no permissions escalation, no data corruption. The `medium` rating reflects the surprise-factor for participants who expected deletion to be permanent.
+- 195/195 tests still pass, no regressions on existing 596 tools.
+
 ## [0.11.1] — 2026-05-26
 
 ### Fixed — correct DfI permission names that don't exist in Microsoft Graph

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built on the architecture and endpoint-driven design pioneered by [Softeria/ms-3
 
 ## Features
 
-- **596 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **macOS custom attribute scripts**, **assignment filters**, **Remediations**, **Windows PowerShell scripts**, **custom compliance scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, **Defender for Identity (sensors, candidates, migration, identity accounts, audit policy)**, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, **eDiscovery v3 (cases, custodians, noncustodial data sources, review sets, queries, exports, operations)**, **Purview DSPM (protection scopes)**, **event-based retention triggers**, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
+- **603 tools** covering security, audit, identity, app credentials, guest users, Exchange, Intune (devices, apps, MAM, reports, **macOS Platform Scripts**, **macOS custom attribute scripts**, **assignment filters**, **Remediations**, **Windows PowerShell scripts**, **custom compliance scripts**), governance (PIM, access reviews, entitlement, lifecycle), compliance, threat intelligence, advanced hunting, **Defender for Identity (sensors, candidates, migration, identity accounts, audit policy)**, Copilot admin, custom security attributes, LAPS, policies, reports, incident response, **eDiscovery v3 (cases, custodians, noncustodial data sources, review sets, queries, exports, operations)**, **Purview DSPM (protection scopes)**, **event-based retention triggers**, **Teams online meeting attendance reports (app-only with Application Access Policy)**, **deleted chats restore (admin recovery flow)**, Cloud PC, call records, Universal Print, information protection, SharePoint admin, and records management
 - **Application permissions** (client credentials) — no user interaction required
 - **Read-only by default** — write operations require explicit `--allow-writes`
 - **Risk classification** on write tools (low/medium/high/critical)
@@ -1296,6 +1296,7 @@ AttackSimulation.Read.All
 AuditLog.Read.All
 BitlockerKey.Read.All
 CallRecords.Read.All
+Chat.ManageDeletion.All
 Channel.ReadBasic.All
 CloudPC.Read.All
 ConsentRequest.Read.All
@@ -1324,6 +1325,8 @@ IdentityUserFlow.Read.All
 InformationProtectionPolicy.Read.All
 LifecycleWorkflows.Read.All
 MailboxSettings.Read
+OnlineMeetingArtifact.Read.All
+OnlineMeetings.Read.All
 OnPremDirectorySynchronization.Read.All
 Organization.Read.All
 Policy.Read.All

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@okapi-ca/ms-365-admin-mcp-server",
   "mcpName": "io.github.okapi-ca/ms-365-admin",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "A Model Context Protocol (MCP) server for Microsoft 365 admin operations via Graph API application permissions",
   "type": "module",
   "main": "dist/index.js",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4498,5 +4498,27 @@
     "toolName": "list-user-meeting-attendance-records",
     "appPermissions": ["OnlineMeetingArtifact.Read.All"],
     "llmTip": "Lists individual attendance records for an attendance report — one record per participant per join session. Each record has identity (UPN/displayName), emailAddress, role (organizer | presenter | attendee), totalAttendanceInSeconds (cumulative across all joins for this report), and attendanceIntervals (array of {joinDateTime, leaveDateTime, durationInSeconds} — useful for detecting drops/rejoins). Tip: it's more efficient to use get-user-meeting-attendance-report with $expand=attendanceRecords than to call this endpoint separately. REQUIRES Application Access Policy on the target user."
+  },
+  {
+    "pathPattern": "/teamwork/deletedChats",
+    "method": "get",
+    "toolName": "list-deleted-chats",
+    "appPermissions": ["Chat.ManageDeletion.All"],
+    "llmTip": "Lists Teams chats that have been soft-deleted tenant-wide — chats deleted by users (or by deletion policies) but still recoverable. Each has id (the chat-id, immutable across delete/restore), chatType (oneOnOne | group | meeting), topic (display name for group/meeting chats), createdDateTime, lastMessagePreview (snippet of last message before deletion), deletedDateTime. Retention window: typically 30 days before Microsoft purges deleted chats permanently. Use to audit recent chat deletions or identify chats to restore via undo-delete-chat. Supports $filter (e.g. on deletedDateTime), $top, $skip, $orderby."
+  },
+  {
+    "pathPattern": "/teamwork/deletedChats/{deletedChat-id}",
+    "method": "get",
+    "toolName": "get-deleted-chat",
+    "appPermissions": ["Chat.ManageDeletion.All"],
+    "llmTip": "Gets a specific deleted Teams chat by ID. Returns the same fields as list-deleted-chats plus members (snapshot of participants at deletion time) and viewpoint (per-caller chat state). Use before calling undo-delete-chat to confirm the chat identity and the participants who will regain access on restore."
+  },
+  {
+    "pathPattern": "/teamwork/deletedChats/{deletedChat-id}/undoDelete",
+    "method": "post",
+    "toolName": "undo-delete-chat",
+    "appPermissions": ["Chat.ManageDeletion.All"],
+    "riskLevel": "medium",
+    "llmTip": "Restores a soft-deleted Teams chat to active state. Empty request body. All original participants regain access; the chat reappears in their Teams client. IMPORTANT: this operation is NOT supported for non-admin users (per Microsoft docs) — it's an admin recovery flow only. CONSIDERATIONS: (1) participants who left the organization between delete and restore may have lost access independently; (2) message history is preserved as it was at deletion time, not subsequent activity (deleted chats accept no new messages); (3) consider notifying participants before restoring sensitive chats — they may have expected deletion to be permanent. Returns 204 on success."
   }
 ]

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4470,5 +4470,33 @@
     "appPermissions": ["RecordsManagement.ReadWrite.All"],
     "riskLevel": "medium",
     "llmTip": "Creates a retention event type — the category definition that event-based retention labels reference. Body example: {\"displayName\":\"Project closed\",\"description\":\"Triggered when an LCI project is marked closed in the PMO system\"}. After creation, label admins can author event-based retention labels that reference this eventType's id. Then operational scripts call create-retention-event with the same eventType to trigger retention on tagged content."
+  },
+  {
+    "pathPattern": "/users/{user-id}/onlineMeetings/{onlineMeeting-id}",
+    "method": "get",
+    "toolName": "get-user-online-meeting",
+    "appPermissions": ["OnlineMeetings.Read.All"],
+    "llmTip": "Gets a Teams online meeting on behalf of a specific user (app-only path). Returns subject, organizer, startDateTime / endDateTime, joinWebUrl, audioConferencing (dial-in numbers/conferenceId), chatInfo (thread for the meeting chat), participants (organizer + attendees), allowedPresenters, lobbyBypassSettings, recordAutomatically, isBroadcast. REQUIRES Application Access Policy: the LCI app reg must have a CsApplicationAccessPolicy granted to the target user-id (via PowerShell Grant-CsApplicationAccessPolicy) — without it, 403. The meeting-id is the canonical onlineMeeting id (not the joinWebUrl's videoTeleconferenceId). Use to audit meeting metadata for compliance / discovery scenarios where the admin is not a meeting participant."
+  },
+  {
+    "pathPattern": "/users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports",
+    "method": "get",
+    "toolName": "list-user-meeting-attendance-reports",
+    "appPermissions": ["OnlineMeetingArtifact.Read.All"],
+    "llmTip": "Lists attendance reports for a Teams online meeting on behalf of a user. Each report covers ONE session of the meeting — recurring meetings have multiple reports (one per occurrence), and a meeting that drops and resumes generates separate reports. Each has id, totalParticipantCount, meetingStartDateTime, meetingEndDateTime. Reports are only available AFTER the meeting ends (typically within 1-2 hours). REQUIRES Application Access Policy on the target user. The attendanceRecords array is empty in list responses — use get-user-meeting-attendance-report or pass $expand=attendanceRecords to retrieve participant-level details. Supports $filter, $top, $skip, $select, $orderby."
+  },
+  {
+    "pathPattern": "/users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}",
+    "method": "get",
+    "toolName": "get-user-meeting-attendance-report",
+    "appPermissions": ["OnlineMeetingArtifact.Read.All"],
+    "llmTip": "Gets a specific attendance report by ID for a Teams online meeting (app-only). Pass $expand=attendanceRecords to get participant-level details inline (recommended — avoids a second call to list-user-meeting-attendance-records). REQUIRES Application Access Policy on the target user. Useful for: HR audits (who attended this mandatory training?), engagement reporting (avg participant duration), GDPR / Loi 25 subject-rights requests, forensic investigations (who joined this meeting at what time?)."
+  },
+  {
+    "pathPattern": "/users/{user-id}/onlineMeetings/{onlineMeeting-id}/attendanceReports/{meetingAttendanceReport-id}/attendanceRecords",
+    "method": "get",
+    "toolName": "list-user-meeting-attendance-records",
+    "appPermissions": ["OnlineMeetingArtifact.Read.All"],
+    "llmTip": "Lists individual attendance records for an attendance report — one record per participant per join session. Each record has identity (UPN/displayName), emailAddress, role (organizer | presenter | attendee), totalAttendanceInSeconds (cumulative across all joins for this report), and attendanceIntervals (array of {joinDateTime, leaveDateTime, durationInSeconds} — useful for detecting drops/rejoins). Tip: it's more efficient to use get-user-meeting-attendance-report with $expand=attendanceRecords than to call this endpoint separately. REQUIRES Application Access Policy on the target user."
   }
 ]


### PR DESCRIPTION
Continues the P3 family-by-family expansion (DfI → Purview → **Teams advanced** → Copilot admin, one PR each). Builds on PR #116 (P3-DfI), #117 (P3-Purview), #120 (permission name fixes).

Adds 7 Teams admin tools for scenarios that are NOT covered by the user-delegated productivity flow (e.g. the sibling `ms365-advanced` MCP). Both sub-themes operate on data the calling admin is **not** a participant of — meetings of arbitrary users, chats deleted tenant-wide.

## Summary

- **7 new tools** across 2 sub-themes (596 → 603 cumulative)
- **3 commits** (2 feature + 1 docs/bump)
- **3 new Graph permissions** required (admin consent)
- All 7 tools target Graph v1.0 (stable)
- `npm run verify` passes: 195/195 tests, lint clean, prettier clean, build OK
- Version: `0.11.1` → `0.12.0` (minor, additive)

## Why this is distinct from ms365-advanced

| Aspect | `ms365-advanced` (Softeria, **delegated**) | `ms-365-admin` (this server, **application**) |
|---|---|---|
| **Scope** | MY meetings, MY chats | Meetings of arbitrary users, all deleted chats tenant-wide |
| **Permissions** | `OnlineMeetingArtifact.Read.All` (delegated) | `OnlineMeetings.Read.All` + `OnlineMeetingArtifact.Read.All` (application) |
| **Gating** | None beyond MY calendar | **Application Access Policy** per target user (PowerShell) |
| **Audit** | Under my UPN | Under the SP of the app (non-nominal) |
| **Use cases** | "Summarize my meeting yesterday" | HR audits, Loi 25 / GDPR subject-rights, compliance investigations of others |

## Commits

| Commit | Sub-theme | Tools |
|---|---|---|
| `e93d5b9` | Meeting drill-down + attendance reports | 4 |
| `f05b03d` | Deleted chats restore | 3 |
| `6620170` | docs + bump 0.12.0 | — |

## Tools added (7)

### Meeting drill-down + attendance reports (4)

App-only path `/users/{user-id}/onlineMeetings/*` — operating on a target user's meetings:

- `get-user-online-meeting` (GET) — meeting metadata, attendees, settings
- `list-user-meeting-attendance-reports` (GET) — per-session reports
- `get-user-meeting-attendance-report` (GET) — single report (use `\$expand=attendanceRecords`)
- `list-user-meeting-attendance-records` (GET) — per-participant join/leave intervals

### Deleted chats restore (3)

- `list-deleted-chats` (GET /teamwork/deletedChats) — ~30-day retention before permanent purge
- `get-deleted-chat` (GET by ID) — drill-down with member snapshot
- `undo-delete-chat` (POST .../undoDelete, **medium**) — restore to active

## IMPORTANT — Application Access Policy required

The 4 meeting tools target an app-only path that **requires** a tenant-level **Application Access Policy** explicitly granted to each target user via PowerShell — without that policy, requests return 403 even with `OnlineMeetings.Read.All` + `OnlineMeetingArtifact.Read.All` consented.

\`\`\`powershell
New-CsApplicationAccessPolicy \\
  -Identity \"ms365-admin-mcp\" \\
  -AppIds \"<app-id>\" \\
  -Description \"Targeted meeting access\"

Grant-CsApplicationAccessPolicy \\
  -PolicyName \"ms365-admin-mcp\" \\
  -Identity <target-user-upn>
\`\`\`

This is intentional behaviour from Microsoft: it gates access at the user level rather than tenant-wide, supporting targeted-investigation patterns without broad surveillance capability. The recommended operational pattern is to grant the policy on-demand during a specific investigation, then revoke after.

## Why \`undo-delete-chat\` is medium not high

- The chat returns to its original state — no data corruption, no permissions escalation
- All original participants regain access (no privilege bump)
- The operation is reversible (re-delete the chat)
- The \`medium\` rating reflects the surprise-factor for participants who expected deletion to be permanent — confirm before restoring sensitive chats

Per Microsoft docs: \"This operation is not supported for non-admin users\" — server-side gating regardless of the consented permission.

## New Graph permissions required

Must be admin-consented on the app registration (none declared prior to 0.12.0):

- \`OnlineMeetings.Read.All\` — for the meeting object metadata
- \`OnlineMeetingArtifact.Read.All\` — for attendance reports + records
- \`Chat.ManageDeletion.All\` — for listing / restoring deleted chats

## Testing

- \`npm run verify\` passes (generate + lint + format + build + test): 195/195 tests
- Local sanity: all 7 new tool aliases present in \`src/generated/client.ts\`
- No tenant-side validation in this PR — gated by the 3 new permissions + (for meetings) Application Access Policy configuration

## Backward compatibility

- No breaking changes
- All existing tools unaffected
- 195/195 existing tests pass

## Next P3 PR

- **P3.4 Copilot admin** (audit logs, usage analytics, prompt analytics, agent gating, ~5-10 tools) — final P3 family