### PR TITLE
infra(bicep): durably express allowWrites + requiredUserScopes (scp check)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -47,6 +47,12 @@ param oauthMode bool = false
 @description('Comma-separated Entra user object IDs (oid) authorized to authenticate via OAuth. Required when oauthMode=true.')
 param authorizedUsers string = ''
 
+@description('Enable write/mutation tools by passing --allow-writes. Default false (read-only). Set true for admin deployments that perform mutations.')
+param allowWrites bool = false
+
+@description('Scopes a user token must carry in its scp claim (SEC-F03), passed via MS365_ADMIN_MCP_REQUIRED_USER_SCOPES. Default "access_as_user". Set to "" to DISABLE the check — required for the self-resource OAuth design (app is both client and resource), where refresh_token grants are honoured only via {clientId}/.default and the resulting token carries Graph delegated scopes, never access_as_user. Identity then stays gated by audience + authorizedUsers + tenant.')
+param requiredUserScopes string = 'access_as_user'
+
 @description('Public URL that browsers reach the server at (used in OAuth metadata issuer). Leave empty to let the server derive it from request headers.')
 param publicUrl string = ''
 
@@ -157,7 +163,10 @@ var authorizedUserArgs = (oauthMode && !empty(authorizedUsers)) ? [
   '--authorized-users'
   authorizedUsers
 ] : []
-var containerArgs = concat(baseArgs, serviceAuthArgs, oauthArgs, publicUrlArgs, authorizedUserArgs)
+var allowWritesArgs = allowWrites ? [
+  '--allow-writes'
+] : []
+var containerArgs = concat(baseArgs, serviceAuthArgs, oauthArgs, publicUrlArgs, authorizedUserArgs, allowWritesArgs)
 
 // --- User-Assigned Managed Identity ---
 
@@ -388,6 +397,12 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'AZURE_STORAGE_TABLE_NAME'
               value: oauthTableName
+            }
+            {
+              // SEC-F03 scp check. Empty value disables it (required for the
+              // self-resource OAuth design — see the requiredUserScopes param).
+              name: 'MS365_ADMIN_MCP_REQUIRED_USER_SCOPES'
+              value: requiredUserScopes
             }
           ]
         }

--- a/infra/parameters.example.jsonc
+++ b/infra/parameters.example.jsonc
@@ -35,6 +35,18 @@
     "allowedClients": {
       "value": "<comma-separated Entra app IDs for machine-to-machine access, or empty>"
     },
+
+    // Pass --allow-writes to enable mutation tools (default false = read-only).
+    "allowWrites": { "value": false },
+
+    // SEC-F03 scp check. Default "access_as_user". MUST be "" (disabled) for the
+    // self-resource OAuth design (app is both OAuth client and protected
+    // resource): on refresh Entra only honours {clientId}/.default, and that
+    // token's scp carries Graph delegated scopes, never access_as_user — so a
+    // non-empty value 403s every refreshed token. Identity stays gated by
+    // audience + authorizedUsers + tenant.
+    "requiredUserScopes": { "value": "" },
+
     "acrLoginServer": { "value": "" },
 
     // --- VNet integration (set vnetIntegrated=true to deploy an internal CAE) ---


### PR DESCRIPTION
## Why

Follow-up to #124. Two settings live only on the running LCI prod Container App and would be wiped by a full `az deployment group create`, because `infra/main.bicep` never expressed them:

1. **`--allow-writes`** — running prod enables write tools; no bicep param existed.
2. **`MS365_ADMIN_MCP_REQUIRED_USER_SCOPES=""`** — set out-of-band to disable the SEC-F03 scp check, which #124 established is mandatory for the self-resource OAuth design (refresh tokens come back via `{clientId}/.default` carrying Graph delegated scopes, never `access_as_user`).

## Changes

- `param allowWrites bool = false` → conditional `--allow-writes` arg.
- `param requiredUserScopes string = 'access_as_user'` → emitted as the `MS365_ADMIN_MCP_REQUIRED_USER_SCOPES` env var; empty disables the check.
- `parameters.example.jsonc` documents both, with the self-resource caveat.

Template defaults unchanged (read-only, scp check on). Tenant-specific values (LCI sets `allowWrites=true`, `requiredUserScopes=""`) live in the gitignored `parameters.<tenant>.json`.

Not validated with `bicep build` locally (no bicep CLI on the box); changes mirror existing param/arg/env patterns. Recommend a CI `bicep build` or a `what-if` before any full redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)