### PR TITLE
fix(mcp): body coercion for recursive schemas, OneDrive access, retention cleanup, eDiscovery estimate

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -2703,6 +2703,38 @@
     "llmTip": "Gets the default document library (drive) for a SharePoint site. Returns id, name, driveType, webUrl, quota."
   },
   {
+    "pathPattern": "/users/{user-id}/drive",
+    "method": "get",
+    "toolName": "get-user-drive",
+    "appPermissions": ["Files.Read.All"],
+    "riskLevel": "medium",
+    "llmTip": "Gets a user's OneDrive for Business (personal drive). Returns the drive id, driveType ('business'), owner, quota, and webUrl. Use this for DSAR/Loi 25 access requests: a user's OneDrive is a personal site that GET /sites/{...:/personal/...} cannot reach with app permissions — go through /users/{user-id}/drive instead. user-id can be the UPN (e.g. carolann.poulin@lcieducation.com) or the object id. Take the returned drive id and pass it to get-drive-root, then list-drive-children, to enumerate the content."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/root",
+    "method": "get",
+    "toolName": "get-drive-root",
+    "appPermissions": ["Files.Read.All"],
+    "riskLevel": "medium",
+    "llmTip": "Gets the root folder driveItem of a drive (from get-user-drive). Returns the root item id, name, folder.childCount, and webUrl. Pass the root item id to list-drive-children to enumerate top-level files and folders."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}/children",
+    "method": "get",
+    "toolName": "list-drive-children",
+    "appPermissions": ["Files.Read.All"],
+    "riskLevel": "medium",
+    "llmTip": "Lists the children (files and subfolders) of a driveItem in a drive. For the top level, pass the root item id from get-drive-root. Each child returns id, name, size, file/folder facet, createdDateTime, lastModifiedDateTime, webUrl, and @microsoft.graph.downloadUrl for files. Recurse by calling again with a child folder's id. Supports $top, $select, $orderby."
+  },
+  {
+    "pathPattern": "/drives/{drive-id}/items/{driveItem-id}",
+    "method": "get",
+    "toolName": "get-drive-item",
+    "appPermissions": ["Files.Read.All"],
+    "riskLevel": "medium",
+    "llmTip": "Gets metadata for a specific driveItem (file or folder) by id. Returns name, size, file/folder facet, createdBy, lastModifiedBy, timestamps, webUrl, and @microsoft.graph.downloadUrl (a short-lived, pre-authenticated link to download file content without an auth header)."
+  },
+  {
     "pathPattern": "/sites/{site-id}/lists",
     "method": "get",
     "toolName": "list-site-lists",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -4309,6 +4309,14 @@
     "llmTip": "Creates a collection search in a case. Body: displayName, description, contentQuery (KQL), dataSourceScopes ('none'|'allTenantMailboxes'|'allTenantSites'|'allCaseCustodians'|'allCaseNoncustodialDataSources')."
   },
   {
+    "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/searches/{ediscoverySearch-id}/microsoft.graph.security.estimateStatistics",
+    "method": "post",
+    "toolName": "estimate-ediscovery-search-statistics",
+    "appPermissions": ["eDiscovery.ReadWrite.All"],
+    "riskLevel": "medium",
+    "llmTip": "Runs an estimate of how many emails and documents a search would collect — the scoping step before add-to-review-set in a DSAR/collection workflow. No request body. Long-running: returns 202; poll list-case-operations (action='estimateStatistics') until status='succeeded', then read the result counts (indexedItemCount, indexedItemsSize, mailboxCount, siteCount, unindexedItemCount, unindexedItemsSize) from that operation. Use this to size and justify a collection before pulling content into a review set."
+  },
+  {
     "pathPattern": "/security/cases/ediscoveryCases/{ediscoveryCase-id}/custodians/{ediscoveryCustodian-id}",
     "method": "get",
     "toolName": "get-ediscovery-custodian",

--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -1480,13 +1480,6 @@
     "llmTip": "Gets SharePoint tenant-level settings. Returns allowedDomainGuidsForSyncApp, availableManagedPathsForSiteCreation, deletedUserPersonalSiteRetentionPeriodInDays, excludedFileExtensionsForSyncApp, idleSessionSignOut, imageTaggingOption, isCommentingOnSitePagesEnabled, isFileActivityNotificationEnabled, isLoopEnabled, isMacSyncAppEnabled, isResharingByExternalUsersEnabled, isSharePointMobileNotificationEnabled, isSharePointNewsfeedEnabled, isSiteCreationEnabled, isSiteCreationUIEnabled, isSitePagesCreationEnabled, isSitesStorageLimitAutomatic, knowledgeIntelligenceEnabled, personalSiteDefaultStorageLimitInMB, sharingAllowedDomainList, sharingBlockedDomainList, sharingCapability, sharingDomainRestrictionMode, siteCreationDefaultManagedPath, siteCreationDefaultStorageLimitInMB, tenantDefaultTimezone."
   },
   {
-    "pathPattern": "/security/labels/retentionLabels",
-    "method": "get",
-    "toolName": "list-retention-labels",
-    "appPermissions": ["RecordsManagement.Read.All"],
-    "llmTip": "Lists retention labels from Microsoft Purview Records Management. Each has displayName, descriptionForAdmins, descriptionForUsers, retentionDuration, retentionTrigger, behaviorDuringRetentionPeriod, actionAfterRetentionPeriod (none, delete, startDispositionReview), isInUse, createdDateTime, lastModifiedDateTime, and labelToBeApplied."
-  },
-  {
     "pathPattern": "/security/labels/authorities",
     "method": "get",
     "toolName": "list-file-plan-authorities",

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -59,6 +59,33 @@ export function encodePathParamValue(rawValue: string): string {
   return encodeURIComponent(rawValue);
 }
 
+// SEC-F (handoff Finding 3): recursive Microsoft Graph entity bodies are emitted
+// by the generator as `z.lazy(() => z.object(...))` schemas (51 of them today —
+// accessPackage, channel, domain, list, ediscoverySearch, etc.). Some MCP clients
+// cannot render a JSON Schema for a lazy/recursive parameter and downgrade the
+// `body` argument to a JSON *string*. Server-side Zod validation then rejects it
+// with "expected object, received string" — even though the string holds a valid
+// object (this is exactly why create-ediscovery-search failed while
+// create-ediscovery-case/-custodian, whose schemas are non-lazy, succeeded).
+//
+// Wrap every Body param schema in a preprocess step that JSON-parses a string
+// body before validation. To stay safe for endpoints that take a raw text or
+// binary body, only strings that look like a JSON object or array are parsed;
+// primitive-looking and non-JSON strings flow through untouched so the
+// underlying schema still produces a meaningful error.
+export function coerceJsonStringBody(schema: z.ZodTypeAny): z.ZodTypeAny {
+  return z.preprocess((val) => {
+    if (typeof val !== 'string') return val;
+    const trimmed = val.trim();
+    if (!(trimmed.startsWith('{') || trimmed.startsWith('['))) return val;
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return val;
+    }
+  }, schema);
+}
+
 const endpointsData = JSON.parse(
   readFileSync(path.join(__dirname, 'endpoints.json'), 'utf8')
 ) as EndpointConfig[];
