### PR TITLE
feat(auth): optional dedicated OAuth client app (separate client/resource)

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -7,6 +7,15 @@
 //   az keyvault secret set --vault-name <kv> --name ms365-admin-mcp-tenant-id     --value <...>
 //   az keyvault secret set --vault-name <kv> --name ms365-admin-mcp-client-secret --value <...>
 //
+// OPTIONAL — dedicated OAuth client app (recommended for oauthMode, see src/secrets.ts
+// AppSecrets.oauthClientId). Seed these to make the OAuth proxy authenticate to Entra as a
+// SEPARATE client app instead of the resource app itself. This removes the client==resource
+// self-reference (AADSTS90009) on refresh, so the user token carries `access_as_user` and the
+// SEC-F03 scp check can stay enabled (set requiredUserScopes=access_as_user). The client app
+// needs the delegated `access_as_user` permission on the resource app + the same redirect URIs:
+//   az keyvault secret set --vault-name <kv> --name ms365-admin-mcp-oauth-client-id     --value <client-app-id>
+//   az keyvault secret set --vault-name <kv> --name ms365-admin-mcp-oauth-client-secret --value <client-app-secret>
+//
 // Graph API application permissions must be granted to the app registration whose
 // clientId is stored in Key Vault (this template does not touch Entra ID).
 

