### PR TITLE
infra(bicep): parameterize container CPU/memory, default 1.0 vCPU / 2Gi

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -44,6 +44,12 @@ param minReplicas int = 0
 @minValue(1)
 param maxReplicas int = 3
 
+@description('Container vCPU. Must form a valid Container Apps CPU/memory pair with containerMemory (e.g. 0.5/1Gi, 1.0/2Gi, 2.0/4Gi). Default 1.0 — the server rebuilds its full tool set (600+) per MCP request, which OOMed the previous 0.5/1Gi sizing.')
+param containerCpu string = '1.0'
+
+@description('Container memory. Must pair with containerCpu (see above). Default 2Gi.')
+param containerMemory string = '2Gi'
+
 @description('Tags applied to every resource (must satisfy org tag policies)')
 param tags object = {}
 
@@ -379,8 +385,8 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
           ]
           args: containerArgs
           resources: {
-            cpu: json('0.5')
-            memory: '1Gi'
+            cpu: json(containerCpu)
+            memory: containerMemory
           }
           env: [
             {

--- a/infra/parameters.example.jsonc
+++ b/infra/parameters.example.jsonc
@@ -39,13 +39,19 @@
     // Pass --allow-writes to enable mutation tools (default false = read-only).
     "allowWrites": { "value": false },
 
-    // SEC-F03 scp check. Default "access_as_user". MUST be "" (disabled) for the
-    // self-resource OAuth design (app is both OAuth client and protected
-    // resource): on refresh Entra only honours {clientId}/.default, and that
-    // token's scp carries Graph delegated scopes, never access_as_user — so a
-    // non-empty value 403s every refreshed token. Identity stays gated by
-    // audience + authorizedUsers + tenant.
-    "requiredUserScopes": { "value": "" },
+    // SEC-F03 scp check on user tokens. Default "access_as_user".
+    //  - Two-app model (dedicated OAuth client app, recommended): keep
+    //    "access_as_user" — refresh tokens carry that scope, SEC-F03 stays on.
+    //  - Self-resource fallback (no dedicated client app): set "" to DISABLE,
+    //    because Entra only honours refresh via {clientId}/.default, whose token
+    //    carries Graph scopes (not access_as_user) and would 403 otherwise.
+    "requiredUserScopes": { "value": "access_as_user" },
+
+    // Container sizing. Must be a valid Container Apps CPU/memory pair.
+    // Default 1.0/2Gi — 0.5/1Gi OOMs because the server rebuilds its full
+    // tool set (600+) on every MCP request.
+    "containerCpu": { "value": "1.0" },
+    "containerMemory": { "value": "2Gi" },
 
     "acrLoginServer": { "value": "" },
 


### PR DESCRIPTION
## Why

The Container App hardcoded **0.5 vCPU / 1Gi**. The server rebuilds its full tool set (600+ tools) on **every** MCP request; under a fresh `tools/list` + bursts the replica sat at ~98% of the 1Gi memory cap and `tools/list` timed out client-side (`-32001`). Bumping to **1.0 vCPU / 2Gi** (now ~30-45% memory) fixed it in prod (`az containerapp update`).

This makes that sizing **reproducible from a full bicep deploy** — the `lci-deploy` image pipeline preserves `az containerapp update` changes, but a full `az deployment group create` would have reverted to the OOM-prone 0.5/1Gi.

## Changes

- `main.bicep`: new params `containerCpu` (default `"1.0"`) + `containerMemory` (default `"2Gi"`), wired into the container `resources` block (previously hardcoded).
- `parameters.example.jsonc`: document the sizing params; refresh the `requiredUserScopes` guidance for the two-app OAuth model (keep `access_as_user`; `""` only for self-resource mode).

Validated with `az bicep build` (compiles clean; `cpu`/`memory` now parameter-driven). Tenant-specific values live in the gitignored `parameters.<tenant>.json` (LCI sets `1.0`/`2Gi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)