@@ -333,7 +360,7 @@ export function registerGraphTools(
     const paramSchema: Record<string, z.ZodTypeAny> = {};
     for (const param of tool.parameters || []) {
       if (param.type === 'Body') {
-        paramSchema[param.name] = (param.schema || z.unknown()).optional();
+        paramSchema[param.name] = coerceJsonStringBody(param.schema || z.unknown()).optional();
       } else if (param.type === 'Path') {
         paramSchema[param.name] = z.string().describe(param.description || param.name);
       } else if (param.type === 'Query') {

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -110,6 +110,12 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
     description:
       'Records Management (retention labels, file plan authorities, categories, citations, departments, references)',
   },
+  files: {
+    name: 'files',
+    pattern: /user-drive|drive-root|drive-item|drive-children/i,
+    description:
+      "OneDrive / user drive access (DSAR enumeration: a user's personal drive, root, items, and children)",
+  },
   teamsadmin: {
     name: 'teamsadmin',
     pattern:

--- a/src/tool-categories.ts
+++ b/src/tool-categories.ts
@@ -106,9 +106,9 @@ export const TOOL_CATEGORIES: Record<string, ToolCategory> = {
   },
   retention: {
     name: 'retention',
-    pattern: /retention-label|file-plan/i,
+    pattern: /retention-event|file-plan/i,
     description:
-      'Records Management (retention labels, file plan authorities, categories, citations, departments, references)',
+      'Records Management (file plan authorities, categories, citations, departments, references, retention events). Note: listing/getting retentionLabels themselves is not supported with application permissions in Microsoft Graph — use delegated access or Security & Compliance PowerShell.',
   },
   files: {
     name: 'files',

--- a/test/body-json-coercion.test.ts
+++ b/test/body-json-coercion.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { coerceJsonStringBody } from '../src/graph-tools.js';
+
+// Node 18 lacks the File global referenced by generated Zod schemas.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+if (!globalThis.File) (globalThis as any).File = Blob;
+
+/**
+ * SEC-F (handoff Finding 3): recursive Graph entity bodies are generated as
+ * z.lazy(...) schemas. Some MCP clients cannot render a JSON Schema for a lazy
+ * parameter and send `body` as a JSON *string*, which Zod then rejects with
+ * "expected object, received string". coerceJsonStringBody() parses an
+ * object/array-looking string before validation while leaving every other shape
+ * untouched.
+ */
+describe('coerceJsonStringBody', () => {
+  // Mirrors the shape of a lazy Graph entity body (e.g. ediscoverySearch):
+  // the failing real-world case from the Loi 25 DSAR session.
+  const lazyObjectSchema = z.lazy(() =>
+    z
+      .object({
+        displayName: z.string().nullish(),
+        contentQuery: z.string().nullish(),
+        dataSourceScopes: z.string().optional(),
+      })
+      .passthrough()
+  );
+
+  it('parses a JSON-object string into an object (the create-ediscovery-search repro)', () => {
+    const wrapped = coerceJsonStringBody(lazyObjectSchema);
+    const raw = JSON.stringify({
+      displayName: 'DSAR collection',
+      contentQuery: '',
+      dataSourceScopes: 'allCaseCustodians',
+    });
+    const result = wrapped.parse(raw);
+    expect(result).toEqual({
+      displayName: 'DSAR collection',
+      contentQuery: '',
+      dataSourceScopes: 'allCaseCustodians',
+    });
+  });
+
+  it('passes a real object through unchanged (clients that send objects keep working)', () => {
+    const wrapped = coerceJsonStringBody(lazyObjectSchema);
+    const obj = { displayName: 'kept', contentQuery: 'foo' };
+    expect(wrapped.parse(obj)).toEqual(obj);
+  });
+
+  it('parses a JSON-array string', () => {
+    const wrapped = coerceJsonStringBody(z.array(z.number()));
+    expect(wrapped.parse('[1,2,3]')).toEqual([1, 2, 3]);
+  });
+
+  it('leaves a non-JSON / raw-text string untouched (text or binary bodies)', () => {
+    const wrapped = coerceJsonStringBody(z.string());
+    expect(wrapped.parse('plain text body')).toBe('plain text body');
+    // A primitive-looking string is not object/array-shaped → not parsed.
+    expect(wrapped.parse('123')).toBe('123');
+  });
+
+  it('leaves an unparseable object-looking string for the schema to reject', () => {
+    const wrapped = coerceJsonStringBody(z.object({ a: z.string() }));
+    // Looks like an object but is malformed JSON → returned as-is → schema fails.
+    expect(() => wrapped.parse('{not valid json')).toThrow();
+  });
+
+  it('is undefined-safe when made optional (body omitted)', () => {
+    const wrapped = coerceJsonStringBody(lazyObjectSchema).optional();
+    expect(wrapped.parse(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Four independent changes. `npm run verify` is green (204 tests).

### `fix(graph-tools)` — coerce stringified JSON body for recursive (z.lazy) schemas
Recursive Microsoft Graph entity bodies are generated as `z.lazy(() => z.object(...))`
(reaches 7 write tools: accessPackage, accessPackageAssignmentPolicy,
accessPackageCatalog, channel, domain, list, ediscoverySearch). Some MCP clients
cannot render a JSON Schema for a lazy parameter and downgrade `body` to a JSON
string; server-side Zod validation then rejected it with "expected object,
received string" — which is why `create-ediscovery-search` failed while
`create-ediscovery-case`/`-custodian` (non-lazy) succeeded. Body params are now
wrapped in a preprocess that JSON-parses an object/array-looking string before
validation. Conservative: real objects and text/binary bodies pass through
unchanged. +6 unit tests.

### `feat(files)` — app-only OneDrive access endpoints
A user's personal OneDrive can't be reached via `GET /sites/...:/personal/...`
with application permissions (403). Adds four read-only navigation endpoints
(`get-user-drive`, `get-drive-root`, `list-drive-children`, `get-drive-item`)
under a new `files` preset. **Requires the `Files.Read.All` application
permission to be admin-consented on the service principal before the tools
return data (otherwise 403).**

### `fix(retention)` — remove `list-retention-labels`
`GET /security/labels/retentionLabels` is documented by Microsoft Graph as
Application: "Not supported" — only delegated tokens can list retention labels,
so on an application-only server it could never succeed. The retention
sub-resources that DO support application permissions (authorities, categories,
citations, departments, file plan references, retention events/event types) are
retained.

### `feat(ediscovery)` — add `estimate-ediscovery-search-statistics`
Adds the `estimateStatistics` action so a collection can be sized before content
is pulled into a review set, completing the workflow:
search → estimate → add-to-review-set → export.