--- a/src/oauth-proxy.ts
+++ b/src/oauth-proxy.ts
@@ -13,8 +13,17 @@ export interface OAuthProxyOptions {
   // fallback was removed and callers must supply a trusted public URL.
   publicUrl: string;
   tenantId: string;
+  // The protected-resource app: token audience + `api://{clientId}/access_as_user`.
   clientId: string;
   clientSecret?: string;
+  // Optional dedicated OAuth *client* app (distinct from `clientId`). When set, the
+  // proxy authenticates to Entra as this client for authorization_code / refresh_token
+  // / device_code. This removes the client==resource self-reference, so refresh can
+  // request `api://{clientId}/access_as_user` without AADSTS90009 and the token carries
+  // `access_as_user`. When unset, the proxy uses `clientId`/`clientSecret` (self-resource
+  // mode) and refresh falls back to `{clientId}/.default`. See AppSecrets.oauthClientId.
+  oauthClientId?: string;
+  oauthClientSecret?: string;
   scopes: string[];
   enableDynamicRegistration: boolean;
   // SEC-F04b + SEC-F05: externalised storage for PKCE bridge + DCR client
@@ -97,6 +106,12 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
   const storage = options.storage;
   const issuer = stripTrailingSlash(options.publicUrl);
   const authority = `https://login.microsoftonline.com/${options.tenantId}`;
+  // Upstream Entra client identity. Defaults to the resource app (self-resource mode)
+  // unless a dedicated OAuth client app is configured. `separateOAuthClient` gates the
+  // refresh-token scope strategy below (per-scope vs {clientId}/.default).
+  const upstreamClientId = options.oauthClientId ?? options.clientId;
+  const upstreamClientSecret = options.oauthClientSecret ?? options.clientSecret;
+  const separateOAuthClient = !!options.oauthClientId && options.oauthClientId !== options.clientId;
   const fallbackScope =
     options.scopes.length > 0
       ? options.scopes.join(' ')
@@ -203,7 +218,7 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     const upstreamScope = scopeList.join(' ');
 
     const form = new URLSearchParams();
-    form.set('client_id', options.clientId);
+    form.set('client_id', upstreamClientId);
     form.set('scope', upstreamScope);
 
     try {
@@ -321,7 +336,7 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     const upstreamScope = scopeList.join(' ');
 
     const upstream = new URL(`${authority}/oauth2/v2.0/authorize`);
-    upstream.searchParams.set('client_id', options.clientId);
+    upstream.searchParams.set('client_id', upstreamClientId);
     upstream.searchParams.set('response_type', 'code');
     upstream.searchParams.set('redirect_uri', redirectUri);
     upstream.searchParams.set('response_mode', 'query');
@@ -370,8 +385,8 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
     }
 
     const form = new URLSearchParams();
-    form.set('client_id', options.clientId);
-    if (options.clientSecret) form.set('client_secret', options.clientSecret);
+    form.set('client_id', upstreamClientId);
+    if (upstreamClientSecret) form.set('client_secret', upstreamClientSecret);
 
     if (grantType === 'authorization_code') {
       const code = body.code as string | undefined;
@@ -445,23 +460,27 @@ export function registerOAuthRoutes(app: Express, options: OAuthProxyOptions): v
       }
       form.set('grant_type', 'refresh_token');
       form.set('refresh_token', refreshToken);
-      // AADSTS90009: our app registration is BOTH the OAuth client (client_id
-      // forwarded above) AND the protected resource (api://{clientId}/access_as_user).
-      // Entra tolerates this self-reference on the authorization_code exchange but
-      // rejects it on refresh_token: "Application is requesting a token for itself.
-      // This scenario is supported only if resource is specified using the /.default
-      // scope of that resource." This broke token renewal for all callers — sessions
-      // died ~70 min after each interactive sign-in and never recovered.
+      // Refresh-token scope strategy depends on whether a dedicated OAuth client app
+      // is configured (see upstreamClientId / separateOAuthClient above).
       //
-      // The fix follows Entra's stated requirement literally — request the resource's
-      // /.default scope. NEITHER forwarding mcp-remote's per-scope value
-      // (api://{clientId}/access_as_user) NOR omitting scope works: with no explicit
-      // scope Entra still reissues against the refresh token's original resource
-      // (api://{clientId}), the same self-reference, and re-triggers 90009 (confirmed
-      // in prod on the omit-scope revision --0000029). /.default satisfies the rule
-      // and still yields the consented delegated scopes; offline_access keeps the
-      // refresh token rotating.
-      form.set('scope', `api://${options.clientId}/.default offline_access`);
+      // - Separate client app (preferred): client != resource, so we request the
+      //   resource per-scope `api://{clientId}/access_as_user`. No self-reference, so
+      //   no AADSTS90009, and the issued token carries `access_as_user` — letting
+      //   SEC-F03 stay enabled.
+      //
+      // - Self-resource fallback (no oauthClientId): the app is BOTH client and
+      //   resource. Entra rejects `refresh_token` for that self-reference unless the
+      //   resource is named by its GUID-based app identifier with /.default:
+      //   "Application is requesting a token for itself ... supported only if resource
+      //   is specified using the GUID based App Identifier." Forwarding the per-scope
+      //   value or omitting scope both fail (confirmed in prod). `{clientId}/.default`
+      //   works but the token then carries Graph delegated scopes (not access_as_user),
+      //   so SEC-F03 must be disabled in that mode. offline_access keeps the RT rotating.
+      if (separateOAuthClient) {
+        form.set('scope', `api://${options.clientId}/access_as_user offline_access`);
+      } else {
+        form.set('scope', `${options.clientId}/.default offline_access`);
+      }
     } else if (grantType === DEVICE_CODE_GRANT) {
       // RFC 8628 §3.4: token redemption for a device_code. Entra returns
       // authorization_pending / slow_down / expired_token / access_denied

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -17,6 +17,17 @@ export interface AppSecrets {
   tenantId: string;
   clientSecret?: string;
   cloudType: CloudType;
+  // Optional dedicated OAuth *client* app, distinct from the resource app above
+  // (`clientId` is the protected resource: token audience + `api://{clientId}/access_as_user`).
+  // When set, the OAuth proxy authenticates to Entra as this client for the
+  // authorization_code / refresh_token / device_code flows. Because the client is
+  // then no longer the same app as the resource, a refresh can request
+  // `api://{resourceClientId}/access_as_user` without the self-reference that
+  // triggers AADSTS90009 — and the issued token carries `access_as_user`, letting
+  // SEC-F03 stay enabled. Leave unset to keep the single self-resource app
+  // (refresh falls back to `{clientId}/.default`; SEC-F03 must be disabled).
+  oauthClientId?: string;
+  oauthClientSecret?: string;
 }
 
 interface SecretsProvider {
@@ -31,6 +42,8 @@ class EnvironmentSecretsProvider implements SecretsProvider {
       tenantId: requiredEnv('MS365_ADMIN_MCP_TENANT_ID'),
       clientSecret: requiredEnv('MS365_ADMIN_MCP_CLIENT_SECRET'),
       cloudType,
+      oauthClientId: process.env.MS365_ADMIN_MCP_OAUTH_CLIENT_ID?.trim() || undefined,
+      oauthClientSecret: process.env.MS365_ADMIN_MCP_OAUTH_CLIENT_SECRET?.trim() || undefined,
     };
   }
 }
@@ -51,14 +64,21 @@ class KeyVaultSecretsProvider implements SecretsProvider {
 
     logger.info(`Fetching secrets from Key Vault: ${this.vaultUrl}`);
 
-    const [clientIdSecret, tenantIdSecret, clientSecretResult, cloudTypeResult] = await Promise.all(
-      [
-        client.getSecret('ms365-admin-mcp-client-id'),
-        client.getSecret('ms365-admin-mcp-tenant-id'),
-        client.getSecret('ms365-admin-mcp-client-secret').catch(() => null),
-        client.getSecret('ms365-admin-mcp-cloud-type').catch(() => null),
-      ]
-    );
+    const [
+      clientIdSecret,
+      tenantIdSecret,
+      clientSecretResult,
+      cloudTypeResult,
+      oauthClientIdResult,
+      oauthClientSecretResult,
+    ] = await Promise.all([
+      client.getSecret('ms365-admin-mcp-client-id'),
+      client.getSecret('ms365-admin-mcp-tenant-id'),
+      client.getSecret('ms365-admin-mcp-client-secret').catch(() => null),
+      client.getSecret('ms365-admin-mcp-cloud-type').catch(() => null),
+      client.getSecret('ms365-admin-mcp-oauth-client-id').catch(() => null),
+      client.getSecret('ms365-admin-mcp-oauth-client-secret').catch(() => null),
+    ]);
 
     if (!clientIdSecret.value) {
       throw new Error('Required secret ms365-admin-mcp-client-id not found in Key Vault');
@@ -71,6 +91,8 @@ class KeyVaultSecretsProvider implements SecretsProvider {
       tenantId: tenantIdSecret?.value || '',
       clientSecret: clientSecretResult?.value,
       cloudType: parseCloudType(cloudTypeResult?.value),
+      oauthClientId: oauthClientIdResult?.value || undefined,
+      oauthClientSecret: oauthClientSecretResult?.value || undefined,
     };
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -132,10 +132,18 @@ class AdminGraphServer {
       }
 
       // SEC-F03: default to requiring `access_as_user` in scp. An empty string disables the check.
+      // The CLI flag wins; otherwise fall back to MS365_ADMIN_MCP_REQUIRED_USER_SCOPES so a
+      // container deployment can tune (or disable) the check without rewriting startup args.
+      // Disabling is required in self-resource OAuth mode (no oauthClientId): refresh tokens
+      // come back via `{clientId}/.default` carrying Graph delegated scopes, never
+      // `access_as_user`. With a dedicated OAuth client app, refresh yields `access_as_user`
+      // and this check should be re-enabled (set back to `access_as_user`).
+      const rawRequiredScopes =
+        this.options.requiredUserScopes ?? process.env.MS365_ADMIN_MCP_REQUIRED_USER_SCOPES;
       const requiredScopes =
-        this.options.requiredUserScopes === undefined
+        rawRequiredScopes === undefined
           ? ['access_as_user']
-          : this.options.requiredUserScopes
+          : rawRequiredScopes
               .split(',')
               .map((s: string) => s.trim())
               .filter(Boolean);
@@ -165,6 +173,8 @@ class AdminGraphServer {
           tenantId: this.secrets!.tenantId,
           clientId: this.secrets!.clientId,
           clientSecret: this.secrets!.clientSecret,
+          oauthClientId: this.secrets!.oauthClientId,
+          oauthClientSecret: this.secrets!.oauthClientSecret,
           scopes: [
             'openid',
             'profile',

--- a/test/oauth-proxy.test.ts
+++ b/test/oauth-proxy.test.ts
@@ -16,7 +16,10 @@ function sha256(input: string): string {
   return base64url(crypto.createHash('sha256').update(input).digest());
 }
 
-async function buildServer(storage: MemoryStorage): Promise<{ url: string; server: Server }> {
+async function buildServer(
+  storage: MemoryStorage,
+  overrides: Partial<OAuthProxyOptions> = {}
+): Promise<{ url: string; server: Server }> {
   const app = express();
   app.use(express.json({ limit: '100kb' }));
   app.use(express.urlencoded({ extended: true, limit: '100kb' }));
@@ -28,6 +31,7 @@ async function buildServer(storage: MemoryStorage): Promise<{ url: string; serve
     scopes: ['openid', 'profile', 'email', 'offline_access', `api://${CLIENT_ID}/access_as_user`],
     enableDynamicRegistration: true,
     storage,
+    ...overrides,
   };
   registerOAuthRoutes(app as Express, options);
 
@@ -230,14 +234,12 @@ describe('SEC-F04b /token — client authentication required', () => {
     expect(body.access_token).toBe('new-at');
   });
 
-  // AADSTS90009 regression: the app reg is both the OAuth client and the
-  // protected resource. On refresh, Entra rejects the self-reference unless the
-  // resource is requested via its /.default scope ("Application is requesting a
-  // token for itself ... supported only if resource is specified using the
-  // /.default scope"). Forwarding mcp-remote's per-scope value OR omitting scope
-  // both fail (the latter confirmed in prod). The refresh branch must rewrite the
-  // scope to api://{clientId}/.default (+ offline_access for RT rotation).
-  it('rewrites the refresh_token scope to api://{clientId}/.default (AADSTS90009 fix)', async () => {
+  // AADSTS90009 regression — SELF-RESOURCE mode (no dedicated OAuth client app).
+  // The app reg is both client and resource; Entra honours refresh only when the
+  // resource is named by its GUID-based app identifier with /.default. Forwarding
+  // the per-scope value, the api:// URI .default form, or omitting scope all fail
+  // (confirmed in prod). The refresh branch must rewrite to {clientId}/.default.
+  it('uses {clientId}/.default GUID form on refresh in self-resource mode (AADSTS90009)', async () => {
     const { clientId, clientSecret } = await register();
     fetchMock.mockResolvedValue(
       new Response(JSON.stringify({ access_token: 'new-at', refresh_token: 'new-rt' }), {
@@ -265,12 +267,14 @@ describe('SEC-F04b /token — client authentication required', () => {
     );
     expect(upstreamBody.get('grant_type')).toBe('refresh_token');
     expect(upstreamBody.get('refresh_token')).toBe('legit-rt');
-    // The load-bearing assertion: the upstream scope is the resource /.default,
-    // not the per-scope value the client sent, and offline_access is preserved.
+    // GUID-form resource /.default — not the api:// URI form, not the per-scope value.
     const upstreamScope = (upstreamBody.get('scope') ?? '').split(/\s+/).filter(Boolean);
-    expect(upstreamScope).toContain(`api://${CLIENT_ID}/.default`);
+    expect(upstreamScope).toContain(`${CLIENT_ID}/.default`);
     expect(upstreamScope).toContain('offline_access');
+    expect(upstreamScope).not.toContain(`api://${CLIENT_ID}/.default`);
     expect(upstreamScope).not.toContain(`api://${CLIENT_ID}/access_as_user`);
+    // Self-resource mode authenticates upstream as the resource app itself.
+    expect(upstreamBody.get('client_id')).toBe(CLIENT_ID);
   });
 
   it('accepts Basic auth (client_secret_basic) as an alternative to body auth', async () => {
@@ -687,5 +691,86 @@ describe('RFC 8628 /token device_code grant', () => {
     expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe('authorization_pending');
+  });
+});
+
+describe('Dedicated OAuth client app (separate client/resource)', () => {
+  const OAUTH_CLIENT_ID = '33333333-3333-3333-3333-333333333333';
+  let scStorage: MemoryStorage;
+  let scUrl: string;
+  let scServer: Server;
+
+  beforeAll(async () => {
+    scStorage = new MemoryStorage();
+    const built = await buildServer(scStorage, {
+      oauthClientId: OAUTH_CLIENT_ID,
+      oauthClientSecret: 'oauth-client-secret',
+    });
+    scUrl = built.url;
+    scServer = built.server;
+  });
+
+  afterAll(() => {
+    scServer.close();
+  });
+
+  async function scRegister(): Promise<{ clientId: string; clientSecret: string }> {
+    const res = await realFetch(`${scUrl}/register`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ redirect_uris: ['http://localhost/cb'] }),
+    });
+    const body = (await res.json()) as { client_id: string; client_secret: string };
+    return { clientId: body.client_id, clientSecret: body.client_secret };
+  }
+
+  it('authenticates upstream as the dedicated client and requests the resource per-scope on refresh', async () => {
+    const { clientId, clientSecret } = await scRegister();
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ access_token: 'new-at', refresh_token: 'new-rt' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    const res = await realFetch(`${scUrl}/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: 'legit-rt',
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const upstreamBody = new URLSearchParams(
+      String((fetchMock.mock.calls[0][1] as { body: string }).body)
+    );
+    // Upstream identity is the dedicated OAuth client app — NOT the resource app.
+    expect(upstreamBody.get('client_id')).toBe(OAUTH_CLIENT_ID);
+    expect(upstreamBody.get('client_secret')).toBe('oauth-client-secret');
+    // No self-reference → request the resource per-scope, so the token carries
+    // access_as_user (lets SEC-F03 stay enabled). No /.default fallback here.
+    const upstreamScope = (upstreamBody.get('scope') ?? '').split(/\s+/).filter(Boolean);
+    expect(upstreamScope).toContain(`api://${CLIENT_ID}/access_as_user`);
+    expect(upstreamScope).toContain('offline_access');
+    expect(upstreamScope).not.toContain(`${CLIENT_ID}/.default`);
+  });
+
+  it('sends the dedicated client_id on the upstream /authorize redirect', async () => {
+    const { clientId } = await scRegister();
+    const verifier = base64url(crypto.randomBytes(32));
+    const challenge = sha256(verifier);
+    const res = await realFetch(
+      `${scUrl}/authorize?client_id=${clientId}&redirect_uri=http%3A%2F%2Flocalhost%2Fcb&code_challenge=${challenge}&code_challenge_method=S256`,
+      { redirect: 'manual' }
+    );
+    expect(res.status).toBe(302);
+    const upstream = new URL(res.headers.get('location')!);
+    // The redirect to Entra carries the dedicated client, not the resource app.
+    expect(upstream.searchParams.get('client_id')).toBe(OAUTH_CLIENT_ID);
+    // Resource scope is still requested against the resource app.
+    expect(upstream.searchParams.get('scope')).toContain(`api://${CLIENT_ID}/access_as_user`);
   });
 });


### PR DESCRIPTION
## Why

The OAuth-proxy app (`{resourceClientId}`) is currently **both** the OAuth client and the protected resource (`api://{clientId}/access_as_user`). Entra rejects `refresh_token` for that self-reference (AADSTS90009), which forced two workarounds in prod: requesting `{clientId}/.default` (token then carries Graph scopes, not `access_as_user`) **and disabling the SEC-F03 scp check**.

This change lets the proxy use a **separate client app**, eliminating the self-reference so refresh can request the resource per-scope and SEC-F03 can be re-enabled.

## What

- **Optional** `oauthClientId` / `oauthClientSecret` (env `MS365_ADMIN_MCP_OAUTH_CLIENT_*` or Key Vault `ms365-admin-mcp-oauth-client-*`). Backward-compatible: unset → current self-resource behaviour.
- When set: `/authorize`, `/token`, `/devicecode` authenticate upstream as the dedicated client; refresh requests `api://{resourceClientId}/access_as_user` (no self-reference → no AADSTS90009 → token carries `access_as_user`).
- Self-resource fallback corrected to the **GUID-form** `{clientId}/.default` (the `api://` URI form is rejected by Entra).
- Restores the `MS365_ADMIN_MCP_REQUIRED_USER_SCOPES` env fallback in `server.ts`.
- `infra/main.bicep`: documents seeding the optional client secrets.
- Tests: both modes (198 passing).

## Note — reconciles `main`

`main` had been left at the non-working `api://{clientId}/.default` intermediate state with the env fallback missing (an earlier PR squash-merged mid-iteration). This PR brings `main` to the correct, complete state.

## Deploy runbook (to enable the separate-client mode)

1. Register a new client app in Entra; grant it **delegated** `access_as_user` on the resource app; add the same redirect URIs; admin-consent.
2. Seed Key Vault `ms365-admin-mcp-oauth-client-id` + `ms365-admin-mcp-oauth-client-secret`.
3. Set `requiredUserScopes=access_as_user` (remove the empty `MS365_ADMIN_MCP_REQUIRED_USER_SCOPES`) to re-enable SEC-F03.
4. Admins re-authenticate once (client identity changes).

Not validated against live Entra yet — requires the new app registration. Until configured, behaviour is unchanged (self-resource mